### PR TITLE
Add manual Autogen pipeline control panel

### DIFF
--- a/lib/widgets/autogen_pipeline_control_panel_widget.dart
+++ b/lib/widgets/autogen_pipeline_control_panel_widget.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+
+import '../services/autogen_pipeline_state_service.dart';
+
+/// A control panel with buttons to manually update the autogen pipeline state.
+class AutogenPipelineControlPanelWidget extends StatelessWidget {
+  const AutogenPipelineControlPanelWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<AutogenPipelineStatus>(
+      valueListenable: AutogenPipelineStateService.getCurrentState(),
+      builder: (context, status, _) {
+        return Row(
+          children: [
+            ElevatedButton(
+              onPressed: status == AutogenPipelineStatus.publishing
+                  ? null
+                  : () => AutogenPipelineStateService.getCurrentState().value =
+                      AutogenPipelineStatus.publishing,
+              style: ElevatedButton.styleFrom(
+                backgroundColor: Colors.green,
+              ),
+              child: const Text('Start'),
+            ),
+            const SizedBox(width: 8),
+            ElevatedButton(
+              onPressed: status == AutogenPipelineStatus.paused
+                  ? null
+                  : () => AutogenPipelineStateService.getCurrentState().value =
+                      AutogenPipelineStatus.paused,
+              style: ElevatedButton.styleFrom(
+                backgroundColor: Colors.orange,
+              ),
+              child: const Text('Pause'),
+            ),
+            const SizedBox(width: 8),
+            ElevatedButton(
+              onPressed: status == AutogenPipelineStatus.ready
+                  ? null
+                  : () => AutogenPipelineStateService.getCurrentState().value =
+                      AutogenPipelineStatus.ready,
+              style: ElevatedButton.styleFrom(
+                backgroundColor: Colors.red,
+              ),
+              child: const Text('Reset'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}
+

--- a/test/widgets/autogen_pipeline_control_panel_widget_test.dart
+++ b/test/widgets/autogen_pipeline_control_panel_widget_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/autogen_pipeline_state_service.dart';
+import 'package:poker_analyzer/widgets/autogen_pipeline_control_panel_widget.dart';
+
+void main() {
+  group('AutogenPipelineControlPanelWidget', () {
+    setUp(() {
+      AutogenPipelineStateService.getCurrentState().value =
+          AutogenPipelineStatus.ready;
+    });
+
+    testWidgets('updates pipeline state and disables buttons accordingly',
+        (tester) async {
+      await tester.pumpWidget(const MaterialApp(
+        home: Scaffold(body: AutogenPipelineControlPanelWidget()),
+      ));
+
+      final notifier = AutogenPipelineStateService.getCurrentState();
+
+      // Start -> publishing
+      await tester.tap(find.text('Start'));
+      await tester.pump();
+      expect(notifier.value, AutogenPipelineStatus.publishing);
+      expect(
+        tester
+            .widget<ElevatedButton>(find.widgetWithText(ElevatedButton, 'Start'))
+            .onPressed,
+        isNull,
+      );
+
+      // Reset -> ready
+      await tester.tap(find.text('Reset'));
+      await tester.pump();
+      expect(notifier.value, AutogenPipelineStatus.ready);
+      expect(
+        tester
+            .widget<ElevatedButton>(find.widgetWithText(ElevatedButton, 'Start'))
+            .onPressed,
+        isNotNull,
+      );
+
+      // Pause -> paused
+      await tester.tap(find.text('Pause'));
+      await tester.pump();
+      expect(notifier.value, AutogenPipelineStatus.paused);
+      expect(
+        tester
+            .widget<ElevatedButton>(find.widgetWithText(ElevatedButton, 'Pause'))
+            .onPressed,
+        isNull,
+      );
+    });
+  });
+}
+


### PR DESCRIPTION
## Summary
- add `AutogenPipelineControlPanelWidget` with Start/Pause/Reset buttons to update pipeline status
- cover control panel with a widget test ensuring state transitions and button disabling

## Testing
- `flutter test test/widgets/autogen_pipeline_control_panel_widget_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894acbf85e0832aad46d7e12f43b34e