### PR TITLE
Add autogen pipeline progress monitor

### DIFF
--- a/lib/models/autogen_step_status.dart
+++ b/lib/models/autogen_step_status.dart
@@ -1,0 +1,23 @@
+class AutoGenStepStatus {
+  final String stepName;
+  final String status;
+  final String? errorMessage;
+
+  const AutoGenStepStatus({
+    required this.stepName,
+    required this.status,
+    this.errorMessage,
+  });
+
+  AutoGenStepStatus copyWith({
+    String? stepName,
+    String? status,
+    String? errorMessage,
+  }) {
+    return AutoGenStepStatus(
+      stepName: stepName ?? this.stepName,
+      status: status ?? this.status,
+      errorMessage: errorMessage ?? this.errorMessage,
+    );
+  }
+}

--- a/lib/services/autogen_pipeline_session_tracker_service.dart
+++ b/lib/services/autogen_pipeline_session_tracker_service.dart
@@ -1,0 +1,44 @@
+import 'dart:async';
+
+import '../models/autogen_step_status.dart';
+
+/// Tracks progress of autogen steps for a session and exposes updates as a
+/// stream.
+class AutogenPipelineSessionTrackerService {
+  AutogenPipelineSessionTrackerService._();
+
+  static final AutogenPipelineSessionTrackerService _instance =
+      AutogenPipelineSessionTrackerService._();
+
+  factory AutogenPipelineSessionTrackerService() => _instance;
+  static AutogenPipelineSessionTrackerService get instance => _instance;
+
+  final Map<String, List<AutoGenStepStatus>> _sessionSteps = {};
+  final Map<String, StreamController<List<AutoGenStepStatus>>> _controllers = {};
+
+  Stream<List<AutoGenStepStatus>> watchSession(String sessionId) {
+    final controller = _controllers.putIfAbsent(
+      sessionId,
+      () => StreamController<List<AutoGenStepStatus>>.broadcast(),
+    );
+    _sessionSteps.putIfAbsent(sessionId, () => []);
+    return controller.stream;
+  }
+
+  void updateStep(String sessionId, AutoGenStepStatus status) {
+    final steps = _sessionSteps.putIfAbsent(sessionId, () => []);
+    steps.removeWhere((s) => s.stepName == status.stepName);
+    steps.add(status);
+    final controller = _controllers.putIfAbsent(
+      sessionId,
+      () => StreamController<List<AutoGenStepStatus>>.broadcast(),
+    );
+    controller.add(List.unmodifiable(steps));
+  }
+
+  void clearSession(String sessionId) {
+    _controllers[sessionId]?.close();
+    _controllers.remove(sessionId);
+    _sessionSteps.remove(sessionId);
+  }
+}

--- a/lib/widgets/autogen_pipeline_progress_monitor.dart
+++ b/lib/widgets/autogen_pipeline_progress_monitor.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+
+import '../models/autogen_step_status.dart';
+import '../services/autogen_pipeline_session_tracker_service.dart';
+
+/// Displays real-time progress of autogen steps for a given session.
+class AutogenPipelineProgressMonitor extends StatelessWidget {
+  final String sessionId;
+
+  const AutogenPipelineProgressMonitor({super.key, required this.sessionId});
+
+  Icon _buildIcon(AutoGenStepStatus step) {
+    switch (step.status) {
+      case 'ok':
+        return const Icon(Icons.check_circle, color: Colors.green);
+      case 'error':
+        return const Icon(Icons.error, color: Colors.red);
+      default:
+        return const Icon(Icons.hourglass_empty, color: Colors.blue);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder<List<AutoGenStepStatus>>(
+      stream: AutogenPipelineSessionTrackerService.instance.watchSession(sessionId),
+      initialData: const [],
+      builder: (context, snapshot) {
+        final steps = snapshot.data ?? [];
+        return ListView(
+          shrinkWrap: true,
+          children: steps.map((step) {
+            final tile = ListTile(
+              leading: _buildIcon(step),
+              title: Text(step.stepName),
+            );
+            if (step.status == 'error' && step.errorMessage != null) {
+              return Tooltip(message: step.errorMessage!, child: tile);
+            }
+            return tile;
+          }).toList(),
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `AutoGenStepStatus` model for tracking pipeline step states
- implement `AutogenPipelineSessionTrackerService` to stream step updates
- create `AutogenPipelineProgressMonitor` widget showing step progress with icons and tooltips

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894e51b33b4832a99350cbbe8d6c498