### PR TITLE
Add Tag Coverage debug screen

### DIFF
--- a/lib/screens/dev_menu/coverage_section.dart
+++ b/lib/screens/dev_menu/coverage_section.dart
@@ -5,6 +5,7 @@ import '../../services/training_coverage_service.dart';
 import '../pack_coverage_stats_screen.dart';
 import '../theory_coverage_dashboard.dart';
 import '../yaml_coverage_stats_screen.dart';
+import '../pack_tag_counter_debugger_screen.dart';
 
 class CoverageSection extends StatefulWidget {
   const CoverageSection({super.key});
@@ -22,8 +23,9 @@ class _CoverageSectionState extends State<CoverageSection> {
     final ok = await compute(_coverageTask, '');
     if (!mounted) return;
     setState(() => _exporting = false);
-    ScaffoldMessenger.of(context)
-        .showSnackBar(SnackBar(content: Text(ok ? 'Готово' : 'Ошибка')));
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text(ok ? 'Готово' : 'Ошибка')));
   }
 
   @override
@@ -55,6 +57,18 @@ class _CoverageSectionState extends State<CoverageSection> {
                 context,
                 MaterialPageRoute(
                   builder: (_) => const PackCoverageStatsScreen(),
+                ),
+              );
+            },
+          ),
+        if (kDebugMode)
+          ListTile(
+            title: const Text('📊 Tag Coverage'),
+            onTap: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => const PackTagCounterDebuggerScreen(),
                 ),
               );
             },

--- a/lib/screens/pack_tag_counter_debugger_screen.dart
+++ b/lib/screens/pack_tag_counter_debugger_screen.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+import '../services/pack_tag_counter_service.dart';
+
+/// Debug screen that visualizes tag usage counts from [PackTagCounterService].
+class PackTagCounterDebuggerScreen extends StatefulWidget {
+  const PackTagCounterDebuggerScreen({super.key});
+
+  @override
+  State<PackTagCounterDebuggerScreen> createState() =>
+      _PackTagCounterDebuggerScreenState();
+}
+
+class _PackTagCounterDebuggerScreenState
+    extends State<PackTagCounterDebuggerScreen> {
+  Map<String, int> _counts = const <String, int>{};
+
+  @override
+  void initState() {
+    super.initState();
+    _loadCounts();
+  }
+
+  void _loadCounts() {
+    setState(() {
+      _counts = PackTagCounterService.instance.getTagCounts();
+    });
+  }
+
+  void _reset() {
+    PackTagCounterService.instance.reset();
+    _loadCounts();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!kDebugMode) return const SizedBox.shrink();
+    final entries = _counts.entries.toList()
+      ..sort((a, b) => b.value.compareTo(a.value));
+    final maxCount = entries.isEmpty
+        ? 1
+        : entries.map((e) => e.value).reduce((a, b) => a > b ? a : b);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Tag Coverage'),
+        actions: [TextButton(onPressed: _reset, child: const Text('Reset'))],
+      ),
+      body: ListView.separated(
+        padding: const EdgeInsets.all(16),
+        itemCount: entries.length,
+        separatorBuilder: (_, __) => const SizedBox(height: 8),
+        itemBuilder: (_, i) {
+          final e = entries[i];
+          final progress = maxCount == 0 ? 0.0 : e.value / maxCount;
+          return ListTile(
+            title: Text(e.key),
+            subtitle: LinearProgressIndicator(value: progress),
+            trailing: Text('${e.value}'),
+          );
+        },
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Add PackTagCounterDebuggerScreen to visualize tag usage with counts and progress bars
- Wire Tag Coverage screen into Dev Menu's Coverage section

## Testing
- `mise x flutter@3.32.8-stable -- dart format lib/screens/pack_tag_counter_debugger_screen.dart lib/screens/dev_menu/coverage_section.dart`
- `mise x flutter@3.32.8-stable -- flutter pub get`
- `mise x flutter@3.32.8-stable -- flutter test` *(fails: Error: the Dart compiler exited unexpectedly)*

------
https://chatgpt.com/codex/tasks/task_e_6894d45d2094832a94a3c76f4a9ca02a