### PR TITLE
feat: add decay weighting to theory injector

### DIFF
--- a/lib/services/path_injection_engine.dart
+++ b/lib/services/path_injection_engine.dart
@@ -92,6 +92,9 @@ class PathInjectionEngine {
         assessmentPackId: assessmentId,
         createdAt: DateTime.now(),
         triggerReason: 'autoCluster',
+        metrics: {
+          'clusterTags': c.tags,
+        },
         itemsDurations: {
           'theoryMins': theoryMins,
           'boosterMins': boosterMins,

--- a/test/services/theory_link_auto_injector_decay_weight_test.dart
+++ b/test/services/theory_link_auto_injector_decay_weight_test.dart
@@ -1,0 +1,82 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/services/theory_link_auto_injector.dart';
+import 'package:poker_analyzer/services/theory_library_index.dart';
+import 'package:poker_analyzer/services/learning_path_store.dart';
+import 'package:poker_analyzer/services/mistake_telemetry_store.dart';
+import 'package:poker_analyzer/services/theory_novelty_registry.dart';
+import 'package:poker_analyzer/services/decay_tag_retention_tracker_service.dart';
+import 'package:poker_analyzer/models/injected_path_module.dart';
+import 'package:poker_analyzer/core/training/library/training_pack_library_v2.dart';
+
+class _FakeBundle extends CachingAssetBundle {
+  final String data;
+  _FakeBundle(this.data);
+  @override
+  Future<String> loadString(String key, {bool cache = true}) async => data;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('items with higher decay rank earlier', () async {
+    final dir = Directory('test_cache_decay');
+    if (dir.existsSync()) {
+      dir.deleteSync(recursive: true);
+    }
+
+    SharedPreferences.setMockInitialValues({
+      'telemetry.errors.x': 0.1,
+      'telemetry.errors.y': 0.1,
+    });
+
+    final retention = DecayTagRetentionTrackerService();
+    await retention.markTheoryReviewed('x',
+        time: DateTime.now().subtract(const Duration(days: 30)));
+    await retention.markTheoryReviewed('y',
+        time: DateTime.now().subtract(const Duration(days: 1)));
+
+    final bundle = _FakeBundle('[{"id":"th_x","title":"X","uri":"x","tags":["x"]},'
+        '{"id":"th_y","title":"Y","uri":"y","tags":["y"]}]');
+
+    final store = LearningPathStore(rootDir: 'test_cache_decay/path');
+    final module = InjectedPathModule(
+      moduleId: 'm1',
+      clusterId: 'c1',
+      themeName: 't',
+      theoryIds: const [],
+      boosterPackIds: const [],
+      assessmentPackId: '',
+      createdAt: DateTime.now(),
+      triggerReason: 'test',
+      itemsDurations: const {},
+      metrics: const {
+        'clusterTags': ['x', 'y'],
+      },
+    );
+    await store.upsertModule('u1', module);
+
+    final packLibrary = TrainingPackLibraryV2.instance;
+    packLibrary.clear();
+
+    final injector = TheoryLinkAutoInjector(
+      store: store,
+      libraryIndex: TheoryLibraryIndex(assetPath: 'unused', bundle: bundle),
+      telemetry: MistakeTelemetryStore(),
+      noveltyRegistry: TheoryNoveltyRegistry(path: 'test_cache_decay/novelty.json'),
+      retention: retention,
+      packLibrary: packLibrary,
+      maxPerModule: 1,
+    );
+
+    final count = await injector.injectForUser('u1');
+    expect(count, 1);
+
+    final modules = await store.listModules('u1');
+    expect(modules.first.theoryIds, ['th_x']);
+  });
+}


### PR DESCRIPTION
## Summary
- incorporate decay scores and save strategy into TheoryLinkAutoInjector
- persist cluster tags when injecting path modules
- add unit test verifying decay-weighted ranking

## Testing
- `dart test test/services/theory_link_auto_injector_decay_weight_test.dart` *(fails: command not found)*
- `flutter test test/services/theory_link_auto_injector_decay_weight_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895586cd21c832ab7b91a15f6ebc9f9