### PR TITLE
Add Skill Tag Coverage debugger screen

### DIFF
--- a/lib/screens/dev_menu/debug_tools_section.dart
+++ b/lib/screens/dev_menu/debug_tools_section.dart
@@ -7,6 +7,7 @@ import '../../services/learning_graph_engine.dart';
 import '../recent_auto_injections_screen.dart';
 import '../theory_recall_stats_dashboard_screen.dart';
 import '../training_pack_import_validator_screen.dart';
+import '../skill_tag_coverage_debugger_screen.dart';
 
 class DebugToolsSection extends StatefulWidget {
   const DebugToolsSection({super.key});
@@ -91,6 +92,18 @@ class _DebugToolsSectionState extends State<DebugToolsSection> {
                 context,
                 MaterialPageRoute(
                   builder: (_) => const TrainingPackImportValidatorScreen(),
+                ),
+              );
+            },
+          ),
+        if (kDebugMode)
+          ListTile(
+            title: const Text('Skill Tag Coverage Debugger'),
+            onTap: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => const SkillTagCoverageDebuggerScreen(),
                 ),
               );
             },

--- a/lib/screens/skill_tag_coverage_debugger_screen.dart
+++ b/lib/screens/skill_tag_coverage_debugger_screen.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+import '../services/skill_tag_coverage_tracker_service.dart';
+
+/// Debug screen visualizing how often each skill tag appears.
+class SkillTagCoverageDebuggerScreen extends StatefulWidget {
+  const SkillTagCoverageDebuggerScreen({super.key});
+
+  @override
+  State<SkillTagCoverageDebuggerScreen> createState() =>
+      _SkillTagCoverageDebuggerScreenState();
+}
+
+class _SkillTagCoverageDebuggerScreenState
+    extends State<SkillTagCoverageDebuggerScreen> {
+  Map<String, int> _stats = const {};
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  void _load() {
+    _stats = SkillTagCoverageTrackerService.instance.getTagStats();
+    setState(() {});
+  }
+
+  void _reset() {
+    SkillTagCoverageTrackerService.instance.reset();
+    _load();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!kDebugMode) return const SizedBox.shrink();
+    final entries = _stats.entries.toList()
+      ..sort((a, b) => b.value.compareTo(a.value));
+    final max = entries.isEmpty
+        ? 1
+        : entries.map((e) => e.value).reduce((a, b) => a > b ? a : b);
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Skill Tag Coverage'),
+        actions: [
+          TextButton(
+            onPressed: _reset,
+            child: const Text('Reset', style: TextStyle(color: Colors.white)),
+          ),
+        ],
+      ),
+      body: ListView.builder(
+        itemCount: entries.length,
+        itemBuilder: (context, index) {
+          final e = entries[index];
+          return ListTile(
+            title: Text(e.key),
+            trailing: Text('${e.value}'),
+            subtitle: LinearProgressIndicator(
+              value: e.value / max,
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/services/skill_tag_coverage_tracker.dart
+++ b/lib/services/skill_tag_coverage_tracker.dart
@@ -174,5 +174,11 @@ class SkillTagCoverageTracker {
     }, path);
   }
 
+  /// Clears all accumulated tag statistics.
+  void reset() {
+    skillTagCounts.clear();
+    _totalTags = 0;
+  }
+
   String _normalize(String tag) => tag.trim().toLowerCase();
 }

--- a/lib/services/skill_tag_coverage_tracker_service.dart
+++ b/lib/services/skill_tag_coverage_tracker_service.dart
@@ -1,19 +1,33 @@
 import '../models/skill_tag_coverage_report.dart';
 import 'training_pack_library_service.dart';
+import 'skill_tag_coverage_tracker.dart';
 
 /// Evaluates how many spots reference each skill tag across the
 /// training pack library.
 class SkillTagCoverageTrackerService {
+  static final SkillTagCoverageTrackerService instance =
+      SkillTagCoverageTrackerService();
+
   final TrainingPackLibraryService library;
   final Set<String> allSkillTags;
   final int underrepresentedThreshold;
+  final SkillTagCoverageTracker _tracker;
 
   SkillTagCoverageTrackerService({
     TrainingPackLibraryService? library,
     Set<String>? allSkillTags,
     this.underrepresentedThreshold = 5,
-  }) : library = library ?? TrainingPackLibraryService(),
-       allSkillTags = allSkillTags ?? const {};
+    SkillTagCoverageTracker? tracker,
+  })  : library = library ?? TrainingPackLibraryService(),
+        allSkillTags = allSkillTags ?? const {},
+        _tracker = tracker ?? SkillTagCoverageTracker();
+
+  /// Returns current tag usage statistics.
+  Map<String, int> getTagStats() =>
+      Map<String, int>.from(_tracker.skillTagCounts);
+
+  /// Resets the underlying tracker.
+  void reset() => _tracker.reset();
 
   /// Generates a coverage report for all packs in the library.
   Future<SkillTagCoverageReport> generateReport() async {


### PR DESCRIPTION
## Summary
- add SkillTagCoverageDebuggerScreen with reset and progress bars
- expose singleton SkillTagCoverageTrackerService with tag stats and reset
- hook debugger into dev tools menu

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894d92c2574832a877bcfa91c0f7958