### PR TITLE
feat: add autogen error inspector widget

### DIFF
--- a/lib/screens/autogen_metrics_dashboard_screen.dart
+++ b/lib/screens/autogen_metrics_dashboard_screen.dart
@@ -16,6 +16,7 @@ import '../services/file_saver_service.dart';
 import '../widgets/autogen_debug_control_panel_widget.dart';
 import '../widgets/autogen_event_log_viewer_widget.dart';
 import '../widgets/run_comparison_window.dart';
+import '../widgets/autogen_error_inspector_widget.dart';
 
 /// Visual dashboard for autogen pack generation metrics.
 class AutogenMetricsDashboardScreen extends StatefulWidget {
@@ -173,6 +174,8 @@ class _AutogenMetricsDashboardScreenState
                   height: 300,
                   child: AutogenEventLogViewerWidget(),
                 ),
+                const SizedBox(height: 16),
+                const AutogenErrorInspectorWidget(),
                 const SizedBox(height: 16),
                 _buildTile('Generated',
                     (_metrics['generatedCount'] as int? ?? 0).toString()),

--- a/lib/services/autogen_pack_error_classifier_service.dart
+++ b/lib/services/autogen_pack_error_classifier_service.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+
 import '../models/v2/training_pack_template_v2.dart';
 
 /// Enumerates known auto-generation error types for packs.
@@ -10,23 +12,72 @@ enum AutogenPackErrorType {
   unknown,
 }
 
