### PR TITLE
Refine InlinePackTheoryClusterViewer: normalized tag matching, empty states, coverage in headers, safe layout

### DIFF
--- a/lib/widgets/inline_pack_theory_cluster_viewer.dart
+++ b/lib/widgets/inline_pack_theory_cluster_viewer.dart
@@ -12,11 +12,17 @@ import '../services/theory_lesson_tag_clusterer_service.dart';
 class InlinePackTheoryClusterViewer extends StatelessWidget {
   final TrainingPackModel pack;
   final TheoryLessonTagClustererService service;
+  final int maxLessons;
+  final bool shrinkWrap;
+  final ScrollPhysics? physics;
 
   const InlinePackTheoryClusterViewer({
     super.key,
     required this.pack,
     TheoryLessonTagClustererService? service,
+    this.maxLessons = 5,
+    this.shrinkWrap = true,
+    this.physics = const NeverScrollableScrollPhysics(),
   }) : service = service ?? TheoryLessonTagClustererService.instance;
 
   @override
@@ -25,38 +31,59 @@ class InlinePackTheoryClusterViewer extends StatelessWidget {
       future: service.getClusters(),
       builder: (context, snapshot) {
         if (snapshot.connectionState != ConnectionState.done) {
-          return const Center(child: CircularProgressIndicator());
+          return const SizedBox(
+            width: 16,
+            height: 16,
+            child: CircularProgressIndicator(strokeWidth: 2),
+          );
         }
-        final clusters = snapshot.data ?? const [];
-        final tagSet = pack.tags.toSet();
-        final related = clusters
-            .where((c) => c.sharedTags.any(tagSet.contains))
-            .toList();
-        if (related.isEmpty) {
-          return const Text('No related theory clusters');
+        final clusters = snapshot.data ?? const <TheoryLessonCluster>[];
+        if (clusters.isEmpty) {
+          return const Text('No theory clusters found');
+        }
+        final normPackTags = pack.tags.map(_norm).toSet();
+        final relevant = clusters.where((c) {
+          final clusterTags = c.sharedTags.map(_norm).toSet();
+          return clusterTags.any(normPackTags.contains);
+        }).toList();
+        if (relevant.isEmpty) {
+          return const Text('No related clusters for this pack');
         }
         return Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            for (final c in related)
-              ExpansionTile(
-                title: Text('${_tagSummary(c)} (${c.lessons.length})'),
-                children: [
-                  for (final lesson in c.lessons.take(5))
-                    ListTile(
-                      dense: true,
-                      title: Text(lesson.title),
-                    ),
-                ],
-              ),
+            ListView.builder(
+              shrinkWrap: shrinkWrap,
+              physics: physics,
+              itemCount: relevant.length,
+              itemBuilder: (context, index) {
+                final cluster = relevant[index];
+                final clusterTags = cluster.sharedTags.map(_norm).toSet();
+                final matched =
+                    clusterTags.where(normPackTags.contains).length;
+                return ExpansionTile(
+                  title: Text(
+                      '${_tagSummary(cluster)} • $matched/${cluster.sharedTags.length}'),
+                  children: [
+                    for (final lesson in cluster.lessons.take(maxLessons))
+                      ListTile(
+                        dense: true,
+                        title: Text(lesson.title),
+                      ),
+                  ],
+                );
+              },
+            ),
           ],
         );
       },
     );
   }
 
-  String _tagSummary(TheoryLessonCluster cluster) {
-    final tags = cluster.sharedTags.take(3).toList();
+  String _norm(String s) => s.trim().toLowerCase();
+
+  String _tagSummary(TheoryLessonCluster c) {
+    final tags = c.sharedTags.take(3).toList();
     return tags.isEmpty ? 'Cluster' : tags.join(', ');
   }
 }


### PR DESCRIPTION
## Summary
- Add optional layout controls and max lesson cap
- Normalize tag comparison and filter clusters, with coverage in titles
- Handle loading and empty states with compact UI

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689504fefb58832a9f4a5b957e0893bf