### PR TITLE
feat: add unified spot seed format and validator

### DIFF
--- a/bin/usf_lint.dart
+++ b/bin/usf_lint.dart
@@ -1,0 +1,49 @@
+import 'dart:io';
+
+import 'package:poker_analyzer/core/models/spot_seed/spot_seed_codec.dart';
+import 'package:poker_analyzer/core/models/spot_seed/spot_seed_validator.dart';
+
+/// Command line tool to lint YAML seeds using the Unified Spot Seed Format.
+Future<void> main(List<String> args) async {
+  if (args.isEmpty) {
+    stdout.writeln('Usage: usf_lint <directory>');
+    exit(64);
+  }
+
+  final dir = Directory(args.first);
+  if (!await dir.exists()) {
+    stderr.writeln('Directory not found: ${dir.path}');
+    exit(64);
+  }
+
+  final codec = const SpotSeedCodec();
+  final validator = const SpotSeedValidator();
+  var hasErrors = false;
+
+  await for (final entity in dir.list(recursive: true)) {
+    if (entity is! File) continue;
+    if (!entity.path.endsWith('.yaml') && !entity.path.endsWith('.yml')) {
+      continue;
+    }
+    final content = await entity.readAsString();
+    try {
+      final seed = codec.fromYaml(content);
+      final issues = validator.validate(seed);
+      for (final issue in issues) {
+        stdout.writeln(
+          '${entity.path}: ${issue.severity.toUpperCase()} ${issue.code} - ${issue.message}',
+        );
+      }
+      if (issues.any((i) => i.severity == 'error')) {
+        hasErrors = true;
+      }
+    } catch (e) {
+      stderr.writeln('${entity.path}: failed to parse - $e');
+      hasErrors = true;
+    }
+  }
+
+  if (hasErrors) {
+    exit(1);
+  }
+}

--- a/lib/core/models/spot_seed/seed_issue.dart
+++ b/lib/core/models/spot_seed/seed_issue.dart
@@ -1,0 +1,14 @@
+/// Represents an issue found during seed validation.
+class SeedIssue {
+  final String code;
+  final String severity; // 'error' or 'warn'
+  final String message;
+  final List<String> path;
+
+  const SeedIssue({
+    required this.code,
+    required this.severity,
+    required this.message,
+    this.path = const <String>[],
+  });
+}

--- a/lib/core/models/spot_seed/spot_seed_codec.dart
+++ b/lib/core/models/spot_seed/spot_seed_codec.dart
@@ -1,0 +1,110 @@
+import 'dart:convert';
+
+import 'package:json2yaml/json2yaml.dart';
+import 'package:yaml/yaml.dart';
+
+import 'unified_spot_seed_format.dart';
+
+/// Codec for converting [SpotSeed] to and from JSON/YAML.
+class SpotSeedCodec {
+  const SpotSeedCodec();
+
+  /// Decode a [SpotSeed] from a JSON [Map].
+  SpotSeed fromJson(Map<String, dynamic> json) {
+    return SpotSeed(
+      id: json['id'] as String,
+      gameType: json['gameType'] as String,
+      bb: (json['bb'] as num).toDouble(),
+      stackBB: (json['stackBB'] as num).toDouble(),
+      positions: SpotPositions(
+        hero: json['positions']['hero'] as String,
+        villain: json['positions']['villain'] as String?,
+      ),
+      ranges: SpotRanges(
+        hero: json['ranges']?['hero'] as String?,
+        villain: json['ranges']?['villain'] as String?,
+      ),
+      board: SpotBoard(
+        preflop: (json['board']?['preflop'] as List?)?.cast<String>(),
+        flop: (json['board']?['flop'] as List?)?.cast<String>(),
+        turn: (json['board']?['turn'] as List?)?.cast<String>(),
+        river: (json['board']?['river'] as List?)?.cast<String>(),
+      ),
+      pot: (json['pot'] as num).toDouble(),
+      icm: json['icm'] != null
+          ? SpotIcm(
+              stackDistribution: (json['icm']['stackDistribution'] as List?)
+                  ?.map((e) => (e as num).toDouble())
+                  .toList(),
+              payouts: (json['icm']['payouts'] as List?)
+                  ?.map((e) => (e as num).toDouble())
+                  .toList(),
+            )
+          : null,
+      tags: (json['tags'] as List?)?.cast<String>(),
+      difficulty: json['difficulty'] as String?,
+      audience: json['audience'] as String?,
+      meta: (json['meta'] as Map?)?.cast<String, dynamic>(),
+    );
+  }
+
+  /// Encode a [SpotSeed] to JSON.
+  Map<String, dynamic> toJson(SpotSeed seed) {
+    final map = <String, dynamic>{
+      'id': seed.id,
+      'gameType': seed.gameType,
+      'bb': seed.bb,
+      'stackBB': seed.stackBB,
+      'positions': {
+        'hero': seed.positions.hero,
+        if (seed.positions.villain != null) 'villain': seed.positions.villain,
+      },
+      'ranges': {
+        if (seed.ranges.hero != null) 'hero': seed.ranges.hero,
+        if (seed.ranges.villain != null) 'villain': seed.ranges.villain,
+      },
+      'board': {
+        if (seed.board.preflop != null) 'preflop': seed.board.preflop,
+        if (seed.board.flop != null) 'flop': seed.board.flop,
+        if (seed.board.turn != null) 'turn': seed.board.turn,
+        if (seed.board.river != null) 'river': seed.board.river,
+      },
+      'pot': seed.pot,
+    };
+
+    if (seed.icm != null) {
+      map['icm'] = {
+        if (seed.icm!.stackDistribution != null)
+          'stackDistribution': seed.icm!.stackDistribution,
+        if (seed.icm!.payouts != null) 'payouts': seed.icm!.payouts,
+      };
+    }
+
+    if (seed.tags.isNotEmpty) {
+      map['tags'] = seed.tags;
+    }
+    if (seed.difficulty != null) {
+      map['difficulty'] = seed.difficulty;
+    }
+    if (seed.audience != null) {
+      map['audience'] = seed.audience;
+    }
+    if (seed.meta.isNotEmpty) {
+      map['meta'] = seed.meta;
+    }
+    return map;
+  }
+
+  /// Decode from a YAML [String].
+  SpotSeed fromYaml(String yaml) {
+    final dynamic doc = loadYaml(yaml);
+    final json = jsonDecode(jsonEncode(doc)) as Map<String, dynamic>;
+    return fromJson(json);
+  }
+
+  /// Encode [seed] to a YAML [String].
+  String toYaml(SpotSeed seed) {
+    final json = toJson(seed);
+    return json2yaml(json);
+  }
+}

