### PR TITLE
feat: add autogen session dashboard service

### DIFF
--- a/lib/models/autogen_session_meta.dart
+++ b/lib/models/autogen_session_meta.dart
@@ -1,0 +1,27 @@
+class AutogenSessionMeta {
+  final String sessionId;
+  final String packId;
+  final DateTime startedAt;
+  final String status; // running, done, error
+
+  AutogenSessionMeta({
+    required this.sessionId,
+    required this.packId,
+    required this.startedAt,
+    required this.status,
+  });
+
+  AutogenSessionMeta copyWith({
+    String? sessionId,
+    String? packId,
+    DateTime? startedAt,
+    String? status,
+  }) {
+    return AutogenSessionMeta(
+      sessionId: sessionId ?? this.sessionId,
+      packId: packId ?? this.packId,
+      startedAt: startedAt ?? this.startedAt,
+      status: status ?? this.status,
+    );
+  }
+}

--- a/lib/services/autogen_status_dashboard_service.dart
+++ b/lib/services/autogen_status_dashboard_service.dart
@@ -1,6 +1,9 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 
 import '../models/autogen_status.dart';
+import '../models/autogen_session_meta.dart';
 
 class AutogenStatusDashboardService {
   AutogenStatusDashboardService._();
@@ -12,15 +15,63 @@ class AutogenStatusDashboardService {
   static AutogenStatusDashboardService get instance => _instance;
 
   final Map<String, AutogenStatus> _statuses = {};
-  final ValueNotifier<Map<String, AutogenStatus>> notifier =
-      ValueNotifier(const <String, AutogenStatus>{});
+  final ValueNotifier<Map<String, AutogenStatus>> notifier = ValueNotifier(
+    const <String, AutogenStatus>{},
+  );
+
+  final List<AutogenSessionMeta> _sessions = [];
+  final StreamController<List<AutogenSessionMeta>> _sessionController =
+      StreamController.broadcast();
+  static const _sessionTtl = Duration(hours: 24);
 
   void update(String module, AutogenStatus status) {
     _statuses[module] = status;
     notifier.value = Map.unmodifiable(_statuses);
   }
 
+  void registerSession(AutogenSessionMeta meta) {
+    _cleanupOldSessions();
+    _sessions.removeWhere((s) => s.sessionId == meta.sessionId);
+    _sessions.add(meta);
+    _sessions.sort((a, b) => b.startedAt.compareTo(a.startedAt));
+    _sessionController.add(List.unmodifiable(_sessions));
+  }
+
+  void updateSessionStatus(String sessionId, String status) {
+    _cleanupOldSessions();
+    final index = _sessions.indexWhere((s) => s.sessionId == sessionId);
+    if (index != -1) {
+      final s = _sessions[index];
+      _sessions[index] = s.copyWith(status: status);
+      _sessionController.add(List.unmodifiable(_sessions));
+    }
+  }
+
+  List<AutogenSessionMeta> getRecentSessions() {
+    _cleanupOldSessions();
+    return List.unmodifiable(_sessions);
+  }
+
+  Stream<List<AutogenSessionMeta>> watchSessions() => _sessionController.stream;
+
   AutogenStatus? getStatus(String module) => _statuses[module];
 
   Map<String, AutogenStatus> getAll() => Map.unmodifiable(_statuses);
+
+  void _cleanupOldSessions() {
+    final cutoff = DateTime.now().subtract(_sessionTtl);
+    final before = _sessions.length;
+    _sessions.removeWhere((s) => s.startedAt.isBefore(cutoff));
+    if (_sessions.length != before) {
+      _sessionController.add(List.unmodifiable(_sessions));
+    }
+  }
+
+  @visibleForTesting
+  void clear() {
+    _statuses.clear();
+    notifier.value = const <String, AutogenStatus>{};
+    _sessions.clear();
+    _sessionController.add(const <AutogenSessionMeta>[]);
+  }
 }

--- a/test/services/autogen_status_dashboard_service_test.dart
+++ b/test/services/autogen_status_dashboard_service_test.dart
@@ -1,0 +1,47 @@
+import 'package:test/test.dart';
+
+import 'package:poker_analyzer/services/autogen_status_dashboard_service.dart';
+import 'package:poker_analyzer/models/autogen_session_meta.dart';
+
+void main() {
+  final service = AutogenStatusDashboardService.instance;
+
+  setUp(() => service.clear());
+
+  tearDown(() => service.clear());
+
+  test('registers and updates sessions', () {
+    final meta = AutogenSessionMeta(
+      sessionId: 's1',
+      packId: 'p1',
+      startedAt: DateTime.now(),
+      status: 'running',
+    );
+    service.registerSession(meta);
+    expect(service.getRecentSessions(), hasLength(1));
+    expect(service.getRecentSessions().first.status, 'running');
+
+    service.updateSessionStatus('s1', 'done');
+    expect(service.getRecentSessions().first.status, 'done');
+  });
+
+  test('removes sessions older than 24 hours', () {
+    final old = AutogenSessionMeta(
+      sessionId: 'old',
+      packId: 'p',
+      startedAt: DateTime.now().subtract(const Duration(days: 2)),
+      status: 'done',
+    );
+    final recent = AutogenSessionMeta(
+      sessionId: 'new',
+      packId: 'p',
+      startedAt: DateTime.now(),
+      status: 'running',
+    );
+    service.registerSession(old);
+    service.registerSession(recent);
+    final sessions = service.getRecentSessions();
+    expect(sessions, hasLength(1));
+    expect(sessions.first.sessionId, 'new');
+  });
+}


### PR DESCRIPTION
## Summary
- expand AutogenStatusDashboardService with session registry for autogen sessions
- add AutogenSessionMeta model and accompanying tests

## Testing
- `dart pub get` *(fails: Flutter SDK is not available)*
- `dart analyze` *(fails: Target of URI doesn't exist: 'package:path/path.dart')*
- `dart test` *(fails: Target of URI doesn't exist: 'package:flutter/material.dart')*


------
https://chatgpt.com/codex/tasks/task_e_6894e6921b88832ab1b6114733512af1