### PR TITLE
feat: add training run AB comparator

### DIFF
--- a/lib/models/training_run_record.dart
+++ b/lib/models/training_run_record.dart
@@ -1,0 +1,76 @@
+import 'dart:convert';
+
+class FormatMeta {
+  final int spotsPerPack;
+  final int streets;
+  final double theoryRatio;
+
+  const FormatMeta({
+    required this.spotsPerPack,
+    required this.streets,
+    required this.theoryRatio,
+  });
+
+  factory FormatMeta.fromJson(Map<String, dynamic> j) => FormatMeta(
+        spotsPerPack: j['spotsPerPack'] as int? ?? 0,
+        streets: j['streets'] as int? ?? 1,
+        theoryRatio: (j['theoryRatio'] as num?)?.toDouble() ?? 0,
+      );
+
+  Map<String, dynamic> toJson() => {
+        'spotsPerPack': spotsPerPack,
+        'streets': streets,
+        'theoryRatio': theoryRatio,
+      };
+}
+
+class TrainingRunRecord {
+  final String armId;
+  final String packId;
+  final double accuracy;
+  final double dropoffRate;
+  final double timeToComplete;
+  final double novelty;
+  final double retryRate;
+  final String? audience;
+  final FormatMeta format;
+
+  TrainingRunRecord({
+    required this.armId,
+    required this.packId,
+    required this.accuracy,
+    required this.dropoffRate,
+    required this.timeToComplete,
+    required this.novelty,
+    required this.retryRate,
+    this.audience,
+    required this.format,
+  });
+
+  factory TrainingRunRecord.fromJson(Map<String, dynamic> j) => TrainingRunRecord(
+        armId: j['armId'] as String? ?? '',
+        packId: j['packId'] as String? ?? '',
+        accuracy: (j['accuracy'] as num?)?.toDouble() ?? 0,
+        dropoffRate: (j['dropoffRate'] as num?)?.toDouble() ?? 0,
+        timeToComplete: (j['timeToComplete'] as num?)?.toDouble() ?? 0,
+        novelty: (j['novelty'] as num?)?.toDouble() ?? 0,
+        retryRate: (j['retryRate'] as num?)?.toDouble() ?? 0,
+        audience: j['audience'] as String?,
+        format: FormatMeta.fromJson(j['format'] as Map<String, dynamic>? ?? const {}),
+      );
+
+  Map<String, dynamic> toJson() => {
+        'armId': armId,
+        'packId': packId,
+        'accuracy': accuracy,
+        'dropoffRate': dropoffRate,
+        'timeToComplete': timeToComplete,
+        'novelty': novelty,
+        'retryRate': retryRate,
+        if (audience != null) 'audience': audience,
+        'format': format.toJson(),
+      };
+
+  @override
+  String toString() => jsonEncode(toJson());
+}

--- a/lib/screens/autogen_metrics_dashboard_screen.dart
+++ b/lib/screens/autogen_metrics_dashboard_screen.dart
@@ -17,6 +17,7 @@ import '../widgets/autogen_debug_control_panel_widget.dart';
 import '../widgets/autogen_event_log_viewer_widget.dart';
 import '../widgets/run_comparison_window.dart';
 import '../widgets/autogen_error_inspector_widget.dart';
+import '../widgets/ab_results_panel_widget.dart';
 
 /// Visual dashboard for autogen pack generation metrics.
 class AutogenMetricsDashboardScreen extends StatefulWidget {
@@ -176,6 +177,8 @@ class _AutogenMetricsDashboardScreenState
                 ),
                 const SizedBox(height: 16),
                 const AutogenErrorInspectorWidget(),
+                const SizedBox(height: 16),
+                const ABResultsPanelWidget(),
                 const SizedBox(height: 16),
                 _buildTile('Generated',
                     (_metrics['generatedCount'] as int? ?? 0).toString()),

--- a/lib/services/autogen_status_dashboard_service.dart
+++ b/lib/services/autogen_status_dashboard_service.dart
@@ -4,6 +4,8 @@ import 'package:flutter/foundation.dart';
 
 import '../models/autogen_status.dart';
 import '../models/autogen_session_meta.dart';