--- a/lib/core/models/spot_seed/spot_seed_validator.dart
+++ b/lib/core/models/spot_seed/spot_seed_validator.dart
@@ -1,0 +1,111 @@
+import 'unified_spot_seed_format.dart';
+import 'seed_issue.dart';
+
+/// Preferences controlling validator behaviour.
+class SpotSeedValidatorPreferences {
+  final bool allowUnknownTags;
+  final int? maxComboCount;
+  final String? requireRangesForStreets;
+
+  const SpotSeedValidatorPreferences({
+    this.allowUnknownTags = true,
+    this.maxComboCount,
+    this.requireRangesForStreets,
+  });
+}
+
+/// Validates [SpotSeed] instances.
+class SpotSeedValidator {
+  final SpotSeedValidatorPreferences prefs;
+
+  const SpotSeedValidator({SpotSeedValidatorPreferences? preferences})
+    : prefs = preferences ?? const SpotSeedValidatorPreferences();
+
+  /// Returns a list of issues found within [seed].
+  List<SeedIssue> validate(SpotSeed seed) {
+    final issues = <SeedIssue>[];
+
+    if (seed.stackBB <= 0) {
+      issues.add(
+        const SeedIssue(
+          code: 'stackBB_non_positive',
+          severity: 'error',
+          message: 'stackBB must be greater than 0',
+          path: ['stackBB'],
+        ),
+      );
+    }
+
+    if (seed.positions.villain != null &&
+        seed.positions.villain == seed.positions.hero) {
+      issues.add(
+        const SeedIssue(
+          code: 'positions_conflict',
+          severity: 'error',
+          message: 'hero and villain positions cannot match',
+          path: ['positions'],
+        ),
+      );
+    }
+
+    // Tag normalization check
+    final seen = <String>{};
+    for (final tag in seed.tags) {
+      final lower = tag.toLowerCase();
+      if (tag != lower) {
+        issues.add(
+          SeedIssue(
+            code: 'tag_not_lowercase',
+            severity: 'warn',
+            message: 'tag `$tag` should be lowercase',
+            path: ['tags'],
+          ),
+        );
+      }
+      if (!seen.add(lower)) {
+        issues.add(
+          SeedIssue(
+            code: 'tag_duplicate',
+            severity: 'warn',
+            message: 'duplicate tag `$tag`',
+            path: ['tags'],
+          ),
+        );
+      }
+    }
+
+    // Range requirement based on board presence
+    if (prefs.requireRangesForStreets != null) {
+      final req = prefs.requireRangesForStreets!;
+      final hasBoardBeyondPreflop =
+          (req == 'flop' && (seed.board.flop?.isNotEmpty ?? false)) ||
+          (req == 'turn' && (seed.board.turn?.isNotEmpty ?? false)) ||
+          (req == 'river' && (seed.board.river?.isNotEmpty ?? false));
+      if (hasBoardBeyondPreflop) {
+        if (seed.ranges.hero == null || seed.ranges.villain == null) {
+          issues.add(
+            const SeedIssue(
+              code: 'ranges_missing',
+              severity: 'error',
+              message: 'ranges required for specified streets',
+              path: ['ranges'],
+            ),
+          );
+        }
+      }
+    }
+
+    if (seed.icm != null && seed.gameType != 'tournament') {
+      issues.add(
+        const SeedIssue(
+          code: 'icm_not_allowed',
+          severity: 'error',
+          message: 'ICM data only valid for tournaments',
+          path: ['icm'],
+        ),
+      );
+    }
+
+    return issues;
+  }
+}

