### PR TITLE
feat: add autogen pipeline event logger

### DIFF
--- a/lib/services/auto_deduplication_engine.dart
+++ b/lib/services/auto_deduplication_engine.dart
@@ -6,6 +6,7 @@ import 'training_pack_library_service.dart';
 import 'spot_fingerprint_generator.dart';
 import '../utils/app_logger.dart';
 import 'autogen_pipeline_debug_stats_service.dart';
+import 'autogen_pipeline_event_logger_service.dart';
 
 class AutoDeduplicationReport {
   final List<PackSimilarityResult> duplicates;
@@ -50,6 +51,10 @@ class AutoDeduplicationEngine {
     if (_seen.contains(fp)) {
       _skipped++;
       AutogenPipelineDebugStatsService.incrementDeduplicated();
+      AutogenPipelineEventLoggerService.log(
+        'deduplicated',
+        'Skipped duplicate ${spot.id} from ${source ?? 'unknown'}',
+      );
       _log.writeln('Skipped duplicate from ${source ?? 'unknown'}: ${spot.id}');
       return true;
     }
@@ -76,6 +81,10 @@ class AutoDeduplicationEngine {
       if (_seen.contains(fp) && existing == null) {
         _skipped++;
         AutogenPipelineDebugStatsService.incrementDeduplicated();
+        AutogenPipelineEventLoggerService.log(
+          'deduplicated',
+          'Dropped ${spot.id} from ${source ?? 'memory'}',
+        );
         _log.writeln('dropped ${spot.id} from ${source ?? 'memory'}');
         continue;
       }
@@ -97,6 +106,10 @@ class AutoDeduplicationEngine {
       }
       _skipped++;
       AutogenPipelineDebugStatsService.incrementDeduplicated();
+      AutogenPipelineEventLoggerService.log(
+        'deduplicated',
+        'Dropped ${spot.id} duplicate of ${existing.id}',
+      );
     }
 
     _seen.addAll(unique.keys);

--- a/lib/services/autogen_pipeline_event_logger_service.dart
+++ b/lib/services/autogen_pipeline_event_logger_service.dart
@@ -1,0 +1,36 @@
+class AutogenPipelineEvent {
+  final String type;
+  final String message;
+  final DateTime timestamp;
+
+  const AutogenPipelineEvent({
+    required this.type,
+    required this.message,
+    required this.timestamp,
+  });
+}
+
+/// Simple in-memory logger for autogen pipeline events.
+class AutogenPipelineEventLoggerService {
+  AutogenPipelineEventLoggerService._();
+
+  static final List<AutogenPipelineEvent> _events = [];
+
+  /// Adds an event to the log.
+  static void log(String type, String message) {
+    _events.add(
+      AutogenPipelineEvent(
+        type: type,
+        message: message,
+        timestamp: DateTime.now(),
+      ),
+    );
+  }
+
+  /// Returns an immutable view of all logged events.
+  static List<AutogenPipelineEvent> getLog() => List.unmodifiable(_events);
+
+  /// Clears all logged events.
+  static void clearLog() => _events.clear();
+}
+

--- a/lib/services/autogen_pipeline_executor.dart
+++ b/lib/services/autogen_pipeline_executor.dart
@@ -22,6 +22,7 @@ import 'icm_scenario_library_injector.dart';
 import 'pack_quality_gatekeeper_service.dart';
 import 'autogen_run_history_logger_service.dart';
 import 'autogen_pipeline_debug_stats_service.dart';
+import 'autogen_pipeline_event_logger_service.dart';
 
 /// Centralized orchestrator running the full auto-generation pipeline.
 class AutogenPipelineExecutor {
@@ -136,6 +137,10 @@ class AutogenPipelineExecutor {
           continue;
         }
         AutogenPipelineDebugStatsService.incrementGenerated();
+        AutogenPipelineEventLoggerService.log(
+          'generated',
+          'Generated ${spots.length} spots for template ${set.baseSpot.id}',
+        );
 
         theoryInjector.injectAll(spots, theoryIndex);
         boardClassifier?.classifyAll(spots);
@@ -179,6 +184,10 @@ class AutogenPipelineExecutor {
         }
         generatedCount++;
         AutogenPipelineDebugStatsService.incrementCurated();
+        AutogenPipelineEventLoggerService.log(
+          'curated',
+          'Curated pack ${pack.id} with ${spots.length} spots',
+        );
         pack.meta['qualityScore'] = score;
 
         coverage.analyzePack(model);

--- a/lib/services/yaml_pack_exporter.dart
+++ b/lib/services/yaml_pack_exporter.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import '../core/training/export/training_pack_exporter_v2.dart';
 import '../models/v2/training_pack_template_v2.dart';
 import 'autogen_pipeline_debug_stats_service.dart';
+import 'autogen_pipeline_event_logger_service.dart';
 
 /// Exports training packs to YAML files.
 class YamlPackExporter {
@@ -15,6 +16,10 @@ class YamlPackExporter {
   Future<File> export(TrainingPackTemplateV2 pack) async {
     final file = await _delegate.exportToFile(pack);
     AutogenPipelineDebugStatsService.incrementPublished();
+    AutogenPipelineEventLoggerService.log(
+      'published',
+      'Published pack ${pack.id} to ${file.path}',
+    );
     return file;
   }
 


### PR DESCRIPTION
## Summary
- add AutogenPipelineEventLoggerService to capture timestamped generation events
- log generated, curated, deduplicated, and published steps in pipeline services

## Testing
- `flutter format lib/services/autogen_pipeline_event_logger_service.dart lib/services/autogen_pipeline_executor.dart lib/services/auto_deduplication_engine.dart lib/services/yaml_pack_exporter.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894b00d94a0832abf93437d1f62e025