### PR TITLE
feat: add theory link auto injector

### DIFF
--- a/assets/theory_index.json
+++ b/assets/theory_index.json
@@ -1,0 +1,5 @@
+[
+  {"id":"th_push","title":"Push/Fold Basics","uri":"theory/push_fold_basics","tags":["push","icm"]},
+  {"id":"th_bb_def","title":"BB Defense vs 2.5x","uri":"theory/bb_defense_2_5x","tags":["bb","defense"]},
+  {"id":"th_mono","title":"Monotone Flops Strategy","uri":"theory/monotone_flops","tags":["monotone","postflop"]}
+]

--- a/lib/services/autogen_status_dashboard_service.dart
+++ b/lib/services/autogen_status_dashboard_service.dart
@@ -45,6 +45,11 @@ class AutogenStatusDashboardService {
   final ValueNotifier<List<String>> boosterIdsNotifier =
       ValueNotifier(const <String>[]);
 
+  final ValueNotifier<int> theoryClustersInjectedNotifier =
+      ValueNotifier(0);
+  final ValueNotifier<int> theoryLinksInjectedNotifier =
+      ValueNotifier(0);
+
   final ValueNotifier<int> pathModulesInjectedNotifier = ValueNotifier(0);
   final ValueNotifier<int> pathModulesInProgressNotifier = ValueNotifier(0);
   final ValueNotifier<int> pathModulesCompletedNotifier = ValueNotifier(0);
@@ -130,6 +135,17 @@ class AutogenStatusDashboardService {
     boostersSkippedNotifier.value = Map.unmodifiable(map);
   }
 
+  void recordTheoryInjection({int clusters = 0, int links = 0}) {
+    if (clusters != 0) {
+      theoryClustersInjectedNotifier.value =
+          theoryClustersInjectedNotifier.value + clusters;
+    }
+    if (links != 0) {
+      theoryLinksInjectedNotifier.value =
+          theoryLinksInjectedNotifier.value + links;
+    }
+  }
+
   void recordPathModuleInjected() {
     pathModulesInjectedNotifier.value = pathModulesInjectedNotifier.value + 1;
   }
@@ -183,5 +199,7 @@ class AutogenStatusDashboardService {
     pathModulesInProgressNotifier.value = 0;
     pathModulesCompletedNotifier.value = 0;
     avgPassRateNotifier.value = 0.0;
+    theoryClustersInjectedNotifier.value = 0;
+    theoryLinksInjectedNotifier.value = 0;
   }
 }

--- a/lib/services/mistake_telemetry_store.dart
+++ b/lib/services/mistake_telemetry_store.dart
@@ -1,0 +1,38 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Stores per-tag mistake telemetry in [SharedPreferences].
+class MistakeTelemetryStore {
+  static const _errPrefix = 'telemetry.errors.';
+  static const _seenPrefix = 'telemetry.lastSeen.';
+
+  /// Returns error rates per tag in the range 0..1.
+  Future<Map<String, double>> getErrorRates() async {
+    final prefs = await SharedPreferences.getInstance();
+    final res = <String, double>{};
+    for (final key in prefs.getKeys()) {
+      if (key.startsWith(_errPrefix)) {
+        final tag = key.substring(_errPrefix.length);
+        final v = prefs.getDouble(key) ?? 0;
+        res[tag] = v.clamp(0.0, 1.0);
+      }
+    }
+    return res;
+  }
+
+  /// Records a mistake for [tag] with optional [weight].
+  Future<void> recordMistake(String tag, {double weight = 1.0}) async {
+    final prefs = await SharedPreferences.getInstance();
+    final key = '$_errPrefix$tag';
+    final current = prefs.getDouble(key) ?? 0.0;
+    await prefs.setDouble(key, (current + weight).clamp(0.0, 1.0));
+    await prefs.setString('$_seenPrefix$tag', DateTime.now().toIso8601String());
+  }
+
+  /// Returns last time a mistake for [tag] was recorded.
+  Future<DateTime?> lastSeen(String tag) async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString('$_seenPrefix$tag');
+    if (raw == null) return null;
+    return DateTime.tryParse(raw);
+  }
+}

