### PR TITLE
feat: add path injection engine skeleton

### DIFF
--- a/lib/models/injected_path_module.dart
+++ b/lib/models/injected_path_module.dart
@@ -1,0 +1,50 @@
+import 'dart:convert';
+
+/// Model representing an automatically injected learning path module.
+class InjectedPathModule {
+  final String moduleId;
+  final String clusterId;
+  final String themeName;
+  final List<String> theoryIds;
+  final List<String> boosterPackIds;
+  final String assessmentPackId;
+  final DateTime createdAt;
+  final String triggerReason;
+
+  const InjectedPathModule({
+    required this.moduleId,
+    required this.clusterId,
+    required this.themeName,
+    required this.theoryIds,
+    required this.boosterPackIds,
+    required this.assessmentPackId,
+    required this.createdAt,
+    required this.triggerReason,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'moduleId': moduleId,
+        'clusterId': clusterId,
+        'themeName': themeName,
+        'theoryIds': theoryIds,
+        'boosterPackIds': boosterPackIds,
+        'assessmentPackId': assessmentPackId,
+        'createdAt': createdAt.toIso8601String(),
+        'triggerReason': triggerReason,
+      };
+
+  static InjectedPathModule fromJson(Map<String, dynamic> json) =>
+      InjectedPathModule(
+        moduleId: json['moduleId'] as String,
+        clusterId: json['clusterId'] as String,
+        themeName: json['themeName'] as String,
+        theoryIds: (json['theoryIds'] as List).cast<String>(),
+        boosterPackIds: (json['boosterPackIds'] as List).cast<String>(),
+        assessmentPackId: json['assessmentPackId'] as String,
+        createdAt: DateTime.parse(json['createdAt'] as String),
+        triggerReason: json['triggerReason'] as String,
+      );
+
+  @override
+  String toString() => jsonEncode(toJson());
+}

--- a/lib/services/path_injection_engine.dart
+++ b/lib/services/path_injection_engine.dart
@@ -1,0 +1,133 @@
+import 'dart:convert';
+
+import 'package:crypto/crypto.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/injected_path_module.dart';
+import 'auto_skill_gap_clusterer.dart';
+import 'inline_pack_theory_clusterer.dart';
+import 'targeted_pack_booster_engine.dart';
+import 'path_registry.dart';
+import 'pack_novelty_guard_service.dart';
+import 'autogen_status_dashboard_service.dart';
+
+class PathInjectionDecision {
+  final bool shouldInject;
+  final String reason;
+  const PathInjectionDecision(this.shouldInject, this.reason);
+}
+
+/// Engine that injects theory, boosters and assessments for skill clusters
+/// directly into the user learning path.
+class PathInjectionEngine {
+  final InlinePackTheoryClusterer theoryClusterer;
+  final TargetedPackBoosterEngine boosterEngine;
+  final PackNoveltyGuardService noveltyGuard;
+  final AutogenStatusDashboardService dashboard;
+  final PathRegistry registry;
+
+  PathInjectionEngine({
+    InlinePackTheoryClusterer? theoryClusterer,
+    TargetedPackBoosterEngine? boosterEngine,
+    PackNoveltyGuardService? noveltyGuard,
+    AutogenStatusDashboardService? dashboard,
+    PathRegistry? registry,
+  })  : theoryClusterer = theoryClusterer ?? InlinePackTheoryClusterer(),
+        boosterEngine = boosterEngine ?? TargetedPackBoosterEngine(),
+        noveltyGuard = noveltyGuard ?? const PackNoveltyGuardService(),
+        dashboard = dashboard ?? AutogenStatusDashboardService.instance,
+        registry = registry ?? const PathRegistry();
+
+  Future<List<InjectedPathModule>> injectForClusters({
+    required List<SkillTagCluster> clusters,
+    required String userId,
+  }) async {
+    final prefs = await SharedPreferences.getInstance();
+    if (!(prefs.getBool('path.inject.enabled') ?? true)) return [];
+    final modules = <InjectedPathModule>[];
+    final skips = <String, int>{};
+    for (final c in clusters) {
+      final decision = await evaluateOpportunity(c, userId);
+      if (!decision.shouldInject) {
+        skips.update(decision.reason, (v) => v + 1, ifAbsent: () => 1);
+        continue;
+      }
+      final theoryIds = c.tags.take(2).map((t) => 'theory_$t').toList();
+      final boosters =
+          await boosterEngine.generateClusterBoosterPacks(clusters: [c]);
+      final boosterIds = boosters.map((b) => b.id).toList();
+      final assessmentId = 'assessment_${c.clusterId}';
+      final allIds = [...theoryIds, ...boosterIds, assessmentId];
+      if (!noveltyGuard.isNovel(c.tags.toSet(), allIds)) {
+        skips.update('novelty', (v) => v + 1, ifAbsent: () => 1);
+        continue;
+      }
+      final moduleId = _moduleId(userId, c.clusterId);
+      final module = InjectedPathModule(
+        moduleId: moduleId,
+        clusterId: c.clusterId,
+        themeName: c.themeName,
+        theoryIds: theoryIds,
+        boosterPackIds: boosterIds,
+        assessmentPackId: assessmentId,
+        createdAt: DateTime.now(),
+        triggerReason: 'autoCluster',
+      );
+      modules.add(module);
+      await registry.record(userId, c.tags);
+    }
+    dashboard.update(
+      'PathInjectionEngine',
+      AutogenStatus(
+        isRunning: false,
+        currentStage: jsonEncode({
+          'pathModulesInjected': modules.length,
+          'skips': skips,
+        }),
+        progress: 1.0,
+      ),
+    );
+    return modules;
+  }
+
+  Future<PathInjectionDecision> evaluateOpportunity(
+      SkillTagCluster c, String userId) async {
+    final prefs = await SharedPreferences.getInstance();
+    final recentHours = prefs.getInt('path.inject.recentHours') ?? 72;
+    final maxPerWeek = prefs.getInt('path.inject.maxPerWeek') ?? 3;
+    final maxActive = prefs.getInt('path.inject.maxActive') ?? 2;
+    final recent = Duration(hours: recentHours);
+    final hash = PathRegistry.hashTags(c.tags);
+    if (await registry.hasRecent(userId, hash, recent)) {
+      return const PathInjectionDecision(false, 'recent_duplicate');
+    }
+    final weekAgo = DateTime.now().subtract(const Duration(days: 7));
+    final weekCount = await registry.countSince(userId, weekAgo);
+    if (weekCount >= maxPerWeek) {
+      return const PathInjectionDecision(false, 'cadence_limit');
+    }
+    final activeCount = await registry.countSince(userId, weekAgo);
+    if (activeCount >= maxActive) {
+      return const PathInjectionDecision(false, 'cadence_limit');
+    }
+    return const PathInjectionDecision(true, 'ok');
+  }
+
+  /// Deterministic module id derived from user, cluster and week of year.
+  String _moduleId(String userId, String clusterId) {
+    final now = DateTime.now();
+    final week = _weekOfYear(now);
+    final input = '$userId|$clusterId|$week';
+    return md5.convert(utf8.encode(input)).toString();
+  }
+
+  int _weekOfYear(DateTime date) {
+    final firstDay = DateTime(date.year, 1, 1);
+    final diff = date.difference(firstDay);
+    return (diff.inDays / 7).floor();
+  }
+
+  Future<void> removeModule(String moduleId) async {
+    // Placeholder for rollback support.
+  }
+}

--- a/lib/services/path_registry.dart
+++ b/lib/services/path_registry.dart
@@ -1,0 +1,83 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+
+/// Entry representing a previously injected cluster for a user.
+class _PathRegistryEntry {
+  final String userId;
+  final String clusterHash;
+  final DateTime ts;
+
+  _PathRegistryEntry({
+    required this.userId,
+    required this.clusterHash,
+    required this.ts,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'userId': userId,
+        'clusterHash': clusterHash,
+        'ts': ts.toIso8601String(),
+      };
+
+  static _PathRegistryEntry fromJson(Map<String, dynamic> json) =>
+      _PathRegistryEntry(
+        userId: json['userId'] as String,
+        clusterHash: json['clusterHash'] as String,
+        ts: DateTime.parse(json['ts'] as String),
+      );
+}
+
+/// Simple file-backed registry to keep track of recent path injections.
+class PathRegistry {
+  final String path;
+
+  const PathRegistry({this.path = 'autogen_cache/path_registry.json'});
+
+  Future<List<_PathRegistryEntry>> _load() async {
+    final file = File(path);
+    if (!file.existsSync()) return [];
+    final raw = await file.readAsString();
+    if (raw.trim().isEmpty) return [];
+    final data = jsonDecode(raw) as List;
+    return data.map((e) => _PathRegistryEntry.fromJson(e)).toList();
+  }
+
+  Future<void> _save(List<_PathRegistryEntry> entries) async {
+    final file = File(path);
+    file.parent.createSync(recursive: true);
+    final data = entries.map((e) => e.toJson()).toList();
+    await file.writeAsString(jsonEncode(data));
+  }
+
+  Future<void> record(String userId, List<String> tags) async {
+    final entries = await _load();
+    final hash = hashTags(tags);
+    entries.add(_PathRegistryEntry(
+        userId: userId, clusterHash: hash, ts: DateTime.now()));
+    await _save(entries);
+  }
+
+  Future<bool> hasRecent(
+      String userId, String clusterHash, Duration within) async {
+    final entries = await _load();
+    final cutoff = DateTime.now().subtract(within);
+    return entries.any((e) =>
+        e.userId == userId &&
+        e.clusterHash == clusterHash &&
+        e.ts.isAfter(cutoff));
+  }
+
+  Future<int> countSince(String userId, DateTime since) async {
+    final entries = await _load();
+    return entries
+        .where((e) => e.userId == userId && e.ts.isAfter(since))
+        .length;
+  }
+
+  static String hashTags(List<String> tags) {
+    final sorted = List<String>.from(tags)..sort();
+    return md5.convert(utf8.encode(sorted.join('|'))).toString();
+  }
+}

--- a/test/services/path_injection_engine_test.dart
+++ b/test/services/path_injection_engine_test.dart
@@ -1,0 +1,79 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/services/auto_skill_gap_clusterer.dart';
+import 'package:poker_analyzer/services/path_injection_engine.dart';
+import 'package:poker_analyzer/services/path_registry.dart';
+import 'package:poker_analyzer/services/targeted_pack_booster_engine.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+
+class _FakeBoosterEngine extends TargetedPackBoosterEngine {
+  @override
+  Future<List<TrainingPackTemplateV2>> generateClusterBoosterPacks({
+    required List<SkillTagCluster> clusters,
+    String triggerReason = 'cluster',
+  }) async {
+    return clusters
+        .map((c) => TrainingPackTemplateV2(
+              id: 'boost_${c.clusterId}',
+              name: 'Boost',
+              trainingType: TrainingType.booster,
+              tags: c.tags,
+            ))
+        .toList();
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('PathInjectionEngine', () {
+    late Directory tempDir;
+    late PathRegistry registry;
+    late PathInjectionEngine engine;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('registry');
+      registry = PathRegistry(path: '${tempDir.path}/reg.json');
+      engine = PathInjectionEngine(
+        boosterEngine: _FakeBoosterEngine(),
+        registry: registry,
+      );
+      SharedPreferences.setMockInitialValues({
+        'path.inject.enabled': true,
+        'path.inject.recentHours': 72,
+        'path.inject.maxPerWeek': 3,
+        'path.inject.maxActive': 2,
+      });
+    });
+
+    tearDown(() async {
+      await tempDir.delete(recursive: true);
+    });
+
+    test('injects module for eligible cluster', () async {
+      final cluster = SkillTagCluster(
+          tags: ['a', 'b'], clusterId: 'c1', themeName: 'Theme');
+      final modules =
+          await engine.injectForClusters(clusters: [cluster], userId: 'u1');
+      expect(modules, hasLength(1));
+      final m = modules.first;
+      expect(m.boosterPackIds, contains('boost_c1'));
+      final count = await registry.countSince(
+          'u1', DateTime.now().subtract(const Duration(days: 1)));
+      expect(count, 1);
+    });
+
+    test('respects recency limit', () async {
+      final cluster =
+          SkillTagCluster(tags: ['a'], clusterId: 'c1', themeName: 'Theme');
+      await registry.record('u1', cluster.tags);
+      final decision = await engine.evaluateOpportunity(cluster, 'u1');
+      expect(decision.shouldInject, isFalse);
+      expect(decision.reason, 'recent_duplicate');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- sketch PathInjectionEngine to assemble theory, booster, and assessment modules
- add file-backed PathRegistry for recent injection tracking
- define InjectedPathModule model and basic tests

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68954ee5b2e4832a814efc7a1c7b6254