### PR TITLE
feat: add adaptive planner and user skill model

### DIFF
--- a/lib/services/adaptive_training_planner.dart
+++ b/lib/services/adaptive_training_planner.dart
@@ -1,0 +1,121 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'auto_skill_gap_clusterer.dart';
+import 'autogen_status_dashboard_service.dart';
+import 'decay_tag_retention_tracker_service.dart';
+import 'learning_path_store.dart';
+import 'user_skill_model_service.dart';
+import '../models/autogen_status.dart';
+
+class AdaptivePlan {
+  final List<SkillTagCluster> clusters;
+  final int estMins;
+  final Map<String, double> tagWeights;
+
+  const AdaptivePlan({
+    required this.clusters,
+    required this.estMins,
+    required this.tagWeights,
+  });
+}
+
+class AdaptiveTrainingPlanner {
+  final UserSkillModelService skillService;
+  final DecayTagRetentionTrackerService retention;
+  final AutoSkillGapClusterer clusterer;
+  final LearningPathStore store;
+
+  const AdaptiveTrainingPlanner({
+    UserSkillModelService? skillService,
+    DecayTagRetentionTrackerService? retention,
+    AutoSkillGapClusterer? clusterer,
+    LearningPathStore? store,
+  })  : skillService = skillService ?? UserSkillModelService.instance,
+        retention = retention ?? const DecayTagRetentionTrackerService(),
+        clusterer = clusterer ?? const AutoSkillGapClusterer(),
+        store = store ?? const LearningPathStore();
+
+  Future<AdaptivePlan> plan({
+    required String userId,
+    required int durationMinutes,
+    String? audience,
+  }) async {
+    final prefs = await SharedPreferences.getInstance();
+    final wErr = prefs.getDouble('planner.weight.error') ?? 0.55;
+    final wDecay = prefs.getDouble('planner.weight.decay') ?? 0.30;
+    final wImpact = prefs.getDouble('planner.weight.impact') ?? 0.15;
+    final maxTags = prefs.getInt('planner.maxTagsPerPlan') ?? 6;
+    final padding = prefs.getInt('planner.budgetPaddingMins') ?? 5;
+
+    final skills = await skillService.getSkills(userId);
+    final decays = await retention.getAllDecayScores();
+    final tagScores = <String, double>{};
+    final allTags = {...skills.keys, ...decays.keys};
+    for (final tag in allTags) {
+      final mastery = skills[tag]?.mastery ?? 0.0;
+      final decay = decays[tag] ?? 1.0;
+      final impact =
+          (prefs.getDouble('planner.impact.$tag') ?? 1.0).clamp(0.0, 2.0);
+      tagScores[tag] =
+          wErr * (1 - mastery) + wDecay * decay + wImpact * impact;
+    }
+    final sorted = tagScores.entries.toList()
+      ..sort((a, b) => b.value.compareTo(a.value));
+
+    // Estimate average durations
+    final modules = await store.listModules(userId);
+    var boosterSum = 0, boosterCount = 0;
+    var assessSum = 0, assessCount = 0;
+    for (final m in modules) {
+      final d = m.itemsDurations;
+      if (d != null) {
+        if (d['boosterMins'] != null) {
+          boosterSum += d['boosterMins']!;
+          boosterCount++;
+        }
+        if (d['assessmentMins'] != null) {
+          assessSum += d['assessmentMins']!;
+          assessCount++;
+        }
+      }
+    }
+    final boosterAvg =
+        boosterCount > 0 ? (boosterSum / boosterCount).round() : 10;
+    final assessAvg =
+        assessCount > 0 ? (assessSum / assessCount).round() : 8;
+    final perTag = boosterAvg + assessAvg;
+    final budget = durationMinutes - padding;
+    var used = 0;
+    final selected = <String>[];
+    for (final e in sorted) {
+      if (selected.length >= maxTags) break;
+      if (used + perTag > budget) continue;
+      selected.add(e.key);
+      used += perTag;
+    }
+    final clusters = clusterer.clusterWeakTags(
+      weakTags: selected,
+      spotTags: const {},
+    );
+
+    AutogenStatusDashboardService.instance.update(
+      'AdaptivePlanner',
+      AutogenStatus(
+        isRunning: false,
+        currentStage: jsonEncode({
+          'budget': durationMinutes,
+          'tags': selected,
+          'clusters': clusters.length,
+        }),
+      ),
+    );
+
+    final weights = {
+      for (final t in selected) t: tagScores[t]!,
+    };
+    return AdaptivePlan(clusters: clusters, estMins: used, tagWeights: weights);
+  }
+}
+

--- a/lib/services/learning_path_store.dart
+++ b/lib/services/learning_path_store.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:path/path.dart' as p;
 
 import '../models/injected_path_module.dart';
