### PR TITLE
feat: track skill tag coverage

### DIFF
--- a/lib/screens/autogen_metrics_dashboard_screen.dart
+++ b/lib/screens/autogen_metrics_dashboard_screen.dart
@@ -17,6 +17,7 @@ import '../widgets/autogen_debug_control_panel_widget.dart';
 import '../widgets/autogen_event_log_viewer_widget.dart';
 import '../widgets/run_comparison_window.dart';
 import '../widgets/autogen_error_inspector_widget.dart';
+import '../widgets/skill_tag_coverage_panel_widget.dart';
 
 /// Visual dashboard for autogen pack generation metrics.
 class AutogenMetricsDashboardScreen extends StatefulWidget {
@@ -176,6 +177,8 @@ class _AutogenMetricsDashboardScreenState
                 ),
                 const SizedBox(height: 16),
                 const AutogenErrorInspectorWidget(),
+                const SizedBox(height: 16),
+                const SkillTagCoveragePanelWidget(),
                 const SizedBox(height: 16),
                 _buildTile('Generated',
                     (_metrics['generatedCount'] as int? ?? 0).toString()),

--- a/lib/services/autogen_pipeline_executor.dart
+++ b/lib/services/autogen_pipeline_executor.dart
@@ -12,6 +12,7 @@ import 'auto_deduplication_engine.dart';
 import 'training_pack_auto_generator.dart';
 import 'yaml_pack_exporter.dart';
 import 'skill_tag_coverage_tracker.dart';
+import 'skill_tag_coverage_tracker_service.dart';
 import 'autogen_stats_dashboard_service.dart';
 import 'autogen_status_dashboard_service.dart';
 import 'inline_theory_link_auto_injector.dart';
