### PR TITLE
feat: show recent autogen events in debug panel

### DIFF
--- a/lib/widgets/inline_autogen_debug_panel_widget.dart
+++ b/lib/widgets/inline_autogen_debug_panel_widget.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../services/autogen_pipeline_debug_stats_service.dart';
 import 'autogen_pipeline_status_badge_widget.dart';
 import 'autogen_pipeline_control_panel_widget.dart';
+import 'inline_autogen_event_log_widget.dart';
 
 /// Inline panel showing autogen pipeline status and key metrics.
 class InlineAutogenDebugPanelWidget extends StatelessWidget {
@@ -17,8 +18,7 @@ class InlineAutogenDebugPanelWidget extends StatelessWidget {
         const AutogenPipelineStatusBadgeWidget(),
         const SizedBox(height: 8),
         ValueListenableBuilder<AutogenPipelineStats>(
-          valueListenable:
-              AutogenPipelineDebugStatsService.getLiveStats(),
+          valueListenable: AutogenPipelineDebugStatsService.getLiveStats(),
           builder: (context, stats, _) {
             return Column(
               crossAxisAlignment: CrossAxisAlignment.start,
@@ -37,6 +37,10 @@ class InlineAutogenDebugPanelWidget extends StatelessWidget {
         const Divider(),
         const SizedBox(height: 12),
         const AutogenPipelineControlPanelWidget(),
+        const SizedBox(height: 12),
+        const Divider(),
+        const SizedBox(height: 12),
+        const InlineAutogenEventLogWidget(),
       ],
     );
   }

--- a/lib/widgets/inline_autogen_event_log_widget.dart
+++ b/lib/widgets/inline_autogen_event_log_widget.dart
@@ -1,0 +1,73 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../services/autogen_pipeline_event_logger_service.dart';
+import '../screens/autogen_metrics_dashboard_screen.dart';
+
+/// Compact viewer showing recent autogen pipeline events.
+class InlineAutogenEventLogWidget extends StatefulWidget {
+  const InlineAutogenEventLogWidget({super.key});
+
+  @override
+  State<InlineAutogenEventLogWidget> createState() =>
+      _InlineAutogenEventLogWidgetState();
+}
+
+class _InlineAutogenEventLogWidgetState
+    extends State<InlineAutogenEventLogWidget> {
+  Timer? _timer;
+
+  @override
+  void initState() {
+    super.initState();
+    _timer = Timer.periodic(const Duration(seconds: 1), (_) {
+      if (mounted) setState(() {});
+    });
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final events = List<AutogenPipelineEvent>.from(
+      AutogenPipelineEventLoggerService.getLog(),
+    );
+    events.sort((a, b) => b.timestamp.compareTo(a.timestamp));
+    final recent = events.take(10).toList();
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (recent.isEmpty)
+          const Text('No events logged yet')
+        else
+          for (final e in recent)
+            ListTile(
+              dense: true,
+              leading: Text(DateFormat('HH:mm:ss').format(e.timestamp)),
+              title: Text(e.message),
+              subtitle: Text(e.type),
+            ),
+        Align(
+          alignment: Alignment.centerRight,
+          child: TextButton(
+            onPressed: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (_) => const AutogenMetricsDashboardScreen(),
+                ),
+              );
+            },
+            child: const Text('View Full Log'),
+          ),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `InlineAutogenEventLogWidget` to show up to 10 recent pipeline events
- include quick navigation to full metrics dashboard from the inline log
- embed the event log widget in `InlineAutogenDebugPanelWidget`

## Testing
- `dart test` *(fails: Because poker_analyzer depends on flutter_test from sdk which doesn't exist (the Flutter SDK is not available), version solving failed.)*


------
https://chatgpt.com/codex/tasks/task_e_6894b3329ffc832abee1654bb3ed6921