### PR TITLE
feat: add theory injection scheduler panel

### DIFF
--- a/lib/widgets/theory_injection_dashboard_panel.dart
+++ b/lib/widgets/theory_injection_dashboard_panel.dart
@@ -1,0 +1,102 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../services/autogen_status_dashboard_service.dart';
+import '../services/theory_injection_scheduler_service.dart';
+import '../models/autogen_status.dart';
+import '../providers/provider_globals.dart';
+
+/// Dashboard panel displaying TheoryInjectionScheduler stats.
+class TheoryInjectionDashboardPanel extends StatelessWidget {
+  const TheoryInjectionDashboardPanel({super.key});
+
+  Future<DateTime?> _loadLastRun() async {
+    final prefs = await SharedPreferences.getInstance();
+    final uid = auth.uid;
+    if (uid != null) {
+      final raw = prefs.getString('theoryScheduler.lastRun.' + uid);
+      if (raw != null) return DateTime.tryParse(raw);
+    }
+    DateTime? latest;
+    for (final k in prefs.getKeys()) {
+      if (!k.startsWith('theoryScheduler.lastRun.')) continue;
+      final raw = prefs.getString(k);
+      final dt = raw != null ? DateTime.tryParse(raw) : null;
+      if (dt != null && (latest == null || dt.isAfter(latest))) {
+        latest = dt;
+      }
+    }
+    return latest;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final notifier = AutogenStatusDashboardService.instance.getStatusNotifier(
+      'TheoryInjectionScheduler',
+    );
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: ValueListenableBuilder<AutogenStatus>(
+          valueListenable: notifier,
+          builder: (context, status, _) {
+            int runs = 0;
+            int skipped = 0;
+            try {
+              final data =
+                  jsonDecode(status.currentStage) as Map<String, dynamic>;
+              runs = data['runs'] as int? ?? 0;
+              skipped = data['skipped'] as int? ?? 0;
+            } catch (_) {}
+            return FutureBuilder<DateTime?>(
+              future: _loadLastRun(),
+              builder: (context, snap) {
+                final dt = snap.data;
+                final last = dt != null
+                    ? DateFormat('yyyy-MM-dd HH:mm').format(dt.toLocal())
+                    : '-';
+                return Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        const Text('Status: '),
+                        Text(
+                          status.isRunning ? 'Running' : 'Idle',
+                          style: TextStyle(
+                            color: status.isRunning
+                                ? Colors.green
+                                : Colors.grey,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 8),
+                    Text('Last run: ' + last),
+                    const SizedBox(height: 8),
+                    Text(
+                      'Runs: ' +
+                          runs.toString() +
+                          '  |  Skipped: ' +
+                          skipped.toString(),
+                    ),
+                    const SizedBox(height: 12),
+                    ElevatedButton(
+                      onPressed: () => TheoryInjectionSchedulerService.instance
+                          .runNow(force: true),
+                      child: const Text('Run Now'),
+                    ),
+                  ],
+                );
+              },
+            );
+          },
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- expose per-module status notifier in AutogenStatusDashboardService
- add TheoryInjectionDashboardPanel widget with run controls
- surface scheduler panel on Autogen metrics dashboard

## Testing
- `dart format lib/services/autogen_status_dashboard_service.dart lib/widgets/theory_injection_dashboard_panel.dart lib/screens/autogen_metrics_dashboard_screen.dart`
- `flutter test` *(fails: The Dart compiler exited unexpectedly)*

------
https://chatgpt.com/codex/tasks/task_e_68955bfc384c832ab3e503e4557f896f