### PR TITLE
feat: expand board generator for multi-street support

### DIFF
--- a/lib/models/full_board.dart
+++ b/lib/models/full_board.dart
@@ -1,0 +1,31 @@
+import 'card_model.dart';
+
+class FullBoard {
+  final List<CardModel> flop;
+  final CardModel? turn;
+  final CardModel? river;
+
+  const FullBoard({
+    required this.flop,
+    this.turn,
+    this.river,
+  });
+
+  List<CardModel> get cards => [
+        ...flop,
+        if (turn != null) turn!,
+        if (river != null) river!,
+      ];
+
+  @override
+  String toString() =>
+      cards.map((c) => c.toString()).join(' ');
+
+  String toYAML() {
+    final buffer = StringBuffer();
+    buffer.writeln('flop: ${flop.map((c) => c.toString()).join(' ')}');
+    if (turn != null) buffer.writeln('turn: ${turn.toString()}');
+    if (river != null) buffer.writeln('river: ${river.toString()}');
+    return buffer.toString();
+  }
+}

--- a/lib/services/full_board_generator.dart
+++ b/lib/services/full_board_generator.dart
@@ -1,37 +1,36 @@
-import '../models/board_stages.dart';
+import 'dart:math';
+
+import '../models/full_board.dart';
 import '../models/card_model.dart';
 import '../helpers/board_filtering_params_builder.dart';
-import 'board_texture_filter_service.dart';
 import 'card_deck_service.dart';
+import 'board_texture_filter_service.dart';
 import 'board_filtering_service_v2.dart';
 
 class FullBoardGenerator {
-  const FullBoardGenerator({
+  FullBoardGenerator({
+    Random? random,
     CardDeckService? deckService,
     BoardTextureFilterService? textureFilter,
     BoardFilteringServiceV2? boardFilter,
-  })  : _deckService = deckService ?? const CardDeckService(),
+  })  : _random = random ?? Random(),
+        _deckService = deckService ?? const CardDeckService(),
         _textureFilter = textureFilter ?? const BoardTextureFilterService(),
         _boardFilter = boardFilter ?? const BoardFilteringServiceV2();
 
+  final Random _random;
   final CardDeckService _deckService;
   final BoardTextureFilterService _textureFilter;
   final BoardFilteringServiceV2 _boardFilter;
 
-  /// Generates all possible flop-turn-river combinations that satisfy
-  /// [constraints].
-  ///
-  /// Supported constraint keys include:
-  /// * `texture` (e.g. `paired`)
-  /// * `rainbow` (bool)
-  /// * `broadwayHeavy` (bool)
-  /// * `drawy` (bool)
-  /// * `low` (bool)
-  /// * `paired` (bool)
-  /// * `aceHigh` (bool)
-  /// * `requiredRanks` (List<String>)
-  /// * `requiredSuits` (List<String>)
-  List<BoardStages> generate(Map<String, dynamic> constraints) {
+  int lastAttempts = 0;
+
+  FullBoard generate({
+    Map<String, dynamic>? boardConstraints,
+    String targetStreet = 'full',
+    List<CardModel> excludedCards = const [],
+  }) {
+    final constraints = boardConstraints ?? {};
     final tags = <String>[];
     final requiredRanks = <String>[
       for (final r in (constraints['requiredRanks'] as List? ?? []))
@@ -64,40 +63,123 @@ class FullBoardGenerator {
         t.toString(),
     };
 
-    final deck = _deckService.buildDeck();
-    final results = <BoardStages>[];
+    final deck = _deckService.buildDeck(excludedCards: excludedCards);
 
-    for (var i = 0; i < deck.length - 2; i++) {
-      for (var j = i + 1; j < deck.length - 1; j++) {
-        for (var k = j + 1; k < deck.length; k++) {
-          final flop = [deck[i], deck[j], deck[k]];
-          if (!_textureFilter.isMatch(flop, filter)) {
-            continue;
-          }
-          final remaining = [
-            for (final c in deck)
-              if (!flop.contains(c)) c
-          ];
-          for (var t = 0; t < remaining.length - 1; t++) {
-            for (var r = t + 1; r < remaining.length; r++) {
-              final turn = remaining[t];
-              final river = remaining[r];
-              final board = BoardStages(
-                flop: flop.map((c) => c.toString()).toList(),
-                turn: turn.toString(),
-                river: river.toString(),
-              );
-              if (!_boardFilter.isMatch(board, requiredTags,
-                  excludedTags: excludedTags)) {
-                continue;
-              }
-              results.add(board);
-            }
-          }
-        }
+    const maxAttempts = 10000;
+    lastAttempts = 0;
+    for (var attempt = 0; attempt < maxAttempts; attempt++) {
+      lastAttempts++;
+      deck.shuffle(_random);
+      final cards = <CardModel>[...deck];
+      final flop = cards.sublist(0, 3);
+      if (!_passesConstraints(flop, filter, requiredTags, excludedTags)) {
+        continue;
       }
+      if (targetStreet == 'flop') {
+        return FullBoard(flop: flop);
+      }
+      final turn = cards[3];
+      final flopTurn = [...flop, turn];
+      if (!_passesConstraints(flopTurn, filter, requiredTags, excludedTags)) {
+        continue;
+      }
+      if (targetStreet == 'turn') {
+        return FullBoard(flop: flop, turn: turn);
+      }
+      final river = cards[4];
+      final full = [...flopTurn, river];
+      if (!_passesConstraints(full, filter, requiredTags, excludedTags)) {
+        continue;
+      }
+      return FullBoard(flop: flop, turn: turn, river: river);
+    }
+    throw StateError('Unable to generate board with given constraints');
+  }
+
+  bool _passesConstraints(
+    List<CardModel> board,
+    Map<String, dynamic> filter,
+    Set<String> requiredTags,
+    Set<String> excludedTags,
+  ) {
+    if (!_textureFilter.isMatch(board, filter)) return false;
+    if (requiredTags.isEmpty && excludedTags.isEmpty) return true;
+    final tags = _evaluateTags(board);
+    if (excludedTags.any(tags.contains)) return false;
+    for (final t in requiredTags) {
+      if (!tags.contains(t)) return false;
+    }
+    return true;
+  }
+
+  Set<String> _evaluateTags(List<CardModel> cards) {
+    final tags = <String>{};
+    final ranks = cards.map((c) => c.rank).toList();
+    final suits = cards.map((c) => c.suit).toList();
+    final values = cards.map((c) => _rankValue(c.rank)).toList();
+
+    if (ranks.toSet().length < ranks.length) tags.add('paired');
+    if (values.any((v) => v >= 10)) tags.add('highCard');
+    if (values.any((v) => v == 14)) tags.add('aceHigh');
+    if (values.every((v) => v <= 9)) tags.add('low');
+
+    final broadwayCount = values.where((v) => v >= 10).length;
+    if (broadwayCount >= 3) tags.add('broadwayHeavy');
+    if (broadwayCount == 3) tags.add('tripleBroadway');
+
+    final suitCounts = <String, int>{};
+    for (final s in suits) {
+      suitCounts[s] = (suitCounts[s] ?? 0) + 1;
+    }
+    if (suitCounts.values.any((c) => c >= 4)) {
+      tags.add('fourToFlush');
+      tags.add('flushDraw');
+    }
+    if (suitCounts.values.any((c) => c == 5)) {
+      tags.add('flush');
     }
 
-    return results;
+    if (_isStraightDrawHeavy(values)) tags.add('straightDrawHeavy');
+
+    return tags;
+  }
+
+  bool _isStraightDrawHeavy(List<int> values) {
+    if (values.length < 3) return false;
+    final sorted = [...values]..sort();
+    return sorted.last - sorted.first <= 4;
+  }
+
+  int _rankValue(String r) {
+    switch (r.toUpperCase()) {
+      case 'A':
+        return 14;
+      case 'K':
+        return 13;
+      case 'Q':
+        return 12;
+      case 'J':
+        return 11;
+      case 'T':
+        return 10;
+      case '9':
+        return 9;
+      case '8':
+        return 8;
+      case '7':
+        return 7;
+      case '6':
+        return 6;
+      case '5':
+        return 5;
+      case '4':
+        return 4;
+      case '3':
+        return 3;
+      case '2':
+        return 2;
+      default:
+        return 0;
+    }
   }
 }

--- a/test/full_board_generator_multi_street_test.dart
+++ b/test/full_board_generator_multi_street_test.dart
@@ -1,0 +1,42 @@
+import 'dart:math';
+
+import 'package:test/test.dart';
+
+import 'package:poker_analyzer/services/full_board_generator.dart';
+
+void main() {
+  test('generates flop only when targetStreet is flop', () {
+    final generator = FullBoardGenerator(random: Random(1));
+    final board = generator.generate(targetStreet: 'flop');
+    expect(board.flop.length, 3);
+    expect(board.turn, isNull);
+    expect(board.river, isNull);
+    final all = board.cards.map((c) => c.toString()).toSet();
+    expect(all.length, 3);
+  });
+
+  test('generates full board with constraints', () {
+    final generator = FullBoardGenerator(random: Random(2));
+    final board = generator.generate(boardConstraints: {'low': true});
+    expect(board.flop.length, 3);
+    expect(board.turn, isNotNull);
+    expect(board.river, isNotNull);
+    bool isLow(String rank) {
+      const order = ['2','3','4','5','6','7','8'];
+      return order.contains(rank);
+    }
+    expect(board.cards.every((c) => isLow(c.rank)), isTrue);
+  });
+
+  test('re-rolls until constraints satisfied', () {
+    final generator = FullBoardGenerator(random: Random(3));
+    final board = generator.generate(
+      boardConstraints: {
+        'requiredRanks': ['A','K','Q'],
+      },
+    );
+    expect(generator.lastAttempts, greaterThan(1));
+    final ranks = board.flop.map((c) => c.rank.toUpperCase()).toSet();
+    expect(ranks.containsAll(['A','K','Q']), isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- add FullBoard model with helpers for string and YAML output
- implement multi-street FullBoardGenerator with constraint filtering
- cover generator with unit tests for street targets, full-board constraints, and reroll behavior

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: Because poker_analyzer depends on flutter_test from sdk which doesn't exist (the Flutter SDK is not available), version solving failed.)*


------
https://chatgpt.com/codex/tasks/task_e_68953ef38318832a9df817cb92c78822