### PR TITLE
feat: integrate USF seed ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,16 @@ dart tools/validate_training_content.dart --fix
 
 Use `--ci` to exit with a non-zero code on errors.
 
+### Pre-commit USF lint
+
+Validate seed files before committing by running the USF lint tool:
+
+```bash
+dart run bin/usf_lint.dart <seed_directory>
+```
+
+Add this to your pre-commit hook to block invalid seeds.
+
 ## Precompile Training Packs
 
 Regenerate the precompiled YAML packs before running the app or building a release:

--- a/bin/usf_lint.dart
+++ b/bin/usf_lint.dart
@@ -46,4 +46,5 @@ Future<void> main(List<String> args) async {
   if (hasErrors) {
     exit(1);
   }
+  exit(0);
 }

--- a/lib/core/models/spot_seed/legacy_seed_adapter.dart
+++ b/lib/core/models/spot_seed/legacy_seed_adapter.dart
@@ -1,0 +1,54 @@
+import 'spot_seed_codec.dart';
+import 'unified_spot_seed_format.dart';
+
+/// Converts legacy seed maps into [SpotSeed] instances.
+class LegacySeedAdapter {
+  const LegacySeedAdapter({SpotSeedCodec? codec}) : _codec = codec ?? const SpotSeedCodec();
+
+  final SpotSeedCodec _codec;
+
+  /// Convert [legacy] map to [SpotSeed]. If the map already matches the USF
+  /// structure it is decoded directly. Otherwise a best effort conversion is
+  /// performed from older seed formats. Tags are normalised to lowercase and
+  /// duplicates removed.
+  SpotSeed convert(Map<String, dynamic> legacy) {
+    // If it already looks like USF, just decode using the codec.
+    if (legacy.containsKey('gameType') && legacy.containsKey('bb')) {
+      final map = Map<String, dynamic>.from(legacy);
+      final tags = map['tags'];
+      if (tags is List) {
+        map['tags'] = _normaliseTags(tags.cast<String>());
+      }
+      return _codec.fromJson(map);
+    }
+
+    final tags = _normaliseTags(
+        (legacy['tags'] as List?)?.cast<String>() ?? const <String>[]);
+    final id = legacy['id']?.toString() ??
+        'legacy_${DateTime.now().millisecondsSinceEpoch}';
+    final heroPos = legacy['position']?.toString() ?? 'btn';
+
+    return SpotSeed(
+      id: id,
+      gameType: legacy['gameType']?.toString() ?? 'tournament',
+      bb: (legacy['bb'] as num?)?.toDouble() ?? 1.0,
+      stackBB: (legacy['stackBB'] as num?)?.toDouble() ?? 0.0,
+      positions: SpotPositions(hero: heroPos),
+      ranges: const SpotRanges(),
+      board: SpotBoard(
+        preflop: (legacy['board'] as List?)?.cast<String>(),
+      ),
+      pot: (legacy['pot'] as num?)?.toDouble() ?? 0.0,
+      tags: tags,
+    );
+  }
+
+  List<String> _normaliseTags(List<String> tags) {
+    final set = <String>{};
+    for (final t in tags) {
+      set.add(t.toLowerCase());
+    }
+    return set.toList();
+  }
+}
+

--- a/lib/core/models/spot_seed/seed_issue.dart
+++ b/lib/core/models/spot_seed/seed_issue.dart
@@ -5,10 +5,14 @@ class SeedIssue {
   final String message;
   final List<String> path;
 
+  /// Identifier of the seed that produced this issue when available.
+  final String? seedId;
+
   const SeedIssue({
     required this.code,
     required this.severity,
     required this.message,
     this.path = const <String>[],
+    this.seedId,
   });
 }

--- a/lib/screens/autogen_debug_screen.dart
+++ b/lib/screens/autogen_debug_screen.dart
@@ -9,6 +9,7 @@ import '../widgets/inline_report_viewer_widget.dart';
 import '../widgets/autogen_history_chart_widget.dart';
 import '../services/autogen_stats_dashboard_service.dart';
 import '../services/autogen_status_dashboard_service.dart';
+import '../widgets/seed_lint_panel_widget.dart';
 import '../services/autogen_pipeline_executor.dart';
 import '../services/training_pack_auto_generator.dart';
 import '../services/training_pack_template_set_library_service.dart';