+import 'user_skill_model_service.dart';
 
 /// Persists injected learning path modules per user.
 class LearningPathStore {
@@ -81,6 +82,16 @@ class LearningPathStore {
     }
     modules[idx] = module.copyWith(status: status, metrics: metrics);
     await _save(userId, modules);
+    if (status == 'completed') {
+      final tags = (metrics['clusterTags'] as List?)?.cast<String>() ?? const [];
+      if (tags.isNotEmpty) {
+        await UserSkillModelService.instance.recordAttempt(
+          userId,
+          tags,
+          correct: (passRate ?? 0.0) > 0.6,
+        );
+      }
+    }
   }
 
   Future<void> removeModule(String userId, String moduleId) async {

--- a/lib/services/user_skill_model_service.dart
+++ b/lib/services/user_skill_model_service.dart
@@ -1,0 +1,130 @@
+import 'dart:convert';
+import 'dart:math';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'decay_tag_retention_tracker_service.dart';
+
+class TagSkill {
+  final double mastery;
+  final double confidence;
+  final DateTime lastSeen;
+  final int seenCount;
+
+  const TagSkill({
+    required this.mastery,
+    required this.confidence,
+    required this.lastSeen,
+    required this.seenCount,
+  });
+
+  TagSkill copyWith({
+    double? mastery,
+    double? confidence,
+    DateTime? lastSeen,
+    int? seenCount,
+  }) => TagSkill(
+        mastery: mastery ?? this.mastery,
+        confidence: confidence ?? this.confidence,
+        lastSeen: lastSeen ?? this.lastSeen,
+        seenCount: seenCount ?? this.seenCount,
+      );
+
+  Map<String, dynamic> toJson() => {
+        'mastery': mastery,
+        'confidence': confidence,
+        'lastSeen': lastSeen.toIso8601String(),
+        'seenCount': seenCount,
+      };
+
+  static TagSkill fromJson(Map<String, dynamic> json) => TagSkill(
+        mastery: (json['mastery'] as num).toDouble(),
+        confidence: (json['confidence'] as num).toDouble(),
+        lastSeen: DateTime.parse(json['lastSeen'] as String),
+        seenCount: json['seenCount'] as int,
+      );
+}
+
+class UserSkillModelService {
+  UserSkillModelService._();
+  static final UserSkillModelService instance = UserSkillModelService._();
+
+  static const _prefix = 'skillModel.';
+
+  Future<Map<String, TagSkill>> getSkills(String userId) async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString('$_prefix$userId');
+    if (raw == null) return {};
+    try {
+      final data = jsonDecode(raw) as Map;
+      return data.map((k, v) => MapEntry(
+            k as String,
+            TagSkill.fromJson(Map<String, dynamic>.from(v as Map)),
+          ));
+    } catch (_) {
+      return {};
+    }
+  }
+
+  Future<void> _save(String userId, Map<String, TagSkill> skills) async {
+    final prefs = await SharedPreferences.getInstance();
+    final data = skills.map((k, v) => MapEntry(k, v.toJson()));
+    final json = jsonEncode(data);
+    // safe write with temp key then swap
+    await prefs.setString('$_prefix$userId.tmp', json);
+    await prefs.setString('$_prefix$userId', json);
+  }
+
+  Future<void> recordAttempt(String userId, List<String> tags,
+      {required bool correct}) async {
+    final skills = await getSkills(userId);
+    final now = DateTime.now();
+    for (final t in tags) {
+      final tag = t.toLowerCase();
+      final existing = skills[tag];
+      final mastery = existing?.mastery ?? 0.5;
+      final confidence = existing?.confidence ?? 0.0;
+      final seen = existing?.seenCount ?? 0;
+      final result = correct ? 1.0 : 0.0;
+      final alpha = (0.4 / sqrt(seen + 1)).clamp(0.02, 0.25);
+      final mPrime = (1 - alpha) * mastery + alpha * result;
+      const gamma = 0.02;
+      const delta = 0.002;
+      const epsilon = 0.15;
+      final confPrime =
+          (confidence + ((result - mPrime).abs() < epsilon ? gamma : 0.0) - delta)
+              .clamp(0.0, 1.0);
+      skills[tag] = TagSkill(
+        mastery: mPrime,
+        confidence: confPrime,
+        lastSeen: now,
+        seenCount: seen + 1,
+      );
+    }
+    await _save(userId, skills);
+  }
+
+  Future<void> decayTick(String userId) async {
+    final skills = await getSkills(userId);
+    if (skills.isEmpty) return;
+    final now = DateTime.now();
+    var changed = false;
+    const startDays = 7;
+    const rate = 0.01;
+    final retention = const DecayTagRetentionTrackerService();
+    skills.forEach((tag, skill) {
+      final days = now.difference(skill.lastSeen).inDays;
+      if (days > startDays) {
+        final decay = (days - startDays) * rate;
+        final newMastery = (skill.mastery * (1 - decay)).clamp(0.0, 1.0);
+        if (newMastery != skill.mastery) {
+          skills[tag] = skill.copyWith(mastery: newMastery);
+          changed = true;
+          retention.notifyDecayStateChanged(tag);
+        }
+      }
+    });
+    if (changed) await _save(userId, skills);
+  }
+}
+

