### PR TITLE
feat: load tag counts on debugger init

### DIFF
--- a/lib/screens/pack_tag_counter_debugger_screen.dart
+++ b/lib/screens/pack_tag_counter_debugger_screen.dart
@@ -22,7 +22,9 @@ class _PackTagCounterDebuggerScreenState
     _loadCounts();
   }
 
-  void _loadCounts() {
+  Future<void> _loadCounts() async {
+    await PackTagCounterService.instance.load();
+    if (!mounted) return;
     setState(() {
       _counts = PackTagCounterService.instance.getTagCounts();
     });

--- a/lib/services/pack_tag_counter_service.dart
+++ b/lib/services/pack_tag_counter_service.dart
@@ -19,7 +19,8 @@ class PackTagCounterService {
   final Map<String, int> _counts = <String, int>{};
   bool _loaded = false;
 
-  Future<void> _load() async {
+  /// Loads persisted tag counts from local storage if not yet loaded.
+  Future<void> load() async {
     if (_loaded) return;
     final prefs = await SharedPreferences.getInstance();
     final raw = prefs.getString(_prefsKey);
@@ -45,7 +46,7 @@ class PackTagCounterService {
   }
 
   Future<void> _logPack(TrainingPackModel pack) async {
-    await _load();
+    await load();
     for (final tag in pack.tags) {
       final t = tag.toLowerCase();
       _counts[t] = (_counts[t] ?? 0) + 1;


### PR DESCRIPTION
## Summary
- expose `load` in `PackTagCounterService` to read persisted tag counts
- ensure `PackTagCounterDebuggerScreen` awaits service load before reading counts

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_6894d6bad9ac832aa9df081c201dab48