@@ -234,6 +235,7 @@ class _AutogenDebugScreenState extends State<AutogenDebugScreen> {
           SizedBox(height: 200, child: AutogenHistoryChartWidget()),
           const AutogenRealtimeStatsPanel(),
           SizedBox(height: 200, child: TheoryCoveragePanelWidget()),
+          SizedBox(height: 200, child: SeedLintPanelWidget()),
           SizedBox(height: 200, child: AutogenDuplicateTableWidget()),
           SizedBox(
             height: 200,

--- a/lib/services/autogen_status_dashboard_service.dart
+++ b/lib/services/autogen_status_dashboard_service.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import '../models/autogen_status.dart';
 import '../models/autogen_session_meta.dart';
 import '../models/training_run_record.dart';
+import '../core/models/spot_seed/seed_issue.dart';
 import 'training_run_ab_comparator.dart';
 
 class DuplicatePackInfo {
@@ -47,6 +48,10 @@ class AutogenStatusDashboardService {
   final ValueNotifier<List<ABArmResult>> abResultsNotifier =
       ValueNotifier(const <ABArmResult>[]);
   final TrainingRunABComparator _abComparator = TrainingRunABComparator();
+
+  /// Issues discovered during seed validation.
+  final ValueNotifier<List<SeedIssue>> seedIssuesNotifier =
+      ValueNotifier(const <SeedIssue>[]);
 
   final List<AutogenSessionMeta> _sessions = [];
   final StreamController<List<AutogenSessionMeta>> _sessionController =
@@ -120,6 +125,15 @@ class AutogenStatusDashboardService {
     boostersSkippedNotifier.value = Map.unmodifiable(map);
   }
 
+  /// Append [issues] for [seedId] to the lint feed.
+  void reportSeedIssues(String seedId, List<SeedIssue> issues) {
+    if (issues.isEmpty) return;
+    final list = [...seedIssuesNotifier.value];
+    list.addAll(issues.map((i) =>
+        SeedIssue(code: i.code, severity: i.severity, message: i.message, path: i.path, seedId: seedId)));
+    seedIssuesNotifier.value = List.unmodifiable(list);
+  }
+
   Future<void> refreshAbResults(List<TrainingRunRecord> runs,
       {String? audience}) async {
     final results = await _abComparator.compare(runs, audience: audience);
@@ -145,5 +159,6 @@ class AutogenStatusDashboardService {
     boostersGeneratedNotifier.value = 0;
     boostersSkippedNotifier.value = const {};
     boosterIdsNotifier.value = const <String>[];
+    seedIssuesNotifier.value = const <SeedIssue>[];
   }
 }

--- a/lib/services/pack_quality_gatekeeper_service.dart
+++ b/lib/services/pack_quality_gatekeeper_service.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 
 import '../models/training_pack_model.dart';
 import 'pack_quality_score_calculator_service.dart';
+import '../core/models/spot_seed/seed_issue.dart';
 
 /// Filters out training packs that do not meet the minimum quality score.
 class PackQualityGatekeeperService {
@@ -15,7 +16,8 @@ class PackQualityGatekeeperService {
   ///
   /// If the pack does not already have a `qualityScore` stored in its
   /// metadata, it is calculated and cached before evaluation.
-  bool isQualityAcceptable(TrainingPackModel pack, {double minScore = 0.7}) {
+  bool isQualityAcceptable(TrainingPackModel pack,
+      {double minScore = 0.7, List<SeedIssue> seedIssues = const []}) {
     var score = pack.metadata['qualityScore'] as double?;
     if (score == null) {
       score = _scoreCalculator.calculateQualityScore(pack);
@@ -23,6 +25,11 @@ class PackQualityGatekeeperService {
     if (score < minScore) {
       debugPrint(
           'PackQualityGatekeeperService: rejected pack ${pack.id} with score ${score.toStringAsFixed(2)} < threshold $minScore');
+      return false;
+    }
+    if (seedIssues.any((i) => i.severity == 'error')) {
+      debugPrint(
+          'PackQualityGatekeeperService: rejected pack ${pack.id} due to seed validation errors');
       return false;
     }
     return true;

--- a/lib/widgets/seed_lint_panel_widget.dart
+++ b/lib/widgets/seed_lint_panel_widget.dart
@@ -1,0 +1,87 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+
+import '../core/models/spot_seed/seed_issue.dart';
+import '../services/autogen_status_dashboard_service.dart';
+
+/// Panel displaying validation issues for ingested seeds.
+class SeedLintPanelWidget extends StatefulWidget {
+  const SeedLintPanelWidget({super.key});
+
+  @override
+  State<SeedLintPanelWidget> createState() => _SeedLintPanelWidgetState();
+}
+
+class _SeedLintPanelWidgetState extends State<SeedLintPanelWidget> {
+  String? _severityFilter;
+
+  @override
+  Widget build(BuildContext context) {
+    final service = AutogenStatusDashboardService.instance;
+    return ValueListenableBuilder<List<SeedIssue>>(
+      valueListenable: service.seedIssuesNotifier,
+      builder: (context, issues, _) {
+        final filtered = _severityFilter == null
+            ? issues
+            : issues.where((i) => i.severity == _severityFilter).toList();
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                const Text('Seed Lint'),
+                const SizedBox(width: 16),
+                DropdownButton<String>(
+                  hint: const Text('Severity'),
+                  value: _severityFilter,
+                  items: const [
+                    DropdownMenuItem(value: 'warn', child: Text('Warn')),
+                    DropdownMenuItem(value: 'error', child: Text('Error')),
+                  ],
+                  onChanged: (v) => setState(() => _severityFilter = v),
+                ),
+                const Spacer(),
+                TextButton(
+                  onPressed: () async {
+                    final rows = [
+                      ['id', 'severity', 'code', 'message'],
+                      ...issues.map((i) =>
+                          [i.seedId ?? '', i.severity, i.code, i.message])
+                    ];
+                    final csv = rows.map((r) => r.join(',')).join('\n');
+                    final file = File('seed_lint.csv');
+                    await file.writeAsString(csv);
+                  },
+                  child: const Text('Download CSV'),
+                )
+              ],
+            ),
+            Expanded(
+              child: SingleChildScrollView(
+                child: DataTable(
+                  columns: const [
+                    DataColumn(label: Text('Seed ID')),
+                    DataColumn(label: Text('Severity')),
+                    DataColumn(label: Text('Code')),
+                    DataColumn(label: Text('Message')),
+                  ],
+                  rows: [
+                    for (final i in filtered)
+                      DataRow(cells: [
+                        DataCell(Text(i.seedId ?? '')),
+                        DataCell(Text(i.severity)),
+                        DataCell(Text(i.code)),
+                        DataCell(Text(i.message)),
+                      ])
+                  ],
+                ),
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}
+

--- a/test/core/models/spot_seed/legacy_seed_adapter_test.dart
+++ b/test/core/models/spot_seed/legacy_seed_adapter_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/core/models/spot_seed/legacy_seed_adapter.dart';
+import 'package:poker_analyzer/core/models/spot_seed/spot_seed_codec.dart';
+import 'package:poker_analyzer/core/models/spot_seed/spot_seed_validator.dart';
+
+void main() {
+  test('legacy map converts and validates', () {
+    final legacy = {
+      'id': 'L1',
+      'gameType': 'tournament',
+      'bb': 100,
+      'stackBB': 20,
+      'position': 'sb',
+      'board': ['Ah', 'Kd', 'Qs'],
+      'pot': 1,
+      'tags': ['FOO', 'foo', 'Bar'],
+    };
+    const adapter = LegacySeedAdapter();
+    final seed = adapter.convert(Map<String, dynamic>.from(legacy));
+    expect(seed.tags, ['foo', 'bar']);
+    const codec = SpotSeedCodec();
+    final round = codec.fromJson(codec.toJson(seed));
+    const validator = SpotSeedValidator();
+    final issues = validator.validate(round);
+    expect(issues.where((i) => i.severity == 'error'), isEmpty);
+  });
+}
+

--- a/test/services/autogen_status_dashboard_seed_issue_test.dart
+++ b/test/services/autogen_status_dashboard_seed_issue_test.dart
@@ -1,0 +1,17 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/core/models/spot_seed/seed_issue.dart';
+import 'package:poker_analyzer/services/autogen_status_dashboard_service.dart';
+
+void main() {
+  test('reportSeedIssues updates notifier', () {
+    final service = AutogenStatusDashboardService.instance;
+    service.clear();
+    service.reportSeedIssues('s1', [
+      const SeedIssue(code: 'c', severity: 'warn', message: 'm')
+    ]);
+    expect(service.seedIssuesNotifier.value.length, 1);
+    final issue = service.seedIssuesNotifier.value.first;
+    expect(issue.seedId, 's1');
+  });
+}
+

--- a/test/services/pack_quality_gatekeeper_service_test.dart
+++ b/test/services/pack_quality_gatekeeper_service_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:poker_analyzer/models/training_pack_model.dart';
 import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
 import 'package:poker_analyzer/services/pack_quality_gatekeeper_service.dart';
+import 'package:poker_analyzer/core/models/spot_seed/seed_issue.dart';
 
 void main() {
   group('PackQualityGatekeeperService', () {
@@ -39,6 +40,26 @@ void main() {
       final result = gatekeeper.isQualityAcceptable(pack, minScore: 0.7);
       expect(result, isTrue);
       expect(pack.metadata['qualityScore'], isNotNull);
+    });
+
+    test('blocks packs with seed errors', () {
+      final pack = TrainingPackModel(id: 'p3', title: 'A', spots: const []);
+      const gatekeeper = PackQualityGatekeeperService();
+      final issues = [
+        const SeedIssue(code: 'bad', severity: 'error', message: 'oops'),
+      ];
+      final result = gatekeeper.isQualityAcceptable(pack, seedIssues: issues);
+      expect(result, isFalse);
+    });
+
+    test('allows packs with only warnings', () {
+      final pack = TrainingPackModel(id: 'p4', title: 'B', spots: const []);
+      const gatekeeper = PackQualityGatekeeperService();
+      final issues = [
+        const SeedIssue(code: 'warn', severity: 'warn', message: 'meh'),
+      ];
+      final result = gatekeeper.isQualityAcceptable(pack, seedIssues: issues);
+      expect(result, isTrue);
     });
   });
 }


### PR DESCRIPTION
## Summary
- add LegacySeedAdapter for converting legacy seed maps to USF SpotSeed
- surface seed validation issues and gate packs with errors
- add SeedLintPanelWidget and CLI/README hooks for seed linting

## Testing
- `dart test` *(fails: command not found: dart)*

------
https://chatgpt.com/codex/tasks/task_e_68952a20160c832aba44381ceb9f4dc1