### PR TITLE
feat: central theory link config and policy engine

### DIFF
--- a/lib/services/app_init_service.dart
+++ b/lib/services/app_init_service.dart
@@ -1,5 +1,6 @@
 import 'yaml_pack_archive_auto_cleaner_service.dart';
 import 'theory_injection_scheduler_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class AppInitService {
   AppInitService._();
@@ -7,6 +8,12 @@ class AppInitService {
 
   Future<void> init() async {
     await const YamlPackArchiveAutoCleanerService().clean();
+    final prefs = await SharedPreferences.getInstance();
+    for (final k in prefs.getKeys().toList()) {
+      if (k.startsWith('theory.cap.session.')) {
+        await prefs.remove(k);
+      }
+    }
     await TheoryInjectionSchedulerService.instance.start();
   }
 }

--- a/lib/services/theory_link_config_service.dart
+++ b/lib/services/theory_link_config_service.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class TheoryLinkConfigService {
+  TheoryLinkConfigService._() : notifier = ValueNotifier(TheoryLinkConfig.defaults);
+  static final TheoryLinkConfigService instance = TheoryLinkConfigService._();
+
+  final ValueNotifier<TheoryLinkConfig> notifier;
+  TheoryLinkConfig get value => notifier.value;
+
+  Future<void> reload() async {
+    final prefs = await SharedPreferences.getInstance();
+    final c = TheoryLinkConfig(
+      maxPerModule: prefs.getInt('theory.maxPerModule') ?? 3,
+      maxPerPack: prefs.getInt('theory.maxPerPack') ?? 2,
+      maxPerSpot: prefs.getInt('theory.maxPerSpot') ?? 2,
+      noveltyRecent: Duration(hours: prefs.getInt('theory.noveltyRecentHours') ?? 72),
+      noveltyMinOverlap: prefs.getDouble('theory.noveltyMinOverlap') ?? 0.6,
+      wTag: prefs.getDouble('theory.weight.tag') ?? 0.2,
+      wErr: prefs.getDouble('theory.weight.errorRate') ?? 0.5,
+      wDecay: prefs.getDouble('theory.weight.decay') ?? 0.3,
+      ablationEnabled: prefs.getBool('theory.ablation') ?? false,
+      perSessionCap: prefs.getInt('theory.cap.session') ?? 4,
+      perDayCap: prefs.getInt('theory.cap.day') ?? 8,
+      perTagCooldownHours: prefs.getInt('theory.tag.cooldownHours') ?? 24,
+    );
+    notifier.value = c;
+  }
+}
+
+class TheoryLinkConfig {
+  final int maxPerModule, maxPerPack, maxPerSpot;
+  final Duration noveltyRecent;
+  final double noveltyMinOverlap;
+  final double wTag, wErr, wDecay;
+  final bool ablationEnabled;
+  final int perSessionCap;
+  final int perDayCap;
+  final int perTagCooldownHours;
+
+  const TheoryLinkConfig({
+    required this.maxPerModule,
+    required this.maxPerPack,
+    required this.maxPerSpot,
+    required this.noveltyRecent,
+    required this.noveltyMinOverlap,
+    required this.wTag,
+    required this.wErr,
+    required this.wDecay,
+    required this.ablationEnabled,
+    required this.perSessionCap,
+    required this.perDayCap,
+    required this.perTagCooldownHours,
+  });
+
+  static const TheoryLinkConfig defaults = TheoryLinkConfig(
+    maxPerModule: 3,
+    maxPerPack: 2,
+    maxPerSpot: 2,
+    noveltyRecent: Duration(hours: 72),
+    noveltyMinOverlap: 0.6,
+    wTag: 0.2,
+    wErr: 0.5,
+    wDecay: 0.3,
+    ablationEnabled: false,
+    perSessionCap: 4,
+    perDayCap: 8,
+    perTagCooldownHours: 24,
+  );
+}

