### PR TITLE
feat: add auto skill gap clusterer service

### DIFF
--- a/lib/services/auto_skill_gap_clusterer.dart
+++ b/lib/services/auto_skill_gap_clusterer.dart
@@ -1,0 +1,120 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Represents a cluster of related weak skill tags.
+class SkillGapCluster {
+  final String clusterName;
+  final List<String> tags;
+  final double avgAccuracy;
+  final int occurrenceCount;
+
+  const SkillGapCluster({
+    required this.clusterName,
+    required this.tags,
+    required this.avgAccuracy,
+    required this.occurrenceCount,
+  });
+
+  Map<String, dynamic> toJson() => {
+    'clusterName': clusterName,
+    'tags': tags,
+    'avgAccuracy': avgAccuracy,
+    'occurrenceCount': occurrenceCount,
+  };
+
+  factory SkillGapCluster.fromJson(Map<String, dynamic> json) =>
+      SkillGapCluster(
+        clusterName: json['clusterName'] as String? ?? '',
+        tags: (json['tags'] as List?)?.cast<String>() ?? const [],
+        avgAccuracy: (json['avgAccuracy'] as num?)?.toDouble() ?? 0,
+        occurrenceCount: (json['occurrenceCount'] as num?)?.toInt() ?? 0,
+      );
+}
+
+/// Historical performance data for a user.
+class UserSkillHistory {
+  final Map<String, double> tagAccuracy; // 0..1
+  final Map<String, int> tagOccurrences;
+  final Map<String, String> tagCategories;
+  final Map<String, double> decayWeights;
+
+  const UserSkillHistory({
+    required this.tagAccuracy,
+    required this.tagOccurrences,
+    required this.tagCategories,
+    this.decayWeights = const {},
+  });
+}
+
+/// Detects clusters of weak skills based on historical accuracy data.
+class AutoSkillGapClusterer {
+  AutoSkillGapClusterer({
+    this.weaknessThreshold = 0.7,
+    SharedPreferences? prefs,
+    this.storageKey = 'auto_skill_gap_clusters',
+  }) : _prefs = prefs,
+       clustersNotifier = ValueNotifier<List<SkillGapCluster>>([]);
+
+  final double weaknessThreshold;
+  final String storageKey;
+  final SharedPreferences? _prefs;
+
+  /// Notifies listeners with the latest detected clusters.
+  final ValueNotifier<List<SkillGapCluster>> clustersNotifier;
+
+  Future<List<SkillGapCluster>> detectWeakSkillClusters(
+    UserSkillHistory history,
+  ) async {
+    final data = <String, _ClusterData>{};
+
+    history.tagAccuracy.forEach((tag, acc) {
+      if (acc >= weaknessThreshold) return;
+      final count = history.tagOccurrences[tag] ?? 0;
+      if (count <= 0) return;
+      final category = history.tagCategories[tag] ?? 'misc';
+      final weight = history.decayWeights[tag] ?? 1.0;
+      final c = data.putIfAbsent(category, () => _ClusterData());
+      c.tags.add(tag);
+      c.totalAccuracy += acc * count;
+      c.totalCount += count;
+      c.weightedGap += (1 - acc) * count * weight;
+    });
+
+    final clusters = <SkillGapCluster>[];
+    data.forEach((name, d) {
+      if (d.totalCount == 0) return;
+      final avg = d.totalAccuracy / d.totalCount;
+      clusters.add(
+        SkillGapCluster(
+          clusterName: name,
+          tags: d.tags.toList(),
+          avgAccuracy: avg,
+          occurrenceCount: d.totalCount,
+        ),
+      );
+    });
+
+    clusters.sort((a, b) {
+      final sevA = (1 - a.avgAccuracy) * a.occurrenceCount;
+      final sevB = (1 - b.avgAccuracy) * b.occurrenceCount;
+      return sevB.compareTo(sevA);
+    });
+
+    clustersNotifier.value = clusters;
+    final prefs = _prefs ?? await SharedPreferences.getInstance();
+    await prefs.setString(
+      storageKey,
+      jsonEncode(clusters.map((c) => c.toJson()).toList()),
+    );
+    return clusters;
+  }
+}
+
+class _ClusterData {
+  double totalAccuracy = 0;
+  int totalCount = 0;
+  double weightedGap = 0;
+  final Set<String> tags = <String>{};
+}

--- a/test/services/auto_skill_gap_clusterer_test.dart
+++ b/test/services/auto_skill_gap_clusterer_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/auto_skill_gap_clusterer.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('detects weak skill clusters and sorts by severity', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final clusterer = AutoSkillGapClusterer(prefs: prefs);
+    const history = UserSkillHistory(
+      tagAccuracy: {
+        'pushfold_sb': 0.5,
+        'pushfold_bb': 0.6,
+        'icm_shove': 0.65,
+        'postflop_jam': 0.8,
+      },
+      tagOccurrences: {
+        'pushfold_sb': 10,
+        'pushfold_bb': 5,
+        'icm_shove': 8,
+        'postflop_jam': 10,
+      },
+      tagCategories: {
+        'pushfold_sb': 'push-fold',
+        'pushfold_bb': 'push-fold',
+        'icm_shove': 'ICM',
+        'postflop_jam': 'postflop-jam',
+      },
+    );
+
+    final clusters = await clusterer.detectWeakSkillClusters(history);
+    expect(clusters.length, 2);
+    expect(clusters.first.clusterName, 'push-fold');
+    expect(clusters.first.tags, containsAll(['pushfold_sb', 'pushfold_bb']));
+    expect(clusterer.clustersNotifier.value, clusters);
+  });
+}


### PR DESCRIPTION
## Summary
- add `SkillGapCluster` and `UserSkillHistory` models
- implement `AutoSkillGapClusterer` to detect and store weak skill clusters
- test clustering logic

## Testing
- `flutter test test/services/auto_skill_gap_clusterer_test.dart` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_68951490af14832ab6bf10465ba84ec5