--- a/lib/services/theory_library_index.dart
+++ b/lib/services/theory_library_index.dart
@@ -1,0 +1,43 @@
+import 'dart:convert';
+
+import 'package:flutter/services.dart' show AssetBundle, rootBundle;
+
+import 'inline_pack_theory_clusterer.dart';
+
+/// Loads theory resources from [assetPath] and caches them in memory.
+class TheoryLibraryIndex {
+  final String assetPath;
+  final AssetBundle _bundle;
+  List<TheoryResource>? _cache;
+
+  TheoryLibraryIndex({
+    this.assetPath = 'assets/theory_index.json',
+    AssetBundle? bundle,
+  }) : _bundle = bundle ?? rootBundle;
+
+  /// Returns all valid theory resources.
+  /// Invalid entries (missing fields or empty tags) are skipped.
+  Future<List<TheoryResource>> all() async {
+    if (_cache != null) return _cache!;
+    final raw = await _bundle.loadString(assetPath);
+    final data = jsonDecode(raw);
+    final items = <TheoryResource>[];
+    if (data is List) {
+      for (final e in data) {
+        if (e is Map) {
+          final id = e['id'] as String?;
+          final title = e['title'] as String?;
+          final uri = e['uri'] as String?;
+          final tags = (e['tags'] as List?)?.cast<String>();
+          if (id != null && title != null && uri != null && tags != null && tags.isNotEmpty) {
+            items.add(
+              TheoryResource(id: id, title: title, uri: uri, tags: tags),
+            );
+          }
+        }
+      }
+    }
+    _cache = items;
+    return items;
+  }
+}

--- a/lib/services/theory_link_auto_injector.dart
+++ b/lib/services/theory_link_auto_injector.dart
@@ -1,87 +1,202 @@
-import '../models/v2/training_pack_spot.dart';
-import '../models/autogen_status.dart';
-import 'mini_lesson_library_service.dart';
+import 'dart:math';
+
+import 'package:collection/collection.dart';
+
+import '../models/injected_path_module.dart';
+import '../models/training_pack_model.dart';
 import 'autogen_status_dashboard_service.dart';
+import 'inline_pack_theory_clusterer.dart';
+import 'learning_path_store.dart';
+import 'mistake_telemetry_store.dart';
+import 'theory_library_index.dart';
+import 'theory_novelty_registry.dart';
+import '../core/training/library/training_pack_library_v2.dart';
+import '../models/autogen_status.dart';
 