@@ -30,6 +31,7 @@ class AutogenPipelineExecutor {
   final AutoDeduplicationEngine dedup;
   final YamlPackExporter exporter;
   final SkillTagCoverageTracker coverage;
+  final SkillTagCoverageTrackerService coverageService;
   final InlineTheoryLinkAutoInjector theoryInjector;
   final BoardTextureClassifier? boardClassifier;
   final SkillTreeAutoLinker skillLinker;
@@ -46,6 +48,7 @@ class AutogenPipelineExecutor {
     AutoDeduplicationEngine? dedup,
     YamlPackExporter? exporter,
     SkillTagCoverageTracker? coverage,
+    SkillTagCoverageTrackerService? coverageService,
     InlineTheoryLinkAutoInjector? theoryInjector,
     BoardTextureClassifier? boardClassifier,
     SkillTreeAutoLinker? skillLinker,
@@ -59,6 +62,7 @@ class AutogenPipelineExecutor {
   })  : dedup = dedup ?? AutoDeduplicationEngine(),
         exporter = exporter ?? const YamlPackExporter(),
         coverage = coverage ?? SkillTagCoverageTracker(),
+        coverageService = coverageService ?? SkillTagCoverageTrackerService(),
         theoryInjector = theoryInjector ?? InlineTheoryLinkAutoInjector(),
         boardClassifier = boardClassifier,
         skillLinker = skillLinker ?? const SkillTreeAutoLinker(),
@@ -192,6 +196,7 @@ class AutogenPipelineExecutor {
 
         coverage.analyzePack(model);
         dashboard.recordCoverage(coverage.aggregateReport);
+        await coverageService.logPack(model);
 
         final file = await exporter.export(pack);
         files.add(file);

--- a/lib/utils/shared_prefs_keys.dart
+++ b/lib/utils/shared_prefs_keys.dart
@@ -51,4 +51,5 @@ class SharedPrefsKeys {
 
   // Skill tag coverage report
   static const String skillTagCoverageReport = 'skill_tag_coverage_report';
+  static const String skillTagUsageCounts = 'skill_tag_usage_counts';
 }

--- a/lib/widgets/skill_tag_coverage_panel_widget.dart
+++ b/lib/widgets/skill_tag_coverage_panel_widget.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+
+import '../services/skill_tag_coverage_tracker_service.dart';
+
+/// Displays tags with the lowest coverage based on generation logs.
+class SkillTagCoveragePanelWidget extends StatefulWidget {
+  final Set<String> requiredTags;
+  const SkillTagCoveragePanelWidget({super.key, this.requiredTags = const {}});
+
+  @override
+  State<SkillTagCoveragePanelWidget> createState() =>
+      _SkillTagCoveragePanelWidgetState();
+}
+
+class _SkillTagCoveragePanelWidgetState
+    extends State<SkillTagCoveragePanelWidget> {
+  final SkillTagCoverageTrackerService _service =
+      SkillTagCoverageTrackerService();
+
+  late Future<Map<String, int>> _countsFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _countsFuture = _service.getTagUsageCount();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<Map<String, int>>(
+      future: _countsFuture,
+      builder: (context, snapshot) {
+        if (!snapshot.hasData) {
+          return const SizedBox(
+            height: 100,
+            child: Center(child: CircularProgressIndicator()),
+          );
+        }
+        final counts = snapshot.data!;
+        final allTags = {...widget.requiredTags, ...counts.keys};
+        final entries = [
+          for (final tag in allTags)
+            MapEntry(tag, counts[tag.trim().toLowerCase()] ?? 0)
+        ]
+          ..sort((a, b) => a.value.compareTo(b.value));
+        final top = entries.take(5).toList();
+        return Card(
+          child: Padding(
+            padding: const EdgeInsets.all(8),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text(
+                  'Skill Tag Coverage',
+                  style: TextStyle(fontWeight: FontWeight.bold),
+                ),
+                const SizedBox(height: 8),
+                if (top.isEmpty)
+                  const Text('No data')
+                else
+                  for (final e in top)
+                    Text('• ${e.key}: ${e.value}')
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+

--- a/test/services/skill_tag_coverage_tracker_service_test.dart
+++ b/test/services/skill_tag_coverage_tracker_service_test.dart
@@ -1,48 +1,34 @@
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:test/test.dart';
 import 'package:poker_analyzer/models/training_pack_model.dart';
 import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
 import 'package:poker_analyzer/services/skill_tag_coverage_tracker_service.dart';
-import 'package:poker_analyzer/services/training_pack_library_service.dart';
-
-class _FakeLibraryService extends TrainingPackLibraryService {
-  final List<TrainingPackModel> packs;
-  _FakeLibraryService(this.packs);
-
-  @override
-  Future<List<TrainingPackModel>> getAllPacks() async => packs;
-}
 
 void main() {
-  test('generateReport counts tags and finds underrepresented tags', () async {
-    final library = _FakeLibraryService([
-      TrainingPackModel(
-        id: 'p1',
-        title: 'P1',
-        spots: [
-          TrainingPackSpot(id: 's1', tags: ['a']),
-          TrainingPackSpot(id: 's2', tags: ['b', 'c']),
-        ],
-      ),
-      TrainingPackModel(
-        id: 'p2',
-        title: 'P2',
-        spots: [
-          TrainingPackSpot(id: 's3', tags: ['a']),
-        ],
-      ),
-    ]);
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
 
-    final service = SkillTagCoverageTrackerService(
-      library: library,
-      allSkillTags: {'a', 'b', 'c', 'd'},
-      underrepresentedThreshold: 2,
+  test('logPack updates counts and identifies uncovered tags', () async {
+    final service = SkillTagCoverageTrackerService();
+    final pack = TrainingPackModel(
+      id: 'p1',
+      title: 'P1',
+      spots: [
+        TrainingPackSpot(id: 's1', tags: ['a', 'b']),
+        TrainingPackSpot(id: 's2', tags: ['b']),
+      ],
     );
+    await service.logPack(pack);
 
-    final report = await service.generateReport();
-    expect(report.tagCounts['a'], 2);
-    expect(report.tagCounts['b'], 1);
-    expect(report.tagCounts['c'], 1);
-    expect(report.underrepresentedTags, containsAll(['b', 'c', 'd']));
-    expect(report.underrepresentedTags, isNot(contains('a')));
+    final counts = await service.getTagUsageCount();
+    expect(counts['a'], 1);
+    expect(counts['b'], 2);
+
+    final uncovered = await service.getUncoveredTags({'a', 'b', 'c'});
+    expect(uncovered, contains('c'));
+    expect(uncovered, isNot(contains('a')));
+    expect(uncovered, isNot(contains('b')));
   });
 }
+


### PR DESCRIPTION
## Summary
- add SkillTagCoverageTrackerService with SharedPreferences-backed analytics
- show low coverage skill tags in dashboard
- log skill tag usage during autogen pipeline

## Testing
- `dart test test/services/skill_tag_coverage_tracker_service_test.dart` *(fails: command not found)*
- `apt-get install dart -y` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_6894cdaaebe0832ab1cd3ba0256b7a7c