### PR TITLE
Add simple CounterButton widget

### DIFF
--- a/lib/widgets/counter_button.dart
+++ b/lib/widgets/counter_button.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+/// A simple button that increments a counter on each tap.
+class CounterButton extends StatefulWidget {
+  const CounterButton({super.key});
+
+  @override
+  State<CounterButton> createState() => _CounterButtonState();
+}
+
+class _CounterButtonState extends State<CounterButton> {
+  int _count = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return ElevatedButton(
+      onPressed: () => setState(() => _count++),
+      child: Text('Count: $_count'),
+    );
+  }
+}

--- a/test/counter_button_test.dart
+++ b/test/counter_button_test.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/widgets/counter_button.dart';
+
+void main() {
+  testWidgets('CounterButton increments counter on tap', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(const MaterialApp(home: CounterButton()));
+    expect(find.text('Count: 0'), findsOneWidget);
+
+    await tester.tap(find.byType(ElevatedButton));
+    await tester.pump();
+
+    expect(find.text('Count: 1'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add `CounterButton` widget that increments count on tap
- test counter increments on tap

## Testing
- `flutter test test/counter_button_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_6894cd8349a4832a9bb2f55922463b03