--- a/lib/core/models/spot_seed/unified_spot_seed_format.dart
+++ b/lib/core/models/spot_seed/unified_spot_seed_format.dart
@@ -1,55 +1,94 @@
-/// Represents a normalized poker spot used to generate training content.
-class UnifiedSpotSeedFormat {
+/// Unified Spot Seed Format (USF).
+///
+/// Represents a canonical description of a poker training spot.
+class SpotSeed {
   /// Unique identifier for this seed.
   final String id;
 
-  /// Type of training (preflop, postflop, etc.).
-  final String trainingType;
+  /// Game type identifier (e.g. `cash`, `tournament`).
+  final String gameType;
 
-  /// Primary goal for this training spot.
-  final String goal;
+  /// Size of the big blind in chips.
+  final double bb;
 
-  /// High level theme or category for filtering.
-  final String theme;
+  /// Effective stack in big blinds.
+  final double stackBB;
 
-  /// Human readable description of the scenario.
-  final String description;
+  /// Hero and optional villain positions.
+  final SpotPositions positions;
 
-  /// Player position at the table (e.g. UTG, BTN).
-  final String position;
+  /// Ranges for hero and villain when available.
+  final SpotRanges ranges;
 
-  /// Action hero is facing (e.g. open, 3bet, shove).
-  final String actionFacing;
+  /// Board cards for each street.
+  final SpotBoard board;
 
-  /// Board street for this scenario: preflop, flop, turn, river.
-  final String boardStreet;
+  /// Current pot size in big blinds.
+  final double pot;
 
-  /// Tags used for clustering and search.
+  /// ICM data for tournament contexts.
+  final SpotIcm? icm;
+
+  /// Normalized, lowercase tags.
   final List<String> tags;
 
-  /// Difficulty level of the spot.
-  final String level;
+  /// Optional difficulty level.
+  final String? difficulty;
 
-  /// Estimated number of spots generated from this seed.
-  final int spotCount;
+  /// Optional audience identifier.
+  final String? audience;
 
-  /// Additional metadata used by generators.
+  /// Additional metadata for generators.
   final Map<String, dynamic> meta;
 
-  UnifiedSpotSeedFormat({
+  SpotSeed({
     required this.id,
-    required this.trainingType,
-    required this.goal,
-    required this.theme,
-    required this.description,
-    required this.position,
-    required this.actionFacing,
-    required this.boardStreet,
+    required this.gameType,
+    required this.bb,
+    required this.stackBB,
+    required this.positions,
+    required this.ranges,
+    required this.board,
+    required this.pot,
+    this.icm,
     List<String>? tags,
-    required this.level,
-    required this.spotCount,
+    this.difficulty,
+    this.audience,
     Map<String, dynamic>? meta,
-  })  : tags = tags ?? const <String>[],
-        meta = meta ?? const <String, dynamic>{};
+  }) : tags = tags ?? const <String>[],
+       meta = meta ?? const <String, dynamic>{};
 }
 
+/// Holds positional information.
+class SpotPositions {
+  final String hero;
+  final String? villain;
+
+  const SpotPositions({required this.hero, this.villain});
+}
+
+/// Holds range information.
+class SpotRanges {
+  final String? hero;
+  final String? villain;
+
+  const SpotRanges({this.hero, this.villain});
+}
+
+/// Represents the board cards for each street.
+class SpotBoard {
+  final List<String>? preflop;
+  final List<String>? flop;
+  final List<String>? turn;
+  final List<String>? river;
+
+  const SpotBoard({this.preflop, this.flop, this.turn, this.river});
+}
+
+/// ICM specific data.
+class SpotIcm {
+  final List<double>? stackDistribution;
+  final List<double>? payouts;
+
+  const SpotIcm({this.stackDistribution, this.payouts});
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -68,6 +68,7 @@ dependencies:
   graphview: ^1.2.0
   package_info_plus: ^8.3.0
   visibility_detector: ^0.4.0+2
+  json2yaml: ^3.0.0
 
 dependency_overrides:
   intl: ^0.20.2
@@ -86,7 +87,6 @@ dev_dependencies:
   fake_cloud_firestore: ^3.1.0
   firebase_auth_mocks: ^0.14.0
   mocktail: ^1.0.4
-  json2yaml: ^3.0.0
   yaml: ^3.1.1
 
 flutter:

--- a/test/core/models/spot_seed/spot_seed_codec_test.dart
+++ b/test/core/models/spot_seed/spot_seed_codec_test.dart
@@ -1,0 +1,28 @@
+import 'package:poker_analyzer/core/models/spot_seed/unified_spot_seed_format.dart';
+import 'package:poker_analyzer/core/models/spot_seed/spot_seed_codec.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final codec = const SpotSeedCodec();
+
+  SpotSeed buildSeed() => SpotSeed(
+    id: 's1',
+    gameType: 'cash',
+    bb: 1,
+    stackBB: 20,
+    positions: const SpotPositions(hero: 'SB', villain: 'BB'),
+    ranges: const SpotRanges(hero: '22+', villain: '55+'),
+    board: const SpotBoard(flop: ['Ah', 'Kd', '9c']),
+    pot: 1.5,
+    tags: const ['test'],
+    difficulty: 'easy',
+    audience: 'public',
+  );
+
+  test('round trip json/yaml', () {
+    final seed = buildSeed();
+    final yaml = codec.toYaml(seed);
+    final decoded = codec.fromYaml(yaml);
+    expect(codec.toJson(decoded), equals(codec.toJson(seed)));
+  });
+}

--- a/test/core/models/spot_seed/spot_seed_validator_test.dart
+++ b/test/core/models/spot_seed/spot_seed_validator_test.dart
@@ -1,0 +1,59 @@
+import 'package:poker_analyzer/core/models/spot_seed/unified_spot_seed_format.dart';
+import 'package:poker_analyzer/core/models/spot_seed/spot_seed_validator.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final validator = const SpotSeedValidator();
+
+  SpotSeed baseSeed() => SpotSeed(
+    id: 's1',
+    gameType: 'cash',
+    bb: 1,
+    stackBB: 20,
+    positions: const SpotPositions(hero: 'SB', villain: 'BB'),
+    ranges: const SpotRanges(hero: '22+', villain: '55+'),
+    board: const SpotBoard(flop: ['Ah', 'Kd', '9c']),
+    pot: 1.5,
+    tags: const ['tag'],
+  );
+
+  test('valid seed passes', () {
+    final issues = validator.validate(baseSeed());
+    expect(issues, isEmpty);
+  });
+
+  test('stackBB <= 0 triggers error', () {
+    final seed = baseSeed();
+    final bad = SpotSeed(
+      id: seed.id,
+      gameType: seed.gameType,
+      bb: seed.bb,
+      stackBB: 0,
+      positions: seed.positions,
+      ranges: seed.ranges,
+      board: seed.board,
+      pot: seed.pot,
+    );
+    final issues = validator.validate(bad);
+    expect(issues.where((i) => i.severity == 'error'), isNotEmpty);
+  });
+
+  test('tag normalization emits warnings', () {
+    final seed = SpotSeed(
+      id: 's1',
+      gameType: 'cash',
+      bb: 1,
+      stackBB: 20,
+      positions: const SpotPositions(hero: 'SB', villain: 'BB'),
+      ranges: const SpotRanges(),
+      board: const SpotBoard(),
+      pot: 1,
+      tags: const ['TAG', 'tag'],
+    );
+    final issues = validator.validate(seed);
+    expect(
+      issues.where((i) => i.severity == 'warn').length,
+      greaterThanOrEqualTo(1),
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- add Unified Spot Seed (USF) model with positions, ranges, board, icm and metadata
- provide SpotSeedCodec for JSON/YAML conversion
- implement SpotSeedValidator with issue reporting and CLI linter
- move json2yaml dependency into runtime dependencies
- add basic tests for codec and validator

## Testing
- `flutter test` *(fails: The current Dart SDK version is 3.4.0. Because poker_analyzer requires SDK version >=3.6.0 <4.0.0, version solving failed.)*

------
https://chatgpt.com/codex/tasks/task_e_68952753278c832aa6073aa0c8badfb0