+/// Detailed record of a rejected pack.
+class AutogenPackErrorEntry {
+  final DateTime timestamp;
+  final String packId;
+  final AutogenPackErrorType type;
+  final String message;
+
+  AutogenPackErrorEntry({
+    required this.timestamp,
+    required this.packId,
+    required this.type,
+    required this.message,
+  });
+}
+
 /// Classifies rejected packs into [AutogenPackErrorType] categories.
 class AutogenPackErrorClassifierService {
   const AutogenPackErrorClassifierService();
 
+  static const int _maxErrors = 50;
+  static final ValueNotifier<List<AutogenPackErrorEntry>> _recentErrors =
+      ValueNotifier<List<AutogenPackErrorEntry>>([]);
+
   /// Returns the [AutogenPackErrorType] for a rejected [pack] and optional
-  /// generation [error].
-  AutogenPackErrorType classify(TrainingPackTemplateV2 pack, Exception? error) {
+  /// generation [error]. Logs the classification for later inspection.
+  AutogenPackErrorType classify(
+      TrainingPackTemplateV2 pack, Exception? error) {
     final msg = error?.toString().toLowerCase() ?? '';
-    if (msg.contains('duplicate')) return AutogenPackErrorType.duplicate;
-    if (msg.contains('empty')) return AutogenPackErrorType.emptyOutput;
-    if (msg.contains('invalid board')) return AutogenPackErrorType.invalidBoard;
-    if (msg.contains('syntax') || msg.contains('format')) {
-      return AutogenPackErrorType.templateSyntaxError;
+    AutogenPackErrorType type;
+    if (msg.contains('duplicate')) {
+      type = AutogenPackErrorType.duplicate;
+    } else if (msg.contains('empty')) {
+      type = AutogenPackErrorType.emptyOutput;
+    } else if (msg.contains('invalid board')) {
+      type = AutogenPackErrorType.invalidBoard;
+    } else if (msg.contains('syntax') || msg.contains('format')) {
+      type = AutogenPackErrorType.templateSyntaxError;
+    } else if (pack.spots.isEmpty || pack.spotCount == 0) {
+      type = AutogenPackErrorType.noSpotsGenerated;
+    } else {
+      type = AutogenPackErrorType.unknown;
     }
-    if (pack.spots.isEmpty || pack.spotCount == 0) {
-      return AutogenPackErrorType.noSpotsGenerated;
+
+    final entry = AutogenPackErrorEntry(
+      timestamp: DateTime.now(),
+      packId: pack.name.isNotEmpty ? pack.name : pack.id,
+      type: type,
+      message: error?.toString() ?? '',
+    );
+    final list = List<AutogenPackErrorEntry>.from(_recentErrors.value)..add(entry);
+    if (list.length > _maxErrors) {
+      list.removeRange(0, list.length - _maxErrors);
     }
-    return AutogenPackErrorType.unknown;
+    _recentErrors.value = list;
+
+    return type;
   }
+
+  /// Returns a listenable of recent classified errors.
+  static ValueListenable<List<AutogenPackErrorEntry>> recentErrorsListenable() =>
+      _recentErrors;
+
+  /// Returns the current recent error list.
+  static List<AutogenPackErrorEntry> getRecentErrors() =>
+      List.unmodifiable(_recentErrors.value);
+
+  /// Clears the recent error log.
+  static void clearRecentErrors() => _recentErrors.value = [];
 }

--- a/lib/widgets/autogen_error_inspector_widget.dart
+++ b/lib/widgets/autogen_error_inspector_widget.dart
@@ -1,0 +1,133 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+import 'package:share_plus/share_plus.dart';
+
+import '../services/autogen_pack_error_classifier_service.dart';
+import '../services/file_saver_service.dart';
+
+/// Displays recent autogen errors with classification details.
+class AutogenErrorInspectorWidget extends StatefulWidget {
+  const AutogenErrorInspectorWidget({super.key});
+
+  @override
+  State<AutogenErrorInspectorWidget> createState() =>
+      _AutogenErrorInspectorWidgetState();
+}
+
+class _AutogenErrorInspectorWidgetState
+    extends State<AutogenErrorInspectorWidget> {
+  AutogenPackErrorType? _filter;
+
+  Future<void> _exportCsv(List<AutogenPackErrorEntry> entries) async {
+    final buffer = StringBuffer('timestamp,packId,errorType,message\n');
+    for (final e in entries) {
+      final ts = e.timestamp.toIso8601String();
+      final msg = e.message.replaceAll('\n', ' ').replaceAll(',', ';');
+      buffer.writeln('$ts,${e.packId},${e.type.name},$msg');
+    }
+    final csv = buffer.toString();
+    try {
+      if (kIsWeb || !(Platform.isAndroid || Platform.isIOS)) {
+        await FileSaverService.instance.saveCsv('autogen_recent_errors', csv);
+      } else {
+        final dir =
+            await getDownloadsDirectory() ?? await getApplicationDocumentsDirectory();
+        final file = File(p.join(dir.path, 'autogen_recent_errors.csv'));
+        await file.writeAsString(csv);
+        await Share.shareXFiles([XFile(file.path)]);
+      }
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Recent errors exported')),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed to export errors: $e')),
+        );
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<List<AutogenPackErrorEntry>>(
+      valueListenable:
+          AutogenPackErrorClassifierService.recentErrorsListenable(),
+      builder: (context, errors, _) {
+        final filtered = _filter == null
+            ? errors
+            : errors.where((e) => e.type == _filter).toList();
+        return Card(
+          child: Padding(
+            padding: const EdgeInsets.all(8),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    const Text(
+                      'Recent Errors',
+                      style: TextStyle(fontWeight: FontWeight.bold),
+                    ),
+                    const Spacer(),
+                    DropdownButton<AutogenPackErrorType?>(
+                      value: _filter,
+                      hint: const Text('Filter'),
+                      onChanged: (v) => setState(() => _filter = v),
+                      items: [
+                        const DropdownMenuItem(
+                            value: null, child: Text('All')),
+                        ...AutogenPackErrorType.values.map(
+                          (t) => DropdownMenuItem(
+                            value: t,
+                            child: Text(t.name),
+                          ),
+                        ),
+                      ],
+                    ),
+                    IconButton(
+                      tooltip: 'Export to CSV',
+                      icon: const Icon(Icons.download),
+                      onPressed:
+                          filtered.isEmpty ? null : () => _exportCsv(filtered),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 8),
+                if (filtered.isEmpty)
+                  const Text('No recent errors')
+                else
+                  SizedBox(
+                    height: 200,
+                    child: ListView.builder(
+                      itemCount: filtered.length,
+                      itemBuilder: (context, index) {
+                        final e =
+                            filtered[filtered.length - 1 - index]; // latest first
+                        final ts = DateFormat('HH:mm:ss').format(e.timestamp);
+                        return ListTile(
+                          dense: true,
+                          leading: Text(ts),
+                          title: Text(e.packId),
+                          subtitle: Text(e.message),
+                          trailing: Text(e.type.name),
+                        );
+                      },
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+

--- a/test/services/autogen_pack_error_classifier_service_test.dart
+++ b/test/services/autogen_pack_error_classifier_service_test.dart
@@ -21,6 +21,8 @@ void main() {
   group('AutogenPackErrorClassifierService', () {
     const classifier = AutogenPackErrorClassifierService();
 
+    setUp(() => AutogenPackErrorClassifierService.clearRecentErrors());
+
     test('detects no spots generated', () {
       final type = classifier.classify(_emptyPack(), null);
       expect(type, AutogenPackErrorType.noSpotsGenerated);
@@ -38,6 +40,21 @@ void main() {
         Exception('Invalid board sequence'),
       );
       expect(type, AutogenPackErrorType.invalidBoard);
+    });
+
+    test('stores recent errors with classification', () {
+      classifier.classify(_emptyPack(), Exception('duplicate spot'));
+      final errors = AutogenPackErrorClassifierService.getRecentErrors();
+      expect(errors, hasLength(1));
+      expect(errors.first.type, AutogenPackErrorType.duplicate);
+    });
+
+    test('limits recent errors to 50', () {
+      for (var i = 0; i < 60; i++) {
+        classifier.classify(_emptyPack(), Exception('duplicate spot $i'));
+      }
+      final errors = AutogenPackErrorClassifierService.getRecentErrors();
+      expect(errors.length, 50);
     });
   });
 }


### PR DESCRIPTION
## Summary
- expand autogen error classifier to log recent rejected packs
- add AutogenErrorInspectorWidget with filtering and CSV export
- embed widget into AutogenMetricsDashboardScreen and test logging

## Testing
- `dart test test/services/autogen_pack_error_classifier_service_test.dart` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6894b4f5ada0832ab95d5b08f75d83b2