### PR TITLE
feat: cluster weak skill tags for multi-tag boosters

### DIFF
--- a/test/services/auto_skill_gap_clusterer_test.dart
+++ b/test/services/auto_skill_gap_clusterer_test.dart
@@ -1,39 +1,28 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:poker_analyzer/services/auto_skill_gap_clusterer.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  test('detects weak skill clusters and sorts by severity', () async {
-    SharedPreferences.setMockInitialValues({});
-    final prefs = await SharedPreferences.getInstance();
-    final clusterer = AutoSkillGapClusterer(prefs: prefs);
-    const history = UserSkillHistory(
-      tagAccuracy: {
-        'pushfold_sb': 0.5,
-        'pushfold_bb': 0.6,
-        'icm_shove': 0.65,
-        'postflop_jam': 0.8,
-      },
-      tagOccurrences: {
-        'pushfold_sb': 10,
-        'pushfold_bb': 5,
-        'icm_shove': 8,
-        'postflop_jam': 10,
-      },
-      tagCategories: {
-        'pushfold_sb': 'push-fold',
-        'pushfold_bb': 'push-fold',
-        'icm_shove': 'ICM',
-        'postflop_jam': 'postflop-jam',
-      },
+  test('clusters overlapping weak tags', () {
+    final clusterer = AutoSkillGapClusterer(
+      linkPercentage: 0.5,
+      maxClusterSize: 3,
     );
-
-    final clusters = await clusterer.detectWeakSkillClusters(history);
+    final weak = ['a', 'b', 'c', 'd'];
+    final spotTags = {
+      's1': ['a', 'b'],
+      's2': ['a', 'b'],
+      's3': ['a', 'c'],
+      's4': ['d'],
+    };
+    final clusters = clusterer.clusterWeakTags(
+      weakTags: weak,
+      spotTags: spotTags,
+    );
     expect(clusters.length, 2);
-    expect(clusters.first.clusterName, 'push-fold');
-    expect(clusters.first.tags, containsAll(['pushfold_sb', 'pushfold_bb']));
-    expect(clusterer.clustersNotifier.value, clusters);
+    final main = clusters.firstWhere((c) => c.tags.contains('a'));
+    expect(main.tags, containsAll(['a', 'b', 'c']));
+    expect(clusters.any((c) => c.tags.length == 1 && c.tags.first == 'd'), isTrue);
   });
 }


### PR DESCRIPTION
## Summary
- cluster weak/decayed tags with AutoSkillGapClusterer using co-occurrence and union-find
- support multi-tag booster generation via TargetedPackBoosterEngine.generateClusterBoosterPacks
- test clustering logic and multi-tag booster coverage

## Testing
- `flutter test test/services/auto_skill_gap_clusterer_test.dart test/services/targeted_pack_booster_engine_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689548366980832a8509653efc1eaa33