--- a/lib/services/theory_link_policy_engine.dart
+++ b/lib/services/theory_link_policy_engine.dart
@@ -1,0 +1,51 @@
+import 'package:intl/intl.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'theory_link_config_service.dart';
+
+class TheoryLinkPolicyEngine {
+  TheoryLinkPolicyEngine({required SharedPreferences prefs}) : _prefs = prefs;
+
+  final SharedPreferences _prefs;
+
+  Future<bool> canInject(String userId, Set<String> demandTags) async {
+    final cfg = TheoryLinkConfigService.instance.value;
+    final sessionKey = 'theory.cap.session.$userId';
+    final sessionCount = _prefs.getInt(sessionKey) ?? 0;
+    if (sessionCount >= cfg.perSessionCap) return false;
+
+    final date = DateFormat('yyyyMMdd').format(DateTime.now().toUtc());
+    final dayKey = 'theory.cap.day.$userId.$date';
+    final dayCount = _prefs.getInt(dayKey) ?? 0;
+    if (dayCount >= cfg.perDayCap) return false;
+
+    final now = DateTime.now().toUtc();
+    for (final tag in demandTags) {
+      final key = 'theory.tag.last.$userId.$tag';
+      final raw = _prefs.getString(key);
+      if (raw == null) continue;
+      final last = DateTime.tryParse(raw);
+      if (last != null && now.difference(last) < Duration(hours: cfg.perTagCooldownHours)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  Future<void> onInjected(String userId, Set<String> demandTags) async {
+    final sessionKey = 'theory.cap.session.$userId';
+    final sessionCount = (_prefs.getInt(sessionKey) ?? 0) + 1;
+    await _prefs.setInt(sessionKey, sessionCount);
+
+    final date = DateFormat('yyyyMMdd').format(DateTime.now().toUtc());
+    final dayKey = 'theory.cap.day.$userId.$date';
+    final dayCount = (_prefs.getInt(dayKey) ?? 0) + 1;
+    await _prefs.setInt(dayKey, dayCount);
+
+    final now = DateTime.now().toUtc().toIso8601String();
+    for (final tag in demandTags) {
+      final key = 'theory.tag.last.$userId.$tag';
+      await _prefs.setString(key, now);
+    }
+  }
+}

--- a/test/e2e_theory_injection_path_test.dart
+++ b/test/e2e_theory_injection_path_test.dart
@@ -15,6 +15,8 @@ import 'package:poker_analyzer/services/theory_novelty_registry.dart';
 import 'package:poker_analyzer/services/theory_link_auto_injector.dart';
 import 'package:poker_analyzer/services/autogen_status_dashboard_service.dart';
 import 'package:poker_analyzer/core/training/library/training_pack_library_v2.dart';
+import 'package:poker_analyzer/services/theory_link_policy_engine.dart';
+import 'package:poker_analyzer/services/theory_link_config_service.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -26,6 +28,9 @@ void main() {
       'telemetry.errors.bb': 0.8,
       'telemetry.errors.push': 0.2,
     });
+    final prefs = await SharedPreferences.getInstance();
+    await TheoryLinkConfigService.instance.reload();
+    final policy = TheoryLinkPolicyEngine(prefs: prefs);
 
     final packLibrary = TrainingPackLibraryV2.instance;
     packLibrary.clear();
@@ -61,6 +66,7 @@ void main() {
       noveltyRegistry: TheoryNoveltyRegistry(path: 'test_cache/theory_bundles.json'),
       dashboard: AutogenStatusDashboardService(),
       packLibrary: packLibrary,
+      policy: policy,
     );
 
     final first = await injector.injectForUser('u1');

--- a/test/services/theory_link_auto_injector_ablation_test.dart
+++ b/test/services/theory_link_auto_injector_ablation_test.dart
@@ -1,0 +1,77 @@
+import 'dart:io';
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/models/injected_path_module.dart';
+import 'package:poker_analyzer/models/v2/hand_data.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/services/learning_path_store.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+import 'package:poker_analyzer/services/mistake_telemetry_store.dart';
+import 'package:poker_analyzer/services/theory_library_index.dart';
+import 'package:poker_analyzer/services/theory_link_auto_injector.dart';
+import 'package:poker_analyzer/services/theory_link_config_service.dart';
+import 'package:poker_analyzer/services/theory_link_policy_engine.dart';
+import 'package:poker_analyzer/services/theory_novelty_registry.dart';
+import 'package:poker_analyzer/services/autogen_status_dashboard_service.dart';
+import 'package:poker_analyzer/core/training/library/training_pack_library_v2.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('ablation flag disables injection', () async {
+    final dir = Directory('test_cache_ablation');
+    if (dir.existsSync()) dir.deleteSync(recursive: true);
+    SharedPreferences.setMockInitialValues({'theory.ablation': true});
+    final prefs = await SharedPreferences.getInstance();
+    await TheoryLinkConfigService.instance.reload();
+    final policy = TheoryLinkPolicyEngine(prefs: prefs);
+
+    final packLibrary = TrainingPackLibraryV2.instance;
+    packLibrary.clear();
+    final spot = TrainingPackSpot(id: 's1', hand: HandData(), tags: ['a'], categories: []);
+    final pack = TrainingPackTemplateV2(
+      id: 'p1',
+      name: 'Pack',
+      trainingType: TrainingType.pushFold,
+      spots: [spot],
+      spotCount: 1,
+      tags: ['a'],
+    );
+    packLibrary.addPack(pack);
+
+    final store = LearningPathStore(rootDir: 'test_cache_ablation/path');
+    final module = InjectedPathModule(
+      moduleId: 'm1',
+      clusterId: 'c1',
+      themeName: 't',
+      theoryIds: const [],
+      boosterPackIds: const ['p1'],
+      assessmentPackId: 'p1',
+      createdAt: DateTime.now(),
+      triggerReason: 'test',
+      itemsDurations: const {},
+    );
+    await store.upsertModule('u1', module);
+
+    final injector = TheoryLinkAutoInjector(
+      store: store,
+      libraryIndex: TheoryLibraryIndex(),
+      telemetry: MistakeTelemetryStore(),
+      noveltyRegistry: TheoryNoveltyRegistry(path: 'test_cache_ablation/novelty.json'),
+      policy: policy,
+      packLibrary: packLibrary,
+      dashboard: AutogenStatusDashboardService(),
+    );
+
+    final count = await injector.injectForUser('u1');
+    expect(count, 0);
+    final status = AutogenStatusDashboardService.instance
+        .getStatusNotifier('TheoryLinkPolicy')
+        .value;
+    final data = jsonDecode(status.currentStage) as Map<String, dynamic>;
+    expect(data['ablation'], true);
+  });
+}

