### PR TITLE
feat: enhance seed validation and lint UI

### DIFF
--- a/lib/services/pack_quality_gatekeeper_service.dart
+++ b/lib/services/pack_quality_gatekeeper_service.dart
@@ -17,7 +17,8 @@ class PackQualityGatekeeperService {
   /// If the pack does not already have a `qualityScore` stored in its
   /// metadata, it is calculated and cached before evaluation.
   bool isQualityAcceptable(TrainingPackModel pack,
-      {double minScore = 0.7, List<SeedIssue> seedIssues = const []}) {
+      {double minScore = 0.7,
+      Map<String, List<SeedIssue>> seedIssues = const {}}) {
     var score = pack.metadata['qualityScore'] as double?;
     if (score == null) {
       score = _scoreCalculator.calculateQualityScore(pack);
@@ -27,7 +28,8 @@ class PackQualityGatekeeperService {
           'PackQualityGatekeeperService: rejected pack ${pack.id} with score ${score.toStringAsFixed(2)} < threshold $minScore');
       return false;
     }
-    if (seedIssues.any((i) => i.severity == 'error')) {
+    final issues = seedIssues[pack.id] ?? const <SeedIssue>[];
+    if (issues.any((i) => i.severity == 'error')) {
       debugPrint(
           'PackQualityGatekeeperService: rejected pack ${pack.id} due to seed validation errors');
       return false;

--- a/test/services/pack_quality_gatekeeper_service_test.dart
+++ b/test/services/pack_quality_gatekeeper_service_test.dart
@@ -45,9 +45,11 @@ void main() {
     test('blocks packs with seed errors', () {
       final pack = TrainingPackModel(id: 'p3', title: 'A', spots: const []);
       const gatekeeper = PackQualityGatekeeperService();
-      final issues = [
-        const SeedIssue(code: 'bad', severity: 'error', message: 'oops'),
-      ];
+      final issues = {
+        pack.id: [
+          const SeedIssue(code: 'bad', severity: 'error', message: 'oops'),
+        ]
+      };
       final result = gatekeeper.isQualityAcceptable(pack, seedIssues: issues);
       expect(result, isFalse);
     });
@@ -55,9 +57,11 @@ void main() {
     test('allows packs with only warnings', () {
       final pack = TrainingPackModel(id: 'p4', title: 'B', spots: const []);
       const gatekeeper = PackQualityGatekeeperService();
-      final issues = [
-        const SeedIssue(code: 'warn', severity: 'warn', message: 'meh'),
-      ];
+      final issues = {
+        pack.id: [
+          const SeedIssue(code: 'warn', severity: 'warn', message: 'meh'),
+        ]
+      };
       final result = gatekeeper.isQualityAcceptable(pack, seedIssues: issues);
       expect(result, isTrue);
     });


### PR DESCRIPTION
## Summary
- extend SpotSeedValidator with stricter validation preferences
- add fail-fast option for seed errors in AutogenPipelineExecutor
- scope quality gate seed issues per pack and improve seed lint panel

## Testing
- `sudo apt-get update`
- `sudo apt-get install -y dart` *(fails: Unable to locate package dart)*
- `dart run bin/usf_lint.dart seeds/` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68952eb23b5c832aadc1dd27048b98e8