-/// Automatically links [TrainingPackSpot]s with relevant theory lessons.
-///
-/// For each spot, the first matching lesson found by tag is written to the
-/// [TrainingPackSpot.theoryId] field. Existing values are never overwritten.
-/// A summary log is printed indicating how many spots were updated.
 class TheoryLinkAutoInjector {
-  TheoryLinkAutoInjector({MiniLessonLibraryService? library})
-      : _library = library ?? MiniLessonLibraryService.instance;
+  TheoryLinkAutoInjector({
+    required this.store,
+    required this.libraryIndex,
+    required this.telemetry,
+    required this.noveltyRegistry,
+    InlinePackTheoryClusterer? clusterer,
+    AutogenStatusDashboardService? dashboard,
+    TrainingPackLibraryV2? packLibrary,
+    this.maxPerModule = 3,
+    this.maxPerPack = 2,
+    this.maxPerSpot = 2,
+    this.weightErrorRate = 0.5,
+    this.weightTagMatch = 0.5,
+    this.noveltyRecent = const Duration(hours: 72),
+    this.noveltyMinOverlap = 0.6,
+  })  : clusterer =
+            clusterer ?? InlinePackTheoryClusterer(maxPerPack: maxPerPack, maxPerSpot: maxPerSpot),
+        dashboard = dashboard ?? AutogenStatusDashboardService.instance,
+        packLibrary = packLibrary ?? TrainingPackLibraryV2.instance;
 
-  final MiniLessonLibraryService _library;
+  final LearningPathStore store;
+  final TheoryLibraryIndex libraryIndex;
+  final MistakeTelemetryStore telemetry;
+  final TheoryNoveltyRegistry noveltyRegistry;
+  final InlinePackTheoryClusterer clusterer;
+  final AutogenStatusDashboardService dashboard;
+  final TrainingPackLibraryV2 packLibrary;
+  final int maxPerModule;
+  final int maxPerPack;
+  final int maxPerSpot;
+  final double weightErrorRate;
+  final double weightTagMatch;
+  final Duration noveltyRecent;
+  final double noveltyMinOverlap;
 
-  /// Scans [spots] and injects `theoryId` references when a matching lesson is
-  /// found. Only the first matching tag per spot is used.
-  Future<void> injectAll(List<TrainingPackSpot> spots) async {
-    final status = AutogenStatusDashboardService.instance;
-    status.update(
-      'TheoryLinkAutoInjector',
-      const AutogenStatus(
-        isRunning: true,
-        currentStage: 'inject',
-        progress: 0,
-      ),
-    );
-    try {
-      var injected = 0;
-      for (var i = 0; i < spots.length; i++) {
-        final spot = spots[i];
-        if (spot.theoryId != null && spot.theoryId!.isNotEmpty) {
-          status.update(
-            'TheoryLinkAutoInjector',
-            AutogenStatus(
-              isRunning: true,
-              currentStage: 'inject',
-              progress: (i + 1) / spots.length,
-            ),
-          );
-          continue;
-        }
-        for (final tag in spot.tags) {
-          final lesson = _library.findLessonByTag(tag);
-          if (lesson != null) {
-            spot.theoryId = lesson.id;
-            injected++;
-            break;
+  Future<int> injectForUser(String userId) async {
+    final modules = await store.listModules(userId);
+    final pending = modules.where((m) => m.status == 'pending' || m.status == 'in_progress');
+    if (pending.isEmpty) return 0;
+    final library = await libraryIndex.all();
+    final errorRates = await telemetry.getErrorRates();
+    var injected = 0;
+
+    for (final module in pending) {
+      final demand = <String>{};
+      final clusterTags = (module.metrics['clusterTags'] as List?)?.cast<String>();
+      if (clusterTags != null && clusterTags.isNotEmpty) {
+        demand.addAll(clusterTags.map((e) => e.toLowerCase()));
+      } else {
+        for (final id in [...module.boosterPackIds, module.assessmentPackId]) {
+          final tpl = packLibrary.getById(id);
+          if (tpl != null) {
+            demand.addAll(tpl.tags.map((e) => e.toLowerCase()));
           }
         }
-        status.update(
-          'TheoryLinkAutoInjector',
-          AutogenStatus(
-            isRunning: true,
-            currentStage: 'inject',
-            progress: (i + 1) / spots.length,
-          ),
+      }
+      if (demand.isEmpty) continue;
+
+      final candidates = <_Scored>[];
+      for (final res in library) {
+        final j = _jaccard(res.tags, demand);
+        if (j == 0) continue;
+        var err = 0.0;
+        for (final t in res.tags) {
+          err = max(err, errorRates[t] ?? 0);
+        }
+        final score = weightTagMatch * j + weightErrorRate * err;
+        candidates.add(_Scored(res, score));
+      }
+      if (candidates.isEmpty) continue;
+      candidates.sort((a, b) => b.score.compareTo(a.score));
+
+      final uncovered = Set<String>.from(demand);
+      final selected = <_Scored>[];
+      final remaining = List<_Scored>.from(candidates);
+      while (selected.length < maxPerModule && uncovered.isNotEmpty && remaining.isNotEmpty) {
+        remaining.sort((a, b) {
+          final gainA = a.resource.tags.where(uncovered.contains).length;
+          final gainB = b.resource.tags.where(uncovered.contains).length;
+          if (gainA != gainB) return gainB.compareTo(gainA);
+          return b.score.compareTo(a.score);
+        });
+        final best = remaining.removeAt(0);
+        final gain = best.resource.tags.where(uncovered.contains).length;
+        if (gain == 0 && selected.isNotEmpty) break;
+        selected.add(best);
+        uncovered.removeAll(best.resource.tags);
+      }
+      if (selected.isEmpty) continue;
+      final theoryIds = selected.map((e) => e.resource.id).toList();
+
+      if (await noveltyRegistry.isRecentDuplicate(userId, demand.toList(), theoryIds,
+          within: noveltyRecent, minOverlap: noveltyMinOverlap)) {
+        if (candidates.length > selected.length) {
+          final weakest = selected.reduce((a, b) => a.score <= b.score ? a : b);
+          final replacement = candidates.firstWhere(
+              (c) => !theoryIds.contains(c.resource.id) && c.resource.id != weakest.resource.id,
+              orElse: () => weakest);
+          if (replacement != weakest) {
+            final idx = selected.indexOf(weakest);
+            selected[idx] = replacement;
+          }
+        }
+        final swappedIds = selected.map((e) => e.resource.id).toList();
+        if (await noveltyRegistry.isRecentDuplicate(userId, demand.toList(), swappedIds,
+            within: noveltyRecent, minOverlap: noveltyMinOverlap)) {
+          dashboard.update(
+            'TheoryLinkAutoInjector',
+            AutogenStatus(isRunning: false, currentStage: 'novelty-skip:${module.moduleId}', progress: 1.0),
+          );
+          continue;
+        } else {
+          theoryIds
+            ..clear()
+            ..addAll(swappedIds);
+        }
+      }
+
+      if (ListEquality().equals(module.theoryIds, theoryIds)) {
+        continue; // idempotent
+      }
+
+      final durations = Map<String, int>.from(module.itemsDurations ?? {});
+      durations['theoryMins'] = theoryIds.length * 5;
+
+      final updated = InjectedPathModule(
+        moduleId: module.moduleId,
+        clusterId: module.clusterId,
+        themeName: module.themeName,
+        theoryIds: theoryIds,
+        boosterPackIds: module.boosterPackIds,
+        assessmentPackId: module.assessmentPackId,
+        createdAt: module.createdAt,
+        triggerReason: module.triggerReason,
+        status: module.status,
+        metrics: module.metrics,
+        itemsDurations: durations,
+      );
+
+      await store.upsertModule(userId, updated);
+      await noveltyRegistry.record(userId, demand.toList(), theoryIds);
+      injected++;
+
+      var clustersCount = 0;
+      var linksCount = 0;
+      for (final pid in [...module.boosterPackIds, module.assessmentPackId]) {
+        final tpl = packLibrary.getById(pid);
+        if (tpl == null) continue;
+        final model = TrainingPackModel(
+          id: tpl.id,
+          title: tpl.name,
+          spots: tpl.spots,
+          tags: tpl.tags,
+          metadata: Map<String, dynamic>.from(tpl.meta),
         );
+        final attached = clusterer.attach(
+          model,
+          library,
+          mistakeTelemetry: errorRates,
+        );
+        final clusters = (attached.metadata['theoryClusters'] as List?)?.length ?? 0;
+        clustersCount += clusters;
+        for (final s in attached.spots) {
+          final links = (s.meta['theoryLinks'] as List?)?.length ?? 0;
+          linksCount += links;
+        }
       }
-      if (injected > 0) {
-        // ignore: avoid_print
-        print('TheoryLinkAutoInjector: injected $injected links');
-      }
-      status.update(
-        'TheoryLinkAutoInjector',
-        const AutogenStatus(
-          isRunning: false,
-          currentStage: 'complete',
-          progress: 1,
-        ),
-      );
-    } catch (e) {
-      status.update(
-        'TheoryLinkAutoInjector',
-        AutogenStatus(
-          isRunning: false,
-          currentStage: 'error',
-          progress: 0,
-          lastError: e.toString(),
-        ),
-      );
-      rethrow;
+      dashboard.recordTheoryInjection(clusters: clustersCount, links: linksCount);
     }
+    return injected;
   }
 }
 
+class _Scored {
+  final TheoryResource resource;
+  final double score;
+  _Scored(this.resource, this.score);
+}
+
+double _jaccard(List<String> a, Set<String> b) {
+  final setA = a.toSet();
+  final inter = setA.intersection(b).length;
+  final union = setA.union(b).length;
+  if (union == 0) return 0;
+  return inter / union;
+}

--- a/lib/services/theory_novelty_registry.dart
+++ b/lib/services/theory_novelty_registry.dart
@@ -1,0 +1,65 @@
+import 'dart:convert';
+import 'dart:io';
+
+/// Stores recent theory bundles per user to avoid repetition.
+class TheoryNoveltyRegistry {
+  final String path;
+  TheoryNoveltyRegistry({this.path = 'autogen_cache/theory_bundles.json'});
+
+  Future<List<Map<String, dynamic>>> _load() async {
+    final file = File(path);
+    if (!file.existsSync()) return [];
+    final raw = await file.readAsString();
+    if (raw.trim().isEmpty) return [];
+    final data = jsonDecode(raw);
+    if (data is List) {
+      return data.map((e) => Map<String, dynamic>.from(e as Map)).toList();
+    }
+    return [];
+  }
+
+  Future<void> _save(List<Map<String, dynamic>> list) async {
+    final file = File(path);
+    file.parent.createSync(recursive: true);
+    await file.writeAsString(jsonEncode(list));
+  }
+
+  Future<void> record(String userId, List<String> tags, List<String> theoryIds) async {
+    final list = await _load();
+    list.add({
+      'userId': userId,
+      'tags': List<String>.from(tags)..sort(),
+      'theoryIds': List<String>.from(theoryIds)..sort(),
+      'ts': DateTime.now().toIso8601String(),
+    });
+    await _save(list);
+  }
+
+  Future<bool> isRecentDuplicate(
+    String userId,
+    List<String> tags,
+    List<String> theoryIds, {
+    Duration within = const Duration(hours: 72),
+    double minOverlap = 0.6,
+  }) async {
+    final list = await _load();
+    if (list.isEmpty) return false;
+    final now = DateTime.now();
+    final tagSet = tags.toSet();
+    final idSet = theoryIds.toSet();
+    for (final item in list) {
+      if (item['userId'] != userId) continue;
+      final ts = DateTime.tryParse(item['ts']?.toString() ?? '');
+      if (ts == null || now.difference(ts) > within) continue;
+      final prevTags = (item['tags'] as List).cast<String>().toSet();
+      if (prevTags.length != tagSet.length || !prevTags.containsAll(tagSet)) continue;
+      final prevIds = (item['theoryIds'] as List).cast<String>().toSet();
+      final inter = prevIds.intersection(idSet).length;
+      final union = prevIds.union(idSet).length;
+      if (union == 0) continue;
+      final overlap = inter / union;
+      if (overlap >= minOverlap) return true;
+    }
+    return false;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -137,6 +137,7 @@ flutter:
     - assets/lessons/
     - assets/lesson_tracks/
     - assets/pack_matrix.json
+    - assets/theory_index.json
     - assets/learning_intro.svg
     - assets/training_paths.yaml
     - assets/learning_paths/

--- a/test/services/mistake_telemetry_store_test.dart
+++ b/test/services/mistake_telemetry_store_test.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/mistake_telemetry_store.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('records and persists error rates', () async {
+    SharedPreferences.setMockInitialValues({});
+    final store = MistakeTelemetryStore();
+    await store.recordMistake('push', weight: 0.2);
+    await store.recordMistake('push', weight: 0.3);
+    final rates = await store.getErrorRates();
+    expect(rates['push'], closeTo(0.5, 0.001));
+    final seen = await store.lastSeen('push');
+    expect(seen, isNotNull);
+
+    final store2 = MistakeTelemetryStore();
+    final rates2 = await store2.getErrorRates();
+    expect(rates2['push'], closeTo(0.5, 0.001));
+  });
+}

--- a/test/services/theory_library_index_test.dart
+++ b/test/services/theory_library_index_test.dart
@@ -1,0 +1,13 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/theory_library_index.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('loads theory index and validates entries', () async {
+    final index = TheoryLibraryIndex();
+    final items = await index.all();
+    expect(items.length, 3);
+    expect(items.any((e) => e.id == 'th_push'), isTrue);
+  });
+}

--- a/test/services/theory_novelty_registry_test.dart
+++ b/test/services/theory_novelty_registry_test.dart
@@ -1,0 +1,22 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/services/theory_novelty_registry.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('records and detects duplicates', () async {
+    final cacheDir = Directory('test_cache');
+    if (cacheDir.existsSync()) cacheDir.deleteSync(recursive: true);
+    final path = 'test_cache/theory_bundles.json';
+    final file = File(path);
+    if (file.existsSync()) file.deleteSync();
+    final reg = TheoryNoveltyRegistry(path: path);
+    await reg.record('u1', ['a', 'b'], ['t1', 't2']);
+    final dup = await reg.isRecentDuplicate('u1', ['a', 'b'], ['t1', 't2']);
+    expect(dup, isTrue);
+    final notDup = await reg.isRecentDuplicate('u1', ['a', 'b'], ['t1']);
+    expect(notDup, isFalse);
+  });
+}


### PR DESCRIPTION
## Summary
- add theory resource index and services for telemetry and novelty
- implement theory link auto injector with tag match and error rates
- extend dashboard with theory injection counters

## Testing
- `flutter pub get` *(failed: command not found)*
- `flutter test test/services/theory_library_index_test.dart test/services/mistake_telemetry_store_test.dart test/services/theory_novelty_registry_test.dart test/services/theory_link_auto_injector_test.dart test/e2e_theory_injection_path_test.dart` *(not run: flutter missing)*

------
https://chatgpt.com/codex/tasks/task_e_689555b9a868832abcdc8bf5f506814a