### PR TITLE
feat: schedule theory injection for learning paths

### DIFF
--- a/lib/services/app_init_service.dart
+++ b/lib/services/app_init_service.dart
@@ -1,4 +1,5 @@
 import 'yaml_pack_archive_auto_cleaner_service.dart';
+import 'theory_injection_scheduler_service.dart';
 
 class AppInitService {
   AppInitService._();
@@ -6,5 +7,6 @@ class AppInitService {
 
   Future<void> init() async {
     await const YamlPackArchiveAutoCleanerService().clean();
+    await TheoryInjectionSchedulerService.instance.start();
   }
 }

--- a/lib/services/learning_path_store.dart
+++ b/lib/services/learning_path_store.dart
@@ -1,6 +1,8 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:path/path.dart' as p;
+
 import '../models/injected_path_module.dart';
 
 /// Persists injected learning path modules per user.
@@ -10,6 +12,19 @@ class LearningPathStore {
   const LearningPathStore({this.rootDir = 'autogen_cache/learning_paths'});
 
   File _fileFor(String userId) => File('$rootDir/$userId.json');
+
+  Future<List<String>> listUsers() async {
+    final dir = Directory(rootDir);
+    if (!dir.existsSync()) return [];
+    final users = <String>[];
+    await for (final entity in dir.list()) {
+      if (entity is File && entity.path.endsWith('.json')) {
+        final id = p.basenameWithoutExtension(entity.path);
+        if (id.isNotEmpty) users.add(id);
+      }
+    }
+    return users;
+  }
 
   Future<List<InjectedPathModule>> listModules(String userId) async {
     final file = _fileFor(userId);
@@ -74,4 +89,3 @@ class LearningPathStore {
     await _save(userId, modules);
   }
 }
-


### PR DESCRIPTION
## Summary
- add TheoryInjectionSchedulerService to periodically auto-inject theory links
- track last-run per user and invoke after path module generation
- start scheduler on app init and expose user listing in LearningPathStore

## Testing
- `dart analyze lib/services/learning_path_store.dart lib/services/theory_injection_scheduler_service.dart lib/services/autogen_pipeline_executor.dart lib/services/app_init_service.dart` *(fails: Target of URI doesn't exist: 'package:shared_preferences/shared_preferences.dart' ...)*
- `dart test` *(fails: depends on flutter_test from sdk which doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_689559e62a24832aab5bfd7daa5f9795