### PR TITLE
feat: add ICM scenario injection

### DIFF
--- a/assets/icm_scenarios/library.json
+++ b/assets/icm_scenarios/library.json
@@ -1,0 +1,74 @@
+[
+  {
+    "scenarioId": "ft9_1",
+    "stage": "FT9",
+    "players": 9,
+    "stacksBB": [20,15,12,10,9,8,7,6,5],
+    "heroSeat": 0,
+    "payouts": [50,30,20],
+    "effectiveBB": 5,
+    "positions": ["BTN","SB","BB","UTG1","UTG2","LJ","HJ","CO","UTG"],
+    "tags": ["icm","mtt","FT9","finalTable"],
+    "weight": 1.0,
+    "spot": {
+      "id": "ft9_1_spot",
+      "hand": {
+        "heroCards": "Ah Kh",
+        "position": "btn",
+        "playerCount": 9,
+        "heroIndex": 0,
+        "actions": {},
+        "stacks": {}
+      },
+      "tags": []
+    }
+  },
+  {
+    "scenarioId": "ft6_1",
+    "stage": "FT6",
+    "players": 6,
+    "stacksBB": [25,20,15,10,8,5],
+    "heroSeat": 2,
+    "payouts": [60,25,15],
+    "effectiveBB": 5,
+    "positions": ["BTN","SB","BB","UTG","HJ","CO"],
+    "tags": ["icm","mtt","FT6"],
+    "weight": 1.0,
+    "spot": {
+      "id": "ft6_1_spot",
+      "hand": {
+        "heroCards": "Qh Qd",
+        "position": "co",
+        "playerCount": 6,
+        "heroIndex": 2,
+        "actions": {},
+        "stacks": {}
+      },
+      "tags": []
+    }
+  },
+  {
+    "scenarioId": "hu_1",
+    "stage": "HU",
+    "players": 2,
+    "stacksBB": [20,10],
+    "heroSeat": 0,
+    "payouts": [70,30],
+    "effectiveBB": 10,
+    "positions": ["BTN","BB"],
+    "tags": ["icm","mtt","HU"],
+    "weight": 1.0,
+    "spot": {
+      "id": "hu_1_spot",
+      "hand": {
+        "heroCards": "7s 7c",
+        "position": "btn",
+        "playerCount": 2,
+        "heroIndex": 0,
+        "actions": {},
+        "stacks": {}
+      },
+      "tags": []
+    }
+  }
+]