+import '../models/training_run_record.dart';
+import 'training_run_ab_comparator.dart';
 
 class DuplicatePackInfo {
   final String candidateId;
@@ -41,6 +43,10 @@ class AutogenStatusDashboardService {
       ValueNotifier(const {});
   final ValueNotifier<List<String>> boosterIdsNotifier =
       ValueNotifier(const <String>[]);
+
+  final ValueNotifier<List<ABArmResult>> abResultsNotifier =
+      ValueNotifier(const <ABArmResult>[]);
+  final TrainingRunABComparator _abComparator = TrainingRunABComparator();
 
   final List<AutogenSessionMeta> _sessions = [];
   final StreamController<List<AutogenSessionMeta>> _sessionController =
@@ -112,6 +118,12 @@ class AutogenStatusDashboardService {
     final map = Map<String, int>.from(boostersSkippedNotifier.value);
     map[reason] = (map[reason] ?? 0) + 1;
     boostersSkippedNotifier.value = Map.unmodifiable(map);
+  }
+
+  Future<void> refreshAbResults(List<TrainingRunRecord> runs,
+      {String? audience}) async {
+    final results = await _abComparator.compare(runs, audience: audience);
+    abResultsNotifier.value = List.unmodifiable(results);
   }
 
   void _cleanupOldSessions() {

--- a/lib/services/training_run_ab_comparator.dart
+++ b/lib/services/training_run_ab_comparator.dart
@@ -1,0 +1,253 @@
+import 'dart:convert';
+import 'dart:math';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/training_run_record.dart';
+
+class ABArmResult {
+  final String armId;
+  final int n;
+  final double accuracy;
+  final double dropoffRate;
+  final double timeToComplete;
+  final double novelty;
+  final double compositeScore;
+  final double confidence;
+
+  const ABArmResult({
+    required this.armId,
+    required this.n,
+    required this.accuracy,
+    required this.dropoffRate,
+    required this.timeToComplete,
+    required this.novelty,
+    required this.compositeScore,
+    required this.confidence,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'armId': armId,
+        'n': n,
+        'accuracy': accuracy,
+        'dropoffRate': dropoffRate,
+        'timeToComplete': timeToComplete,
+        'novelty': novelty,
+        'compositeScore': compositeScore,
+        'confidence': confidence,
+      };
+}
+
+class TrainingRunABComparator {
+  static const _armsKey = 'ab.experiment_arms';
+  static const _reportKey = 'ab.last_report';
+  static const _recommendedKey = 'ab.recommended_format';
+  static const _weightsKey = 'ab.metric_weights';
+  static const _controlKey = 'ab.control_arm';
+
+  Future<List<ABArmResult>> compare(List<TrainingRunRecord> runs,
+      {String? audience}) async {
+    if (runs.isEmpty) return [];
+    final prefs = await SharedPreferences.getInstance();
+    final armsConfig = await _loadArms(prefs);
+    final filtered = audience == null
+        ? runs
+        : runs.where((r) => r.audience == audience).toList();
+    if (filtered.isEmpty) return [];
+
+    final grouped = <String, List<TrainingRunRecord>>{};
+    for (final r in filtered) {
+      grouped.putIfAbsent(r.armId, () => []).add(r);
+    }
+
+    final stats = <String, _ArmStats>{};
+    for (final e in grouped.entries) {
+      stats[e.key] = _computeStats(e.value);
+    }
+
+    final means = _MetricAverages.from(stats.values);
+    final stds = _MetricStd.from(stats.values, means);
+    final weights = _loadWeights(prefs);
+
+    final results = <ABArmResult>[];
+    for (final entry in stats.entries) {
+      final id = entry.key;
+      final s = entry.value;
+      final accZ = _zScore(s.accuracy, means.accuracy, stds.accuracy);
+      final dropZ = -_zScore(s.dropoff, means.dropoff, stds.dropoff);
+      final timeZ = -_zScore(s.time, means.time, stds.time);
+      final noveltyZ = _zScore(s.novelty, means.novelty, stds.novelty);
+      final composite =
+          weights['accuracy']! * accZ +
+          weights['dropoff']! * dropZ +
+          weights['time']! * timeZ +
+          weights['novelty']! * noveltyZ;
+      final confidence = s.n / (s.n + 10);
+      results.add(ABArmResult(
+        armId: id,
+        n: s.n,
+        accuracy: s.accuracy,
+        dropoffRate: s.dropoff,
+        timeToComplete: s.time,
+        novelty: s.novelty,
+        compositeScore: composite,
+        confidence: confidence,
+      ));
+    }
+    results.sort((a, b) => b.compositeScore.compareTo(a.compositeScore));
+
+    await prefs.setString(_reportKey, jsonEncode(results.map((e) => e.toJson()).toList()));
+    if (results.isNotEmpty) {
+      final best = results.first;
+      final arm = armsConfig.firstWhere((a) => a['id'] == best.armId,
+          orElse: () => null);
+      if (arm != null) {
+        await prefs.setString(
+            _recommendedKey, jsonEncode(arm['format'] ?? {}));
+      }
+    }
+    return results;
+  }
+
+  Future<ABArmResult?> best(List<TrainingRunRecord> runs,
+      {String? audience}) async {
+    final results = await compare(runs, audience: audience);
+    return results.isEmpty ? null : results.first;
+  }
+
+  Future<List<Map<String, dynamic>>> _loadArms(SharedPreferences prefs) async {
+    final raw = prefs.getString(_armsKey);
+    if (raw == null || raw.isEmpty) return const [];
+    try {
+      final data = jsonDecode(raw);
+      if (data is List) {
+        return data.whereType<Map<String, dynamic>>().toList();
+      }
+    } catch (_) {}
+    return const [];
+  }
+
+  Map<String, double> _loadWeights(SharedPreferences prefs) {
+    const def = {'accuracy': 0.4, 'dropoff': 0.25, 'time': 0.2, 'novelty': 0.15};
+    final raw = prefs.getString(_weightsKey);
+    if (raw == null) return def;
+    try {
+      final data = jsonDecode(raw);
+      if (data is Map) {
+        return {
+          'accuracy': (data['accuracy'] as num?)?.toDouble() ?? def['accuracy']!,
+          'dropoff': (data['dropoff'] as num?)?.toDouble() ?? def['dropoff']!,
+          'time': (data['time'] as num?)?.toDouble() ?? def['time']!,
+          'novelty': (data['novelty'] as num?)?.toDouble() ?? def['novelty']!,
+        };
+      }
+    } catch (_) {}
+    return def;
+  }
+
+  Future<void> saveWeights(Map<String, double> w) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_weightsKey, jsonEncode(w));
+  }
+
+  Future<Map<String, double>> getWeights() async {
+    final prefs = await SharedPreferences.getInstance();
+    return _loadWeights(prefs);
+  }
+
+  Future<void> saveControlArm(String id) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_controlKey, id);
+  }
+
+  Future<String?> getControlArm() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString(_controlKey);
+  }
+
+  double _zScore(double value, double mean, double std) {
+    if (std == 0) return 0;
+    return (value - mean) / std;
+  }
+}
+
+class _ArmStats {
+  final int n;
+  final double accuracy;
+  final double dropoff;
+  final double time;
+  final double novelty;
+
+  _ArmStats({
+    required this.n,
+    required this.accuracy,
+    required this.dropoff,
+    required this.time,
+    required this.novelty,
+  });
+}
+
+_ArmStats _computeStats(List<TrainingRunRecord> list) {
+  final n = list.length;
+  double avg(List<double> xs) =>
+      xs.isEmpty ? 0 : xs.reduce((a, b) => a + b) / xs.length;
+  return _ArmStats(
+    n: n,
+    accuracy: avg(list.map((e) => e.accuracy).toList()),
+    dropoff: avg(list.map((e) => e.dropoffRate).toList()),
+    time: avg(list.map((e) => e.timeToComplete).toList()),
+    novelty: avg(list.map((e) => e.novelty).toList()),
+  );
+}
+
+class _MetricAverages {
+  final double accuracy;
+  final double dropoff;
+  final double time;
+  final double novelty;
+
+  _MetricAverages(
+      {required this.accuracy,
+      required this.dropoff,
+      required this.time,
+      required this.novelty});
+
+  factory _MetricAverages.from(Iterable<_ArmStats> stats) {
+    double avg(Iterable<double> xs) =>
+        xs.isEmpty ? 0 : xs.reduce((a, b) => a + b) / xs.length;
+    return _MetricAverages(
+      accuracy: avg(stats.map((e) => e.accuracy)),
+      dropoff: avg(stats.map((e) => e.dropoff)),
+      time: avg(stats.map((e) => e.time)),
+      novelty: avg(stats.map((e) => e.novelty)),
+    );
+  }
+}
+
+class _MetricStd {
+  final double accuracy;
+  final double dropoff;
+  final double time;
+  final double novelty;
+
+  _MetricStd(
+      {required this.accuracy,
+      required this.dropoff,
+      required this.time,
+      required this.novelty});
+
+  factory _MetricStd.from(Iterable<_ArmStats> stats, _MetricAverages means) {
+    double variance(Iterable<double> xs, double mean) {
+      if (xs.isEmpty) return 0;
+      final v = xs.map((e) => pow(e - mean, 2)).reduce((a, b) => a + b) / xs.length;
+      return sqrt(v);
+    }
+
+    return _MetricStd(
+      accuracy: variance(stats.map((e) => e.accuracy), means.accuracy),
+      dropoff: variance(stats.map((e) => e.dropoff), means.dropoff),
+      time: variance(stats.map((e) => e.time), means.time),
+      novelty: variance(stats.map((e) => e.novelty), means.novelty),
+    );
+  }
+}

--- a/lib/widgets/ab_results_panel_widget.dart
+++ b/lib/widgets/ab_results_panel_widget.dart
@@ -1,0 +1,173 @@
+import 'package:flutter/material.dart';
+
+import '../services/autogen_status_dashboard_service.dart';
+import '../services/training_run_ab_comparator.dart';
+
+class ABResultsPanelWidget extends StatefulWidget {
+  const ABResultsPanelWidget({super.key});
+
+  @override
+  State<ABResultsPanelWidget> createState() => _ABResultsPanelWidgetState();
+}
+
+class _ABResultsPanelWidgetState extends State<ABResultsPanelWidget> {
+  int? _sortColumnIndex;
+  bool _sortAscending = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final service = AutogenStatusDashboardService.instance;
+    return ValueListenableBuilder<List<ABArmResult>>(
+      valueListenable: service.abResultsNotifier,
+      builder: (context, results, _) {
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Text('Recommended: '
+                    '${results.isNotEmpty ? results.first.armId : '-'}',
+                    style: Theme.of(context).textTheme.titleMedium),
+                const Spacer(),
+                IconButton(
+                    onPressed: _showSettings,
+                    icon: const Icon(Icons.settings)),
+              ],
+            ),
+            SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              child: DataTable(
+                sortColumnIndex: _sortColumnIndex,
+                sortAscending: _sortAscending,
+                columns: [
+                  _buildColumn('Arm', 0, (r) => r.armId),
+                  _buildColumn('N', 1, (r) => r.n),
+                  _buildColumn('Accuracy', 2, (r) => r.accuracy),
+                  _buildColumn('Dropoff', 3, (r) => r.dropoffRate),
+                  _buildColumn('Time', 4, (r) => r.timeToComplete),
+                  _buildColumn('Novelty', 5, (r) => r.novelty),
+                  _buildColumn('Score', 6, (r) => r.compositeScore),
+                  _buildColumn('Confidence', 7, (r) => r.confidence),
+                ],
+                rows: [
+                  for (final r in results)
+                    DataRow(cells: [
+                      DataCell(Text(r.armId)),
+                      DataCell(Text(r.n.toString())),
+                      DataCell(Text(r.accuracy.toStringAsFixed(2))),
+                      DataCell(Text(r.dropoffRate.toStringAsFixed(2))),
+                      DataCell(Text(r.timeToComplete.toStringAsFixed(2))),
+                      DataCell(Text(r.novelty.toStringAsFixed(2))),
+                      DataCell(Text(r.compositeScore.toStringAsFixed(2))),
+                      DataCell(Text(r.confidence.toStringAsFixed(2))),
+                    ])
+                ],
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  DataColumn _buildColumn(String label, int idx,
+      Comparable Function(ABArmResult r) selector) {
+    final service = AutogenStatusDashboardService.instance;
+    return DataColumn(
+      label: Text(label),
+      onSort: (i, asc) {
+        setState(() {
+          _sortColumnIndex = i;
+          _sortAscending = asc;
+        });
+        final list = [...service.abResultsNotifier.value];
+        list.sort((a, b) {
+          final r = Comparable.compare(selector(a), selector(b));
+          return asc ? r : -r;
+        });
+        service.abResultsNotifier.value = list;
+      },
+    );
+  }
+
+  Future<void> _showSettings() async {
+    final comparator = TrainingRunABComparator();
+    final weights = await comparator.getWeights();
+    final control = await comparator.getControlArm() ?? '';
+    final accCtrl =
+        TextEditingController(text: weights['accuracy']!.toStringAsFixed(2));
+    final dropCtrl =
+        TextEditingController(text: weights['dropoff']!.toStringAsFixed(2));
+    final timeCtrl =
+        TextEditingController(text: weights['time']!.toStringAsFixed(2));
+    final novCtrl =
+        TextEditingController(text: weights['novelty']!.toStringAsFixed(2));
+    final controlCtrl = TextEditingController(text: control);
+
+    await showDialog(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('A/B Settings'),
+        content: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              TextField(
+                controller: controlCtrl,
+                decoration:
+                    const InputDecoration(labelText: 'Control Arm ID'),
+              ),
+              TextField(
+                controller: accCtrl,
+                keyboardType:
+                    const TextInputType.numberWithOptions(decimal: true),
+                decoration:
+                    const InputDecoration(labelText: 'Accuracy Weight'),
+              ),
+              TextField(
+                controller: dropCtrl,
+                keyboardType:
+                    const TextInputType.numberWithOptions(decimal: true),
+                decoration:
+                    const InputDecoration(labelText: 'Dropoff Weight'),
+              ),
+              TextField(
+                controller: timeCtrl,
+                keyboardType:
+                    const TextInputType.numberWithOptions(decimal: true),
+                decoration:
+                    const InputDecoration(labelText: 'Time Weight'),
+              ),
+              TextField(
+                controller: novCtrl,
+                keyboardType:
+                    const TextInputType.numberWithOptions(decimal: true),
+                decoration:
+                    const InputDecoration(labelText: 'Novelty Weight'),
+              ),
+            ],
+          ),
+        ),
+        actions: [
+          TextButton(
+              onPressed: () => Navigator.pop(ctx), child: const Text('Cancel')),
+          TextButton(
+            onPressed: () async {
+              final w = {
+                'accuracy': double.tryParse(accCtrl.text) ?? 0.4,
+                'dropoff': double.tryParse(dropCtrl.text) ?? 0.25,
+                'time': double.tryParse(timeCtrl.text) ?? 0.2,
+                'novelty': double.tryParse(novCtrl.text) ?? 0.15,
+              };
+              await comparator.saveWeights(w);
+              await comparator.saveControlArm(controlCtrl.text);
+              if (mounted) setState(() {});
+              Navigator.pop(ctx);
+            },
+            child: const Text('Save'),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `TrainingRunRecord` model and `TrainingRunABComparator` service with scoring and persistence
- expose A/B results through `AutogenStatusDashboardService`
- add `ABResultsPanelWidget` to display and configure experiment arms on the dashboard

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689519efa4cc832a90a7b57215fa53bb