--- a/test/e2e_adaptive_plan_injection_test.dart
+++ b/test/e2e_adaptive_plan_injection_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/services/autogen_pipeline_executor.dart';
+import 'package:poker_analyzer/services/learning_path_store.dart';
+import 'package:poker_analyzer/services/user_skill_model_service.dart';
+import 'package:poker_analyzer/services/autogen_status_dashboard_service.dart';
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('planAndInjectForUser creates modules and is idempotent', () async {
+    const user = 'u3';
+    await UserSkillModelService.instance
+        .recordAttempt(user, ['tag'], correct: false);
+    await UserSkillModelService.instance
+        .recordAttempt(user, ['tag'], correct: false);
+
+    final exec = AutogenPipelineExecutor();
+    await exec.planAndInjectForUser(user, durationMinutes: 40);
+    final store = const LearningPathStore();
+    final modules1 = await store.listModules(user);
+    expect(modules1, isNotEmpty);
+
+    final prefs = await SharedPreferences.getInstance();
+    final lastRun = prefs.getString('theoryScheduler.lastRun.$user');
+    expect(lastRun, isNotNull);
+
+    final status =
+        AutogenStatusDashboardService.instance.getStatus('AdaptivePlanner');
+    expect(status, isNotNull);
+
+    await exec.planAndInjectForUser(user, durationMinutes: 40);
+    final modules2 = await store.listModules(user);
+    expect(modules2.length, modules1.length);
+  });
+}
+

--- a/test/services/adaptive_training_planner_test.dart
+++ b/test/services/adaptive_training_planner_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/services/adaptive_training_planner.dart';
+import 'package:poker_analyzer/services/user_skill_model_service.dart';
+import 'package:poker_analyzer/services/decay_tag_retention_tracker_service.dart';
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('selects high score tags under budget respecting maxTagsPerPlan', () async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt('planner.maxTagsPerPlan', 2);
+    await prefs.setInt('planner.budgetPaddingMins', 5);
+    await prefs.setDouble('planner.impact.a', 2.0);
+    await prefs.setDouble('planner.impact.c', 0.5);
+
+    const user = 'u1';
+    final skills = UserSkillModelService.instance;
+    await skills.recordAttempt(user, ['a'], correct: false);
+    await skills.recordAttempt(user, ['a'], correct: false);
+    await skills.recordAttempt(user, ['b'], correct: true);
+    await skills.recordAttempt(user, ['c'], correct: false);
+    await skills.recordAttempt(user, ['c'], correct: false);
+
+    final retention = const DecayTagRetentionTrackerService();
+    await retention.markBoosterCompleted('b', time: DateTime.now());
+    await retention.markBoosterCompleted(
+        'c', time: DateTime.now().subtract(const Duration(days: 15)));
+
+    final planner = AdaptiveTrainingPlanner();
+    final plan = await planner.plan(userId: user, durationMinutes: 40);
+    expect(plan.tagWeights.length, 2);
+    expect(plan.tagWeights.keys, containsAll(['a', 'c']));
+    expect(plan.tagWeights.keys, isNot(contains('b')));
+  });
+}
+

--- a/test/services/user_skill_model_service_test.dart
+++ b/test/services/user_skill_model_service_test.dart
@@ -1,0 +1,47 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/services/user_skill_model_service.dart';
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('recordAttempt updates mastery and confidence', () async {
+    const user = 'u1';
+    await UserSkillModelService.instance
+        .recordAttempt(user, ['tag1'], correct: true);
+    var skills = await UserSkillModelService.instance.getSkills(user);
+    final first = skills['tag1']!;
+    await UserSkillModelService.instance
+        .recordAttempt(user, ['tag1'], correct: true);
+    skills = await UserSkillModelService.instance.getSkills(user);
+    final second = skills['tag1']!;
+    expect(second.mastery, greaterThan(first.mastery));
+    expect(second.confidence, greaterThan(first.confidence));
+  });
+
+  test('decayTick lowers mastery for stale tags', () async {
+    const user = 'u2';
+    await UserSkillModelService.instance
+        .recordAttempt(user, ['tag2'], correct: true);
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString('skillModel.$user');
+    final data = jsonDecode(raw!) as Map<String, dynamic>;
+    final skill = Map<String, dynamic>.from(data['tag2'] as Map);
+    skill['lastSeen'] =
+        DateTime.now().subtract(const Duration(days: 40)).toIso8601String();
+    data['tag2'] = skill;
+    await prefs.setString('skillModel.$user', jsonEncode(data));
+    final before =
+        (await UserSkillModelService.instance.getSkills(user))['tag2']!.mastery;
+    await UserSkillModelService.instance.decayTick(user);
+    final after =
+        (await UserSkillModelService.instance.getSkills(user))['tag2']!.mastery;
+    expect(after, lessThan(before));
+  });
+}
+


### PR DESCRIPTION
## Summary
- add per-user skill model with mastery decay tracking
- introduce adaptive training planner scoring tags by error, decay, and impact
- allow autogen pipeline to plan and inject modules per user and update skills on completion

## Testing
- `dart test test/services/user_skill_model_service_test.dart test/services/adaptive_training_planner_test.dart test/e2e_adaptive_plan_injection_test.dart` *(fails: command not found: dart)*

------
https://chatgpt.com/codex/tasks/task_e_689565945b8c832a8f3bffb2fe3ada72