--- a/lib/services/autogen_pipeline_executor.dart
+++ b/lib/services/autogen_pipeline_executor.dart
@@ -296,7 +296,7 @@ class AutogenPipelineExecutor {
           metadata: Map<String, dynamic>.from(pack.meta),
         );
         if (icmInjector != null) {
-          model = icmInjector!.injectICMSpots(model);
+          model = await icmInjector!.inject(model);
           pack.spots = model.spots;
           pack.spotCount = model.spots.length;
           spots = model.spots;

--- a/lib/services/icm_scenario_library_injector.dart
+++ b/lib/services/icm_scenario_library_injector.dart
@@ -1,48 +1,231 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math';
+
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:yaml/yaml.dart';
+
 import '../models/training_pack_model.dart';
 import '../models/v2/training_pack_spot.dart';
-import '../data/icm_library.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import '../models/training_pack.dart' show TrainingType;
+import '../models/game_type.dart';
+import 'pack_novelty_guard_service.dart';
 
-class ICMScenarioLibraryInjector {
-  final Map<String, List<TrainingPackSpot>> _library;
+/// Represents a single ICM scenario loaded from the library.
+class ICMScenario {
+  final String scenarioId;
+  final String stage;
+  final int players;
+  final List<num> stacksBB;
+  final int heroSeat;
+  final List<num> payouts;
+  final num effectiveBB;
+  final List<String> positions;
+  final List<String> tags;
+  final TrainingPackSpot spot;
+  final double weight;
 
-  ICMScenarioLibraryInjector({Map<String, List<TrainingPackSpot>>? library})
-      : _library = library ?? ICMLibrary.spotsByType;
+  ICMScenario({
+    required this.scenarioId,
+    required this.stage,
+    required this.players,
+    required this.stacksBB,
+    required this.heroSeat,
+    required this.payouts,
+    required this.effectiveBB,
+    required this.positions,
+    required this.tags,
+    required this.spot,
+    required this.weight,
+  });
 
-  TrainingPackModel injectICMSpots(TrainingPackModel input) {
-    final stageTags = <String>{
-      for (final t in input.tags) t.toLowerCase(),
-    };
-    final stage = input.metadata['stage'];
-    if (stage is String) {
-      stageTags.add(stage.toLowerCase());
-    } else if (stage is List) {
-      stageTags.addAll(stage.map((e) => e.toString().toLowerCase()));
+  factory ICMScenario.fromJson(Map<String, dynamic> j) {
+    void require(String key, bool cond) {
+      if (!cond) throw FormatException('Invalid scenario: missing $key');
     }
 
-    final additions = <TrainingPackSpot>[];
-    for (final entry in _library.entries) {
-      if (stageTags.contains(entry.key.toLowerCase())) {
-        additions.addAll(entry.value.map(_cloneInjected));
+    require('scenarioId', j['scenarioId'] is String);
+    require('stage', j['stage'] is String);
+    require('players', j['players'] is int || j['players'] is num);
+    require('stacksBB', j['stacksBB'] is List);
+    require('heroSeat', j['heroSeat'] is int || j['heroSeat'] is num);
+    require('payouts', j['payouts'] is List);
+    require('effectiveBB', j['effectiveBB'] is int || j['effectiveBB'] is num);
+    require('positions', j['positions'] is List);
+    require('tags', j['tags'] is List);
+    require('spot', j['spot'] is Map);
+
+    return ICMScenario(
+      scenarioId: j['scenarioId'].toString(),
+      stage: j['stage'].toString(),
+      players: (j['players'] as num).toInt(),
+      stacksBB: [for (final v in (j['stacksBB'] as List)) (v as num)],
+      heroSeat: (j['heroSeat'] as num).toInt(),
+      payouts: [for (final v in (j['payouts'] as List)) (v as num)],
+      effectiveBB: j['effectiveBB'] as num,
+      positions: [for (final v in (j['positions'] as List)) v.toString()],
+      tags: [for (final v in (j['tags'] as List)) v.toString()],
+      spot: TrainingPackSpot.fromJson(
+          Map<String, dynamic>.from(j['spot'] as Map)),
+      weight: (j['weight'] as num?)?.toDouble() ?? 1.0,
+    );
+  }
+}
+
+/// Injects ICM scenarios into auto-generated packs based on policy rules.
+class ICMScenarioLibraryInjector {
+  final List<ICMScenario> _library;
+  final PackNoveltyGuardService? _noveltyGuard;
+
+  ICMScenarioLibraryInjector({
+    List<ICMScenario>? scenarios,
+    String libraryPath = 'assets/icm_scenarios',
+    PackNoveltyGuardService? noveltyGuard,
+  })  : _library = scenarios ?? _loadLibrary(libraryPath),
+        _noveltyGuard = noveltyGuard;
+
+  /// Loads scenario files from [path]. Supports JSON and YAML formats.
+  static List<ICMScenario> _loadLibrary(String path) {
+    final dir = Directory(path);
+    if (!dir.existsSync()) return [];
+    final scenarios = <ICMScenario>[];
+    for (final entity in dir.listSync()) {
+      if (entity is! File) continue;
+      final content = entity.readAsStringSync();
+      dynamic raw;
+      if (entity.path.endsWith('.yaml') || entity.path.endsWith('.yml')) {
+        raw = loadYaml(content);
+      } else {
+        raw = jsonDecode(content);
+      }
+      if (raw is List) {
+        for (final item in raw) {
+          if (item is Map) {
+            scenarios.add(ICMScenario.fromJson(Map<String, dynamic>.from(item)));
+          }
+        }
+      } else if (raw is Map) {
+        scenarios.add(ICMScenario.fromJson(Map<String, dynamic>.from(raw)));
       }
     }
-    if (additions.isEmpty) return input;
+    return scenarios;
+  }
 
-    final spots = <TrainingPackSpot>[...additions, ...input.spots];
+  /// Inject scenarios into [input] according to policy rules.
+  Future<TrainingPackModel> inject(TrainingPackModel input) async {
+    final prefs = await SharedPreferences.getInstance();
+    final enabled = prefs.getBool('icm.inject.enabled') ?? true;
+    if (!enabled || _library.isEmpty) return input;
+
+    final requireTags =
+        prefs.getStringList('icm.inject.requireTags') ?? ['icm', 'mtt'];
+    final packTags = {for (final t in input.tags) t.toLowerCase()};
+    if (!requireTags.every((t) => packTags.contains(t.toLowerCase()))) {
+      return input;
+    }
+
+    final ratio = prefs.getDouble('icm.inject.ratio') ?? 0.15;
+    final minSpots = prefs.getInt('icm.inject.minSpots') ?? 2;
+    final maxPerPack = prefs.getInt('icm.inject.maxPerPack') ?? 6;
+
+    var desired = (input.spots.length * ratio).round();
+    if (desired < minSpots) desired = minSpots;
+    if (desired > maxPerPack) desired = maxPerPack;
+    if (desired <= 0) return input;
+
+    final selected = _selectScenarios(input, desired);
+    if (selected.isEmpty) return input;
+
+    var model = _applyScenarios(input, selected);
+
+    // Novelty guard evaluation and fallback
+    if (_noveltyGuard != null) {
+      var tpl = _toTemplate(model);
+      final res = await _noveltyGuard!.evaluate(tpl);
+      if (res.isDuplicate && selected.length > 1) {
+        final reduced = selected.sublist(0, selected.length - 1);
+        model = _applyScenarios(input, reduced);
+        tpl = _toTemplate(model);
+        final res2 = await _noveltyGuard!.evaluate(tpl);
+        if (res2.isDuplicate) {
+          return input; // skip injection
+        }
+      }
+    }
+
+    return model;
+  }
+
+  List<ICMScenario> _selectScenarios(TrainingPackModel model, int desired) {
+    final packTags = {for (final t in model.tags) t.toLowerCase()};
+    var candidates = _library
+        .where((s) => s.tags.any((t) => packTags.contains(t.toLowerCase())))
+        .toList();
+    if (candidates.isEmpty) {
+      candidates = List<ICMScenario>.from(_library);
+      candidates.sort((a, b) => b.weight.compareTo(a.weight));
+    }
+    final rand = Random(model.id.hashCode);
+    candidates.shuffle(rand);
+    final usedStages = <String>{};
+    final selected = <ICMScenario>[];
+    for (final s in candidates) {
+      if (selected.length >= desired) break;
+      if (usedStages.contains(s.stage)) continue;
+      selected.add(s);
+      usedStages.add(s.stage);
+    }
+    return selected;
+  }
+
+  TrainingPackModel _applyScenarios(
+      TrainingPackModel base, List<ICMScenario> scenarios) {
+    if (scenarios.isEmpty) return base;
+    final additions = <TrainingPackSpot>[];
+    for (final sc in scenarios) {
+      final clone = TrainingPackSpot.fromJson(sc.spot.toJson());
+      clone.isInjected = true;
+      final stageTag = sc.stage.toLowerCase();
+      if (!clone.tags.contains('icm')) clone.tags.add('icm');
+      if (!clone.tags.contains(stageTag)) clone.tags.add(stageTag);
+      clone.meta['icm'] = {
+        'scenarioId': sc.scenarioId,
+        'stage': sc.stage,
+        'payouts': sc.payouts,
+        'stacksBB': sc.stacksBB,
+        'heroSeat': sc.heroSeat,
+        'effectiveBB': sc.effectiveBB,
+        'icmWeight': sc.weight,
+        'source': 'ICMScenarioLibraryInjector',
+      };
+      additions.add(clone);
+    }
+    final spots = <TrainingPackSpot>[...additions, ...base.spots];
+    final meta = Map<String, dynamic>.from(base.metadata);
+    meta['icmInjected'] = true;
+    meta['icmScenarioCount'] = additions.length;
     return TrainingPackModel(
-      id: input.id,
-      title: input.title,
+      id: base.id,
+      title: base.title,
       spots: spots,
-      tags: List<String>.from(input.tags),
-      metadata: Map<String, dynamic>.from(input.metadata),
+      tags: List<String>.from(base.tags),
+      metadata: meta,
     );
   }
 
-  TrainingPackSpot _cloneInjected(TrainingPackSpot s) {
-    final clone = TrainingPackSpot.fromJson(s.toJson());
-    if (!clone.tags.contains('icm')) {
-      clone.tags.add('icm');
-    }
-    clone.isInjected = true;
-    return clone;
+  TrainingPackTemplateV2 _toTemplate(TrainingPackModel m) {
+    return TrainingPackTemplateV2(
+      id: m.id,
+      name: m.title,
+      trainingType: TrainingType.custom,
+      spots: List<TrainingPackSpot>.from(m.spots),
+      spotCount: m.spots.length,
+      tags: List<String>.from(m.tags),
+      gameType: GameType.cash,
+      bb: m.spots.isNotEmpty ? m.spots.first.hand.stacks['0']?.toInt() ?? 0 : 0,
+      positions: [],
+      meta: Map<String, dynamic>.from(m.metadata),
+    );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -146,6 +146,7 @@ flutter:
     - assets/skills/cash/
     - assets/paths/
     - assets/precompiled_packs/
+    - assets/icm_scenarios/
 
 # Release build configuration for the demo entry point. Run
 # `flutter build apk --target=main.dart` to compile the demo

--- a/test/services/icm_scenario_library_injector_test.dart
+++ b/test/services/icm_scenario_library_injector_test.dart
@@ -1,39 +1,136 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
-import 'package:poker_analyzer/models/v2/hand_data.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
 import 'package:poker_analyzer/models/training_pack_model.dart';
+import 'package:poker_analyzer/models/v2/hand_data.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
 import 'package:poker_analyzer/services/icm_scenario_library_injector.dart';
+import 'package:poker_analyzer/services/pack_novelty_guard_service.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+
+class _FakeGuard extends PackNoveltyGuardService {
+  final bool Function(int) duplicateWhen;
+  int evaluateCalls = 0;
+
+  _FakeGuard(this.duplicateWhen) : super();
+
+  @override
+  Future<PackNoveltyResult> evaluate(TrainingPackTemplateV2 candidate) async {
+    evaluateCalls++;
+    final dup = duplicateWhen(candidate.spots.length);
+    return PackNoveltyResult(
+      isDuplicate: dup,
+      jaccard: dup ? 1.0 : 0.0,
+      overlapCount: dup ? candidate.spots.length : 0,
+      topSimilar: const [],
+    );
+  }
+
+  @override
+  Future<void> registerExport(TrainingPackTemplateV2 tpl) async {}
+}
+
+ICMScenario _scenario(String id, String stage) {
+  return ICMScenario(
+    scenarioId: id,
+    stage: stage,
+    players: 3,
+    stacksBB: const [10, 10, 10],
+    heroSeat: 0,
+    payouts: const [50, 30, 20],
+    effectiveBB: 10,
+    positions: const ['BTN', 'SB', 'BB'],
+    tags: const ['icm', 'mtt', 'finalTable'],
+    spot: TrainingPackSpot(id: '${id}_spot', hand: HandData()),
+    weight: 1.0,
+  );
+}
 
 void main() {
-  group('ICMScenarioLibraryInjector', () {
-    test('injects spots for final table tag', () {
-      final model = TrainingPackModel(
-        id: 'p1',
-        title: 'Pack',
-        spots: [TrainingPackSpot(id: 's1', hand: HandData())],
-        tags: ['finalTable'],
-        metadata: {},
-      );
-      final injector = ICMScenarioLibraryInjector();
+  TestWidgetsFlutterBinding.ensureInitialized();
 
-      final result = injector.injectICMSpots(model);
-      expect(result.spots.length, greaterThan(1));
-      final injected = result.spots.first;
-      expect(injected.tags.contains('icm'), isTrue);
-      expect(injected.isInjected, isTrue);
+  group('ICMScenarioLibraryInjector', () {
+    late List<ICMScenario> library;
+
+    setUp(() {
+      library = [
+        _scenario('s1', 'FT9'),
+        _scenario('s2', 'FT6'),
+        _scenario('s3', 'HU'),
+      ];
+      SharedPreferences.setMockInitialValues({
+        'icm.inject.enabled': true,
+        'icm.inject.minSpots': 2,
+        'icm.inject.ratio': 0.15,
+        'icm.inject.maxPerPack': 6,
+        'icm.inject.requireTags': ['finalTable'],
+      });
     });
 
-    test('does nothing when stage not matched', () {
-      final model = TrainingPackModel(
+    test('injects scenarios respecting policy and metadata', () async {
+      final pack = TrainingPackModel(
+        id: 'p1',
+        title: 'Pack',
+        spots: [for (var i = 0; i < 10; i++) TrainingPackSpot(id: 's$i', hand: HandData())],
+        tags: const ['finalTable'],
+        metadata: const {},
+      );
+      final injector = ICMScenarioLibraryInjector(scenarios: library);
+      final result = await injector.inject(pack);
+      expect(result.spots.length, 12);
+      expect(result.metadata['icmInjected'], isTrue);
+      expect(result.metadata['icmScenarioCount'], 2);
+      final stages = result.spots.take(2).map((s) => s.meta['icm']['stage']).toSet();
+      expect(stages.length, 2); // diversity by stage
+      expect(result.spots.first.tags.contains('icm'), isTrue);
+    });
+
+    test('does nothing when required tags missing', () async {
+      SharedPreferences.setMockInitialValues({
+        'icm.inject.enabled': true,
+        'icm.inject.requireTags': ['mtt'],
+      });
+      final pack = TrainingPackModel(
         id: 'p1',
         title: 'Pack',
         spots: [TrainingPackSpot(id: 's1', hand: HandData())],
-        tags: ['early'],
-        metadata: {},
+        tags: const ['cash'],
+        metadata: const {},
       );
-      final injector = ICMScenarioLibraryInjector();
-      final result = injector.injectICMSpots(model);
+      final injector = ICMScenarioLibraryInjector(scenarios: library);
+      final result = await injector.inject(pack);
       expect(result.spots.length, 1);
+      expect(result.metadata.containsKey('icmInjected'), isFalse);
+    });
+
+    test('selection is deterministic', () async {
+      final pack = TrainingPackModel(
+        id: 'p42',
+        title: 'Pack',
+        spots: [for (var i = 0; i < 5; i++) TrainingPackSpot(id: 's$i', hand: HandData())],
+        tags: const ['finalTable'],
+        metadata: const {},
+      );
+      final injector = ICMScenarioLibraryInjector(scenarios: library);
+      final r1 = await injector.inject(pack);
+      final r2 = await injector.inject(pack);
+      expect(r1.spots.first.id, r2.spots.first.id);
+    });
+
+    test('reduces injection count when novelty guard flags duplicate', () async {
+      final pack = TrainingPackModel(
+        id: 'p1',
+        title: 'Pack',
+        spots: [for (var i = 0; i < 10; i++) TrainingPackSpot(id: 's$i', hand: HandData())],
+        tags: const ['finalTable'],
+        metadata: const {},
+      );
+      final guard = _FakeGuard((count) => count > 11); // duplicate if >1 injected
+      final injector = ICMScenarioLibraryInjector(scenarios: library, noveltyGuard: guard);
+      final result = await injector.inject(pack);
+      expect(result.spots.length, 11);
+      expect(result.metadata['icmScenarioCount'], 1);
+      expect(guard.evaluateCalls, greaterThan(0));
     });
   });
 }


### PR DESCRIPTION
## Summary
- implement policy-driven ICMScenarioLibraryInjector with asset-backed scenario library
- auto-inject ICM spots into training packs and annotate with metadata
- add tests for policy, determinism, and novelty guard fallback

## Testing
- `flutter test test/services/icm_scenario_library_injector_test.dart` *(fails: command not found)*
- `dart test test/services/icm_scenario_library_injector_test.dart` *(fails: command not found)*
- `apt-get install -y dart` *(package not found)*


------
https://chatgpt.com/codex/tasks/task_e_68954bb8ce54832aad932a75f2979060