### PR TITLE
Add theory gap detector and dashboard panel

### DIFF
--- a/lib/models/theory_gap.dart
+++ b/lib/models/theory_gap.dart
@@ -1,0 +1,32 @@
+class TheoryGap {
+  final String topic;
+  final int coverageCount;
+  final int targetCoverage;
+  final List<String> candidatePacks;
+  final double priorityScore;
+
+  const TheoryGap({
+    required this.topic,
+    required this.coverageCount,
+    required this.targetCoverage,
+    required this.candidatePacks,
+    required this.priorityScore,
+  });
+
+  Map<String, dynamic> toJson() => {
+    'topic': topic,
+    'coverageCount': coverageCount,
+    'targetCoverage': targetCoverage,
+    'candidatePacks': candidatePacks,
+    'priorityScore': priorityScore,
+  };
+
+  factory TheoryGap.fromJson(Map<String, dynamic> json) => TheoryGap(
+    topic: json['topic'] as String? ?? '',
+    coverageCount: json['coverageCount'] as int? ?? 0,
+    targetCoverage: json['targetCoverage'] as int? ?? 0,
+    candidatePacks:
+        (json['candidatePacks'] as List?)?.cast<String>() ?? const [],
+    priorityScore: (json['priorityScore'] as num?)?.toDouble() ?? 0,
+  );
+}

--- a/lib/screens/autogen_debug_screen.dart
+++ b/lib/screens/autogen_debug_screen.dart
@@ -21,13 +21,17 @@ import '../widgets/autogen_pipeline_debug_control_panel.dart';
 import '../widgets/autogen_duplicate_table_widget.dart';
 import 'pack_fingerprint_comparer_report_ui.dart';
 import '../widgets/deduplication_policy_editor.dart';
+import '../widgets/theory_coverage_panel_widget.dart';
 
 class _DirExporter extends TrainingPackExporterV2 {
   final String outDir;
   const _DirExporter(this.outDir);
 
   @override
-  Future<File> exportToFile(TrainingPackTemplateV2 pack, {String? fileName}) async {
+  Future<File> exportToFile(
+    TrainingPackTemplateV2 pack, {
+    String? fileName,
+  }) async {
     final dir = Directory(outDir);
     await dir.create(recursive: true);
     final safeName = (fileName ?? pack.name)
@@ -54,8 +58,9 @@ class _AutogenDebugScreenState extends State<AutogenDebugScreen> {
   TrainingPackAutoGenerator? _generator;
   List<TrainingPackTemplateSet> _templateSets = const [];
   TrainingPackTemplateSet? _selectedSet;
-  final TextEditingController _outputDirController =
-      TextEditingController(text: 'packs/generated');
+  final TextEditingController _outputDirController = TextEditingController(
+    text: 'packs/generated',
+  );
   String? _sessionId;
 
   @override
@@ -64,8 +69,7 @@ class _AutogenDebugScreenState extends State<AutogenDebugScreen> {
     TrainingPackTemplateSetLibraryService.instance.loadAll().then((_) {
       if (mounted) {
         setState(() {
-          _templateSets =
-              TrainingPackTemplateSetLibraryService.instance.all;
+          _templateSets = TrainingPackTemplateSetLibraryService.instance.all;
           if (_templateSets.isNotEmpty) {
             _selectedSet = _templateSets.first;
           }
@@ -122,8 +126,7 @@ class _AutogenDebugScreenState extends State<AutogenDebugScreen> {
     }
     final id = _sessionId;
     if (id != null) {
-      AutogenStatusDashboardService.instance
-          .updateSessionStatus(id, 'stopped');
+      AutogenStatusDashboardService.instance.updateSessionStatus(id, 'stopped');
     }
   }
 
@@ -153,17 +156,15 @@ class _AutogenDebugScreenState extends State<AutogenDebugScreen> {
                   hint: const Text('Select Template Set'),
                   items: [
                     for (final s in _templateSets)
-                      DropdownMenuItem(
-                        value: s,
-                        child: Text(s.baseSpot.id),
-                      ),
+                      DropdownMenuItem(value: s, child: Text(s.baseSpot.id)),
                   ],
                   onChanged: (v) => setState(() => _selectedSet = v),
                 ),
                 TextField(
                   controller: _outputDirController,
-                  decoration:
-                      const InputDecoration(labelText: 'Output Directory'),
+                  decoration: const InputDecoration(
+                    labelText: 'Output Directory',
+                  ),
                 ),
               ],
             ),
@@ -175,13 +176,15 @@ class _AutogenDebugScreenState extends State<AutogenDebugScreen> {
               mainAxisAlignment: MainAxisAlignment.spaceEvenly,
               children: [
                 ElevatedButton(
-                  onPressed:
-                      _status == _AutogenStatus.running ? null : _startAutogen,
+                  onPressed: _status == _AutogenStatus.running
+                      ? null
+                      : _startAutogen,
                   child: const Text('Start Autogen'),
                 ),
                 OutlinedButton(
-                  onPressed:
-                      _status == _AutogenStatus.running ? _stopAutogen : null,
+                  onPressed: _status == _AutogenStatus.running
+                      ? _stopAutogen
+                      : null,
                   child: const Text('Stop'),
                 ),
                 ElevatedButton(
@@ -215,8 +218,10 @@ class _AutogenDebugScreenState extends State<AutogenDebugScreen> {
                           'Status: ${_status.name}',
                           style: TextStyle(color: color),
                         ),
-                        Text('Template: '
-                            '${_selectedSet?.baseSpot.id ?? 'none'}'),
+                        Text(
+                          'Template: '
+                          '${_selectedSet?.baseSpot.id ?? 'none'}',
+                        ),
                         Text('Output: ${_outputDirController.text}'),
                       ],
                     );
@@ -226,15 +231,10 @@ class _AutogenDebugScreenState extends State<AutogenDebugScreen> {
             ),
           ),
           Expanded(child: Container()),
-          SizedBox(
-            height: 200,
-            child: AutogenHistoryChartWidget(),
-          ),
+          SizedBox(height: 200, child: AutogenHistoryChartWidget()),
           const AutogenRealtimeStatsPanel(),
-          SizedBox(
-            height: 200,
-            child: AutogenDuplicateTableWidget(),
-          ),
+          SizedBox(height: 200, child: TheoryCoveragePanelWidget()),
+          SizedBox(height: 200, child: AutogenDuplicateTableWidget()),
           SizedBox(
             height: 200,
             child: _sessionId == null
@@ -246,4 +246,3 @@ class _AutogenDebugScreenState extends State<AutogenDebugScreen> {
     );
   }
 }
-

--- a/lib/services/theory_gap_detector.dart
+++ b/lib/services/theory_gap_detector.dart
@@ -1,0 +1,113 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+
+import '../models/theory_gap.dart';
+import 'skill_tag_coverage_tracker.dart';
+import 'preferences_service.dart';
+
+/// Detects missing or under-covered theory topics across the library.
+class TheoryGapDetector {
+  final Map<String, List<String>> clusters;
+  final SkillTagCoverageTracker coverageTracker;
+  final Map<String, List<String>> theoryIndex;
+  final Map<String, bool> linkStatus;
+  final Map<String, DateTime> topicUpdated;
+  final int targetCoveragePerTopic;
+  final int minTheoryLinksPerPack;
+  final int freshnessWindowDays;
+
+  final ValueNotifier<List<TheoryGap>> gapsNotifier =
+      ValueNotifier<List<TheoryGap>>(<TheoryGap>[]);
+
+  TheoryGapDetector({
+    Map<String, List<String>>? clusters,
+    SkillTagCoverageTracker? coverageTracker,
+    Map<String, List<String>>? theoryIndex,
+    Map<String, bool>? linkStatus,
+    Map<String, DateTime>? topicUpdated,
+    this.targetCoveragePerTopic = 5,
+    this.minTheoryLinksPerPack = 1,
+    this.freshnessWindowDays = 30,
+  }) : clusters = clusters ?? const <String, List<String>>{},
+       coverageTracker = coverageTracker ?? SkillTagCoverageTracker(),
+       theoryIndex = theoryIndex ?? const <String, List<String>>{},
+       linkStatus = linkStatus ?? const <String, bool>{},
+       topicUpdated = topicUpdated ?? const <String, DateTime>{};
+
+  /// Scans all topics and updates [gapsNotifier] with detected gaps.
+  Future<List<TheoryGap>> detectGaps() async {
+    final topics = <String>{}
+      ..addAll(clusters.keys)
+      ..addAll(theoryIndex.keys)
+      ..addAll(coverageTracker.skillTagCounts.keys);
+    final now = DateTime.now();
+    final gaps = <TheoryGap>[];
+    for (final topic in topics) {
+      final coverage = coverageTracker.skillTagCounts[topic] ?? 0;
+      final candidates = <String>[
+        for (final p in clusters[topic] ?? const <String>[])
+          if (!(linkStatus[p] ?? false)) p,
+      ];
+      final target = targetCoveragePerTopic;
+      final severity = (target - coverage).clamp(0, target);
+      final hasTheory = (theoryIndex[topic] ?? const []).isNotEmpty;
+      final needsGap =
+          severity > 0 ||
+          !hasTheory ||
+          candidates.length < minTheoryLinksPerPack;
+      if (!needsGap) continue;
+      final updated = topicUpdated[topic];
+      var freshnessBoost = 1.0;
+      if (updated != null) {
+        final age = now.difference(updated).inDays;
+        if (age > freshnessWindowDays) freshnessBoost = 1.5;
+      }
+      final base = severity > 0
+          ? severity.toDouble()
+          : candidates.length.toDouble();
+      final priority = base * freshnessBoost;
+      gaps.add(
+        TheoryGap(
+          topic: topic,
+          coverageCount: coverage,
+          targetCoverage: target,
+          candidatePacks: candidates,
+          priorityScore: priority,
+        ),
+      );
+    }
+    gaps.sort((a, b) => b.priorityScore.compareTo(a.priorityScore));
+    gapsNotifier.value = gaps;
+    await _saveToPrefs(gaps);
+    return gaps;
+  }
+
+  Future<void> _saveToPrefs(List<TheoryGap> gaps) async {
+    final prefs = await PreferencesService.getInstance();
+    final data = jsonEncode(gaps.map((g) => g.toJson()).toList());
+    await prefs.setString(SharedPrefsKeys.theoryGapReport, data);
+  }
+
+  /// Loads previously detected gaps from [SharedPreferences].
+  Future<List<TheoryGap>> loadFromPrefs() async {
+    final prefs = await PreferencesService.getInstance();
+    final data = prefs.getString(SharedPrefsKeys.theoryGapReport);
+    if (data == null) return <TheoryGap>[];
+    final list = (jsonDecode(data) as List)
+        .map((e) => TheoryGap.fromJson(Map<String, dynamic>.from(e)))
+        .toList();
+    return list;
+  }
+
+  /// Exports a remediation plan for automatic theory link injection.
+  Map<String, List<String>> exportRemediationPlan() {
+    final plan = <String, List<String>>{};
+    for (final g in gapsNotifier.value) {
+      if (g.candidatePacks.isNotEmpty) {
+        plan[g.topic] = List<String>.from(g.candidatePacks);
+      }
+    }
+    return plan;
+  }
+}

--- a/lib/utils/shared_prefs_keys.dart
+++ b/lib/utils/shared_prefs_keys.dart
@@ -9,15 +9,11 @@ class SharedPrefsKeys {
 
   static String boosterInboxLast(String tag) =>
       _boosterTagKey('inbox_last', tag);
-  static final String boosterInboxTotalDate =
-      _boosterKey('inbox_total_date');
-  static final String boosterInboxTotalCount =
-      _boosterKey('inbox_total_count');
-  static final String boosterExclusionLog =
-      _boosterKey('exclusion_log');
+  static final String boosterInboxTotalDate = _boosterKey('inbox_total_date');
+  static final String boosterInboxTotalCount = _boosterKey('inbox_total_count');
+  static final String boosterExclusionLog = _boosterKey('exclusion_log');
 
-  static String boosterOpened(String tag) =>
-      _boosterTagKey('opened', tag);
+  static String boosterOpened(String tag) => _boosterTagKey('opened', tag);
 
   static String boosterDismissed(String tag) =>
       _boosterTagKey('dismissed', tag);
@@ -42,8 +38,7 @@ class SharedPrefsKeys {
   static const String trainingPresetRatingSort = 'training_preset_rating_sort';
   static const String trainingSimpleSortField = 'training_simple_sort_field';
   static const String trainingSimpleSortOrder = 'training_simple_sort_order';
-  static const String trainingCustomTagPresets =
-      'training_custom_tag_presets';
+  static const String trainingCustomTagPresets = 'training_custom_tag_presets';
   static const String trainingQuickPreset = 'training_quick_preset';
   static const String trainingSearchHistory = 'training_search_history';
   static const String trainingSpotListSort = 'training_spot_list_sort';
@@ -51,4 +46,7 @@ class SharedPrefsKeys {
 
   // Skill tag coverage report
   static const String skillTagCoverageReport = 'skill_tag_coverage_report';
+
+  // Theory gap detector
+  static const String theoryGapReport = 'theory_gap_report';
 }

--- a/lib/widgets/theory_coverage_panel_widget.dart
+++ b/lib/widgets/theory_coverage_panel_widget.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+
+import '../models/theory_gap.dart';
+import '../services/theory_gap_detector.dart';
+
+/// Dashboard panel displaying theory coverage gaps.
+class TheoryCoveragePanelWidget extends StatefulWidget {
+  const TheoryCoveragePanelWidget({super.key, TheoryGapDetector? detector})
+    : detector = detector ?? TheoryGapDetector();
+
+  final TheoryGapDetector detector;
+
+  @override
+  State<TheoryCoveragePanelWidget> createState() =>
+      _TheoryCoveragePanelWidgetState();
+}
+
+class _TheoryCoveragePanelWidgetState extends State<TheoryCoveragePanelWidget> {
+  @override
+  void initState() {
+    super.initState();
+    widget.detector.detectGaps();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<List<TheoryGap>>(
+      valueListenable: widget.detector.gapsNotifier,
+      builder: (context, gaps, _) {
+        if (gaps.isEmpty) {
+          return const Center(child: Text('No theory gaps'));
+        }
+        return SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          child: DataTable(
+            columns: const [
+              DataColumn(label: Text('Topic')),
+              DataColumn(label: Text('Coverage'), numeric: true),
+              DataColumn(label: Text('Target'), numeric: true),
+              DataColumn(label: Text('Candidates')),
+              DataColumn(label: Text('Priority'), numeric: true),
+            ],
+            rows: [
+              for (final g in gaps)
+                DataRow(
+                  cells: [
+                    DataCell(Text(g.topic)),
+                    DataCell(Text('${g.coverageCount}')),
+                    DataCell(Text('${g.targetCoverage}')),
+                    DataCell(Text(g.candidatePacks.join(', '))),
+                    DataCell(Text(g.priorityScore.toStringAsFixed(1))),
+                  ],
+                ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}

--- a/test/services/theory_gap_detector_test.dart
+++ b/test/services/theory_gap_detector_test.dart
@@ -1,0 +1,41 @@
+import 'package:test/test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/theory_gap_detector.dart';
+import 'package:poker_analyzer/services/skill_tag_coverage_tracker.dart';
+
+void main() {
+  group('TheoryGapDetector', () {
+    test('detects and ranks theory gaps', () async {
+      SharedPreferences.setMockInitialValues({});
+
+      final coverage = SkillTagCoverageTracker();
+      coverage.skillTagCounts.addAll({'preflop': 1, 'postflop': 5});
+
+      final detector = TheoryGapDetector(
+        clusters: {
+          'preflop': ['pack1', 'pack2'],
+          'postflop': ['pack3'],
+          'icm': [],
+        },
+        coverageTracker: coverage,
+        theoryIndex: {
+          'preflop': ['t1'],
+          'postflop': ['t2'],
+        },
+        linkStatus: {'pack1': true, 'pack2': false, 'pack3': false},
+        topicUpdated: {
+          'preflop': DateTime.now().subtract(const Duration(days: 40)),
+        },
+        targetCoveragePerTopic: 3,
+      );
+
+      final gaps = await detector.detectGaps();
+      expect(gaps.length, 3);
+      final preflop = gaps.firstWhere((g) => g.topic == 'preflop');
+      expect(preflop.candidatePacks, ['pack2']);
+      final saved = await detector.loadFromPrefs();
+      expect(saved.length, 3);
+      expect(detector.gapsNotifier.value.length, 3);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- implement `TheoryGapDetector` service to rank theory coverage gaps
- add dashboard `TheoryCoveragePanelWidget` and wire into autogen debug screen
- persist gap results and expose remediation plan

## Testing
- `flutter test test/services/theory_gap_detector_test.dart` *(fails: Package file_picker:linux references file_picker:linux as the default plugin, but it does not provide an inline implementation)*

------
https://chatgpt.com/codex/tasks/task_e_68951e2bf1d8832aac885df8b4e3e807