### PR TITLE
feat: add theory cluster pack heatmap widget

### DIFF
--- a/lib/widgets/theory_cluster_pack_heatmap_widget.dart
+++ b/lib/widgets/theory_cluster_pack_heatmap_widget.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+
+import '../models/training_pack_model.dart';
+import '../models/theory_lesson_cluster.dart';
+import '../services/theory_lesson_tag_clusterer_service.dart';
+
+/// Visualizes theory cluster coverage for a given training pack.
+///
+/// Computes the fraction of tags from each cluster that are present in the
+/// [TrainingPackModel]'s tags and displays a compact heatmap style list sorted
+/// by coverage.
+class TheoryClusterPackHeatmapWidget extends StatelessWidget {
+  final TrainingPackModel pack;
+  final TheoryLessonTagClustererService service;
+
+  const TheoryClusterPackHeatmapWidget({
+    super.key,
+    required this.pack,
+    TheoryLessonTagClustererService? service,
+  }) : service = service ?? TheoryLessonTagClustererService.instance;
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<List<TheoryLessonCluster>>(
+      future: service.getClusters(),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState != ConnectionState.done) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        final clusters = snapshot.data ?? const [];
+        final tagSet = pack.tags.toSet();
+        final entries = clusters.map((c) {
+          final shared = c.sharedTags;
+          final matched = shared.where(tagSet.contains).length;
+          final coverage = shared.isEmpty ? 0.0 : matched / shared.length;
+          return _ClusterCoverage(cluster: c, coverage: coverage);
+        }).toList()..sort((a, b) => b.coverage.compareTo(a.coverage));
+
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            for (final entry in entries) _ClusterCoverageRow(entry: entry),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _ClusterCoverage {
+  final TheoryLessonCluster cluster;
+  final double coverage;
+
+  _ClusterCoverage({required this.cluster, required this.coverage});
+}
+
+class _ClusterCoverageRow extends StatelessWidget {
+  final _ClusterCoverage entry;
+
+  const _ClusterCoverageRow({required this.entry});
+
+  @override
+  Widget build(BuildContext context) {
+    final percent = (entry.coverage * 100).round();
+    final label = entry.cluster.sharedTags.take(3).join(', ');
+    final color =
+        Color.lerp(Colors.red, Colors.green, entry.coverage) ?? Colors.red;
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 2),
+      child: Row(
+        children: [
+          Expanded(child: Text(label.isEmpty ? 'Cluster' : label)),
+          SizedBox(
+            width: 60,
+            child: LinearProgressIndicator(
+              value: entry.coverage,
+              backgroundColor: Colors.grey.shade300,
+              valueColor: AlwaysStoppedAnimation<Color>(color),
+            ),
+          ),
+          const SizedBox(width: 4),
+          SizedBox(width: 30, child: Text('$percent%')),
+        ],
+      ),
+    );
+  }
+}

--- a/test/widgets/theory_cluster_pack_heatmap_widget_test.dart
+++ b/test/widgets/theory_cluster_pack_heatmap_widget_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/theory_lesson_cluster.dart';
+import 'package:poker_analyzer/models/training_pack_model.dart';
+import 'package:poker_analyzer/widgets/theory_cluster_pack_heatmap_widget.dart';
+import 'package:poker_analyzer/services/theory_lesson_tag_clusterer_service.dart';
+
+class _FakeService implements TheoryLessonTagClustererService {
+  final List<TheoryLessonCluster> clusters;
+  _FakeService(this.clusters);
+
+  @override
+  Future<List<TheoryLessonCluster>> getClusters() async => clusters;
+
+  @override
+  void clearCache() {}
+}
+
+void main() {
+  testWidgets('sorts clusters by coverage', (tester) async {
+    final c1 = TheoryLessonCluster(lessons: const [], tags: {'a', 'b'});
+    final c2 = TheoryLessonCluster(lessons: const [], tags: {'c'});
+    final service = _FakeService([c1, c2]);
+    final pack = TrainingPackModel(
+      id: '1',
+      title: 't',
+      spots: const [],
+      tags: ['a'],
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: TheoryClusterPackHeatmapWidget(pack: pack, service: service),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final indicators = find.byType(LinearProgressIndicator);
+    expect(indicators, findsNWidgets(2));
+
+    final first = tester.widget<LinearProgressIndicator>(indicators.at(0));
+    final second = tester.widget<LinearProgressIndicator>(indicators.at(1));
+    expect(first.value, greaterThan(second.value!));
+  });
+}


### PR DESCRIPTION
## Summary
- add TheoryClusterPackHeatmapWidget to visualize theory coverage per cluster
- test sorting logic for heatmap entries

## Testing
- `flutter test` *(fails: package file_picker references default package missing inline implementation and unresolved imports)*

------
https://chatgpt.com/codex/tasks/task_e_6894e2e2a934832aad58b55a4965adf2