--- a/test/services/theory_link_auto_injector_decay_weight_test.dart
+++ b/test/services/theory_link_auto_injector_decay_weight_test.dart
@@ -12,6 +12,8 @@ import 'package:poker_analyzer/services/theory_novelty_registry.dart';
 import 'package:poker_analyzer/services/decay_tag_retention_tracker_service.dart';
 import 'package:poker_analyzer/models/injected_path_module.dart';
 import 'package:poker_analyzer/core/training/library/training_pack_library_v2.dart';
+import 'package:poker_analyzer/services/theory_link_policy_engine.dart';
+import 'package:poker_analyzer/services/theory_link_config_service.dart';
 
 class _FakeBundle extends CachingAssetBundle {
   final String data;
@@ -32,7 +34,11 @@ void main() {
     SharedPreferences.setMockInitialValues({
       'telemetry.errors.x': 0.1,
       'telemetry.errors.y': 0.1,
+      'theory.maxPerModule': 1,
     });
+    final prefs = await SharedPreferences.getInstance();
+    await TheoryLinkConfigService.instance.reload();
+    final policy = TheoryLinkPolicyEngine(prefs: prefs);
 
     final retention = DecayTagRetentionTrackerService();
     await retention.markTheoryReviewed('x',
@@ -70,7 +76,7 @@ void main() {
       noveltyRegistry: TheoryNoveltyRegistry(path: 'test_cache_decay/novelty.json'),
       retention: retention,
       packLibrary: packLibrary,
-      maxPerModule: 1,
+      policy: policy,
     );
 
     final count = await injector.injectForUser('u1');

--- a/test/services/theory_link_auto_injector_test.dart
+++ b/test/services/theory_link_auto_injector_test.dart
@@ -14,6 +14,8 @@ import 'package:poker_analyzer/services/learning_path_store.dart';
 import 'package:poker_analyzer/services/theory_novelty_registry.dart';
 import 'package:poker_analyzer/services/autogen_status_dashboard_service.dart';
 import 'package:poker_analyzer/core/training/library/training_pack_library_v2.dart';
+import 'package:poker_analyzer/services/theory_link_policy_engine.dart';
+import 'package:poker_analyzer/services/theory_link_config_service.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -25,6 +27,9 @@ void main() {
       'telemetry.errors.bb': 0.8,
       'telemetry.errors.push': 0.2,
     });
+    final prefs = await SharedPreferences.getInstance();
+    await TheoryLinkConfigService.instance.reload();
+    final policy = TheoryLinkPolicyEngine(prefs: prefs);
 
     final packLibrary = TrainingPackLibraryV2.instance;
     packLibrary.clear();
@@ -63,6 +68,7 @@ void main() {
       noveltyRegistry: registry,
       dashboard: AutogenStatusDashboardService(),
       packLibrary: packLibrary,
+      policy: policy,
     );
 
     final injected = await injector.injectForUser('u1');

--- a/test/services/theory_link_config_service_test.dart
+++ b/test/services/theory_link_config_service_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/theory_link_config_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('loads values from prefs', () async {
+    SharedPreferences.setMockInitialValues({
+      'theory.maxPerModule': 5,
+      'theory.maxPerPack': 4,
+      'theory.maxPerSpot': 3,
+      'theory.noveltyRecentHours': 10,
+      'theory.noveltyMinOverlap': 0.7,
+      'theory.weight.tag': 0.1,
+      'theory.weight.errorRate': 0.6,
+      'theory.weight.decay': 0.3,
+      'theory.ablation': true,
+      'theory.cap.session': 9,
+      'theory.cap.day': 20,
+      'theory.tag.cooldownHours': 12,
+    });
+    await TheoryLinkConfigService.instance.reload();
+    final cfg = TheoryLinkConfigService.instance.value;
+    expect(cfg.maxPerModule, 5);
+    expect(cfg.maxPerPack, 4);
+    expect(cfg.maxPerSpot, 3);
+    expect(cfg.noveltyRecent, const Duration(hours: 10));
+    expect(cfg.noveltyMinOverlap, 0.7);
+    expect(cfg.wTag, 0.1);
+    expect(cfg.wErr, 0.6);
+    expect(cfg.wDecay, 0.3);
+    expect(cfg.ablationEnabled, true);
+    expect(cfg.perSessionCap, 9);
+    expect(cfg.perDayCap, 20);
+    expect(cfg.perTagCooldownHours, 12);
+  });
+}

--- a/test/services/theory_link_policy_engine_test.dart
+++ b/test/services/theory_link_policy_engine_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/theory_link_config_service.dart';
+import 'package:poker_analyzer/services/theory_link_policy_engine.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('perSessionCap=1 blocks second inject', () async {
+    SharedPreferences.setMockInitialValues({
+      'theory.cap.session': 1,
+      'theory.cap.day': 99,
+      'theory.tag.cooldownHours': 24,
+    });
+    final prefs = await SharedPreferences.getInstance();
+    await TheoryLinkConfigService.instance.reload();
+    final policy = TheoryLinkPolicyEngine(prefs: prefs);
+    final allowed1 = await policy.canInject('u1', {'t'});
+    expect(allowed1, true);
+    await policy.onInjected('u1', {'t'});
+    final allowed2 = await policy.canInject('u1', {'t'});
+    expect(allowed2, false);
+  });
+
+  test('perDayCap=1 blocks second inject same day', () async {
+    SharedPreferences.setMockInitialValues({
+      'theory.cap.session': 99,
+      'theory.cap.day': 1,
+      'theory.tag.cooldownHours': 24,
+    });
+    final prefs = await SharedPreferences.getInstance();
+    await TheoryLinkConfigService.instance.reload();
+    final policy = TheoryLinkPolicyEngine(prefs: prefs);
+    expect(await policy.canInject('u1', {'a'}), true);
+    await policy.onInjected('u1', {'a'});
+    expect(await policy.canInject('u1', {'b'}), false);
+  });
+
+  test('perTagCooldown blocks same tag', () async {
+    SharedPreferences.setMockInitialValues({
+      'theory.cap.session': 99,
+      'theory.cap.day': 99,
+      'theory.tag.cooldownHours': 24,
+    });
+    final prefs = await SharedPreferences.getInstance();
+    await TheoryLinkConfigService.instance.reload();
+    final policy = TheoryLinkPolicyEngine(prefs: prefs);
+    expect(await policy.canInject('u1', {'x'}), true);
+    await policy.onInjected('u1', {'x'});
+    expect(await policy.canInject('u1', {'x'}), false);
+  });
+}


### PR DESCRIPTION
## Summary
- centralize theory link configuration via `TheoryLinkConfigService`
- enforce per-user caps and cooldowns with `TheoryLinkPolicyEngine`
- wire auto-injector to live config, policy, and dashboard ablation status
- reset session caps on app init and surface ablation badge in dashboard
- add comprehensive unit tests for config, policy, and ablation behavior

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68955ed9a56c832aab0f538009a2d0c2