### PR TITLE
Tag generated boards with texture classifications

### DIFF
--- a/lib/models/board_stages.dart
+++ b/lib/models/board_stages.dart
@@ -2,10 +2,12 @@ class BoardStages {
   final List<String> flop;
   final String turn;
   final String river;
+  final Set<String> textureTags;
 
   const BoardStages({
     required this.flop,
     required this.turn,
     required this.river,
+    this.textureTags = const {},
   });
 }

--- a/lib/models/full_board.dart
+++ b/lib/models/full_board.dart
@@ -4,11 +4,13 @@ class FullBoard {
   final List<CardModel> flop;
   final CardModel? turn;
   final CardModel? river;
+  final Set<String> textureTags;
 
   const FullBoard({
     required this.flop,
     this.turn,
     this.river,
+    this.textureTags = const {},
   });
 
   List<CardModel> get cards => [
@@ -18,14 +20,16 @@ class FullBoard {
       ];
 
   @override
-  String toString() =>
-      cards.map((c) => c.toString()).join(' ');
+  String toString() => cards.map((c) => c.toString()).join(' ');
 
   String toYAML() {
     final buffer = StringBuffer();
     buffer.writeln('flop: ${flop.map((c) => c.toString()).join(' ')}');
     if (turn != null) buffer.writeln('turn: ${turn.toString()}');
     if (river != null) buffer.writeln('river: ${river.toString()}');
+    if (textureTags.isNotEmpty) {
+      buffer.writeln('tags: ${textureTags.join(' ')}');
+    }
     return buffer.toString();
   }
 }

--- a/lib/services/board_filtering_service_v2.dart
+++ b/lib/services/board_filtering_service_v2.dart
@@ -4,8 +4,10 @@ import '../models/card_model.dart';
 class BoardFilteringServiceV2 {
   const BoardFilteringServiceV2();
 
-  bool isMatch(BoardStages board, Set<String> requiredTags, {Set<String>? excludedTags}) {
-    final tags = _evaluate(board);
+  bool isMatch(BoardStages board, Set<String> requiredTags,
+      {Set<String>? excludedTags}) {
+    final tags =
+        board.textureTags.isNotEmpty ? board.textureTags : _evaluate(board);
     if (excludedTags != null && excludedTags.any(tags.contains)) {
       return false;
     }

--- a/test/full_board_generator_texture_tags_test.dart
+++ b/test/full_board_generator_texture_tags_test.dart
@@ -1,0 +1,44 @@
+import 'dart:math';
+import 'package:test/test.dart';
+import 'package:poker_analyzer/services/full_board_generator.dart';
+import 'package:poker_analyzer/services/board_filtering_service_v2.dart';
+import 'package:poker_analyzer/models/board_stages.dart';
+import 'package:poker_analyzer/services/board_texture_classifier.dart';
+import 'package:poker_analyzer/models/card_model.dart';
+
+class _CountingClassifier extends BoardTextureClassifier {
+  int calls = 0;
+  @override
+  Set<String> classifyCards(List<CardModel> board) {
+    calls++;
+    return super.classifyCards(board);
+  }
+}
+
+void main() {
+  test('generated boards include texture tags and YAML export', () {
+    final classifier = _CountingClassifier();
+    final generator = FullBoardGenerator(
+      random: Random(1),
+      classifier: classifier,
+    );
+    final board = generator.generate(boardConstraints: {
+      'paired': true,
+      'aceHigh': true,
+    });
+    expect(board.textureTags.containsAll({'paired', 'aceHigh'}), isTrue);
+
+    final yaml = board.toYAML();
+    expect(yaml, contains('tags:'));
+
+    final stages = BoardStages(
+      flop: board.flop.map((c) => c.toString()).toList(),
+      turn: board.turn!.toString(),
+      river: board.river!.toString(),
+      textureTags: board.textureTags,
+    );
+    final filter = BoardFilteringServiceV2();
+    expect(filter.isMatch(stages, {'paired'}), isTrue);
+    expect(classifier.calls, 1);
+  });
+}


### PR DESCRIPTION
## Summary
- classify generated boards with `BoardTextureClassifier` and store texture tags
- expose texture tags on `FullBoard`/`BoardStages` and YAML export
- reuse texture tags in filtering and add tests

## Testing
- `flutter test` *(fails: missing files and plugin implementations)*

------
https://chatgpt.com/codex/tasks/task_e_689540dfd6e8832aa4e73c12cd281085