### PR TITLE
feat: execute adaptive plans with budget and idempotency

### DIFF
--- a/lib/services/adaptive_plan_executor.dart
+++ b/lib/services/adaptive_plan_executor.dart
@@ -1,0 +1,177 @@
+import 'dart:convert';
+import 'dart:math';
+
+import 'package:crypto/crypto.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:collection/collection.dart';
+
+import '../models/injected_path_module.dart';
+import '../models/training_pack_model.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import '../models/autogen_status.dart';
+import 'adaptive_training_planner.dart';
+import 'assessment_pack_synthesizer.dart';
+import 'auto_format_selector.dart';
+import 'autogen_status_dashboard_service.dart';
+import 'learning_path_store.dart';
+import 'pack_quality_gatekeeper_service.dart';
+import 'targeted_pack_booster_engine.dart';
+
+class _PackInfo {
+  final TrainingPackTemplateV2 template;
+  final int mins;
+  final double ev;
+  _PackInfo(this.template, this.mins, this.ev);
+}
+
+/// Executes an [AdaptivePlan] by generating boosters and assessments,
+/// enforcing quality gates, deduplicating and persisting modules
+/// within a given time budget.
+class AdaptivePlanExecutor {
+  final TargetedPackBoosterEngine boosterEngine;
+  final AutoFormatSelector formatSelector;
+  final PackQualityGatekeeperService gatekeeper;
+  final LearningPathStore store;
+  final AssessmentPackSynthesizer synthesizer;
+  final AutogenStatusDashboardService dashboard;
+
+  const AdaptivePlanExecutor({
+    TargetedPackBoosterEngine? boosterEngine,
+    AutoFormatSelector? formatSelector,
+    PackQualityGatekeeperService? gatekeeper,
+    LearningPathStore? store,
+    AssessmentPackSynthesizer? synthesizer,
+    AutogenStatusDashboardService? dashboard,
+  })  : boosterEngine = boosterEngine ?? TargetedPackBoosterEngine(),
+        formatSelector = formatSelector ?? AutoFormatSelector(),
+        gatekeeper = gatekeeper ?? const PackQualityGatekeeperService(),
+        store = store ?? const LearningPathStore(),
+        synthesizer = synthesizer ?? const AssessmentPackSynthesizer(),
+        dashboard = dashboard ?? AutogenStatusDashboardService.instance;
+
+  TrainingPackModel _toModel(TrainingPackTemplateV2 t) => TrainingPackModel(
+        id: t.id,
+        title: t.name,
+        spots: t.spots,
+        tags: t.tags,
+        metadata: t.meta,
+      );
+
+  Future<List<InjectedPathModule>> execute({
+    required String userId,
+    required AdaptivePlan plan,
+    required int budgetMinutes,
+  }) async {
+    final prefs = await SharedPreferences.getInstance();
+    final boosterPerSpot =
+        prefs.getDouble('planner.minsPerSpot.booster') ?? 0.6;
+    final assessPerSpot =
+        prefs.getDouble('planner.minsPerSpot.assessment') ?? 0.5;
+    final dedupDays = prefs.getInt('planner.moduleIdDaysDedup') ?? 14;
+    final padding = prefs.getInt('planner.budgetPaddingMins') ?? 5;
+    final budget = max(0, budgetMinutes - padding);
+
+    final existing = await store.listModules(userId);
+    final cutoff = DateTime.now().subtract(Duration(days: dedupDays));
+
+    final modules = <InjectedPathModule>[];
+    var used = 0;
+
+    for (final c in plan.clusters) {
+      var boosters =
+          await boosterEngine.generateClusterBoosterPacks(clusters: [c]);
+      boosters = boosters
+          .where((b) => gatekeeper.isQualityAcceptable(_toModel(b)))
+          .toList();
+      if (boosters.isEmpty) continue;
+
+      final fmt = formatSelector.effectiveFormat();
+      final assess = await synthesizer.createAssessment(
+        tags: c.tags,
+        size: max(1, (fmt.spotsPerPack / 2).round()),
+        clusterId: c.clusterId,
+        themeName: c.themeName,
+      );
+      if (!gatekeeper.isQualityAcceptable(_toModel(assess))) {
+        continue;
+      }
+
+      final assessMins = (assess.spotCount * assessPerSpot).ceil();
+      final boosterInfos = <_PackInfo>[];
+      for (final b in boosters) {
+        final mins = (b.spotCount * boosterPerSpot).ceil();
+        final ev = b.tags.fold<double>(0,
+            (prev, t) => prev + (plan.tagWeights[t] ?? 0.0));
+        boosterInfos.add(_PackInfo(b, mins, ev));
+      }
+      boosterInfos.sort((a, b) {
+        final cmp = a.ev.compareTo(b.ev);
+        if (cmp != 0) return cmp;
+        return a.template.id.compareTo(b.template.id);
+      });
+      var boosterMins =
+          boosterInfos.fold<int>(0, (s, b) => s + b.mins);
+      var moduleMins = boosterMins + assessMins;
+      while (boosterInfos.isNotEmpty && used + moduleMins > budget) {
+        final removed = boosterInfos.removeAt(0);
+        boosterMins -= removed.mins;
+        moduleMins -= removed.mins;
+      }
+      if (used + moduleMins > budget) continue;
+
+      final boosterIds = [for (final b in boosterInfos) b.template.id];
+      final sortedIds = [...boosterIds]..sort();
+      final assessmentId = assess.id;
+      final duplicate = existing.any((m) {
+        if (m.createdAt.isBefore(cutoff)) return false;
+        if (m.clusterId != c.clusterId) return false;
+        if (m.assessmentPackId != assessmentId) return false;
+        final ids = [...m.boosterPackIds]..sort();
+        return const ListEquality().equals(ids, sortedIds);
+      });
+      if (duplicate) continue;
+
+      final hashInput = [...c.tags, ...sortedIds, assessmentId].join('|');
+      final planHash = sha1.convert(utf8.encode(hashInput)).toString();
+      final plannerScore =
+          c.tags.fold<double>(0, (s, t) => s + (plan.tagWeights[t] ?? 0.0));
+      final module = InjectedPathModule(
+        moduleId: '${userId}_${c.clusterId}_${planHash.substring(0, 8)}',
+        clusterId: c.clusterId,
+        themeName: c.themeName,
+        theoryIds: const [],
+        boosterPackIds: boosterIds,
+        assessmentPackId: assessmentId,
+        createdAt: DateTime.now(),
+        triggerReason: 'adaptivePlan',
+        metrics: {
+          'clusterTags': c.tags,
+          'planHash': planHash,
+          'plannerScore': plannerScore,
+        },
+        itemsDurations: {
+          'theoryMins': 0,
+          'boosterMins': boosterMins,
+          'assessmentMins': assessMins,
+        },
+      );
+      await store.upsertModule(userId, module);
+      modules.add(module);
+      used += moduleMins;
+    }
+
+    dashboard.update(
+      'AdaptiveExecutor',
+      AutogenStatus(
+        isRunning: false,
+        currentStage: jsonEncode({
+          'clusters': plan.clusters.length,
+          'modulesCreated': modules.length,
+          'budgetUsed': used,
+        }),
+      ),
+    );
+
+    return modules;
+  }
+}

--- a/test/e2e_adaptive_plan_injection_test.dart
+++ b/test/e2e_adaptive_plan_injection_test.dart
@@ -1,28 +1,91 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'dart:io';
+
 import 'package:poker_analyzer/services/autogen_pipeline_executor.dart';
 import 'package:poker_analyzer/services/learning_path_store.dart';
 import 'package:poker_analyzer/services/user_skill_model_service.dart';
 import 'package:poker_analyzer/services/autogen_status_dashboard_service.dart';
+import 'package:poker_analyzer/services/adaptive_plan_executor.dart';
+import 'package:poker_analyzer/services/targeted_pack_booster_engine.dart';
+import 'package:poker_analyzer/services/auto_format_selector.dart';
+import 'package:poker_analyzer/services/pack_quality_gatekeeper_service.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+
+class _FakeBoosterEngine extends TargetedPackBoosterEngine {
+  @override
+  Future<List<TrainingPackTemplateV2>> generateClusterBoosterPacks({
+    required List<SkillTagCluster> clusters,
+    String triggerReason = 'cluster',
+  }) async {
+    final c = clusters.first;
+    return [
+      TrainingPackTemplateV2(
+        id: 'boost_${c.clusterId}',
+        name: 'Boost',
+        trainingType: TrainingType.booster,
+        tags: c.tags,
+        spots: [
+          TrainingPackSpot(id: 's1', tags: c.tags, board: const ['Ah']),
+        ],
+        spotCount: 4,
+        meta: const {'qualityScore': 1.0},
+      ),
+    ];
+  }
+}
+
+class _FakeFormatSelector extends AutoFormatSelector {
+  @override
+  FormatMeta effectiveFormat({String? audience}) =>
+      const FormatMeta(spotsPerPack: 4, streets: 1, theoryRatio: 0.5);
+}
+
+class _PassGatekeeper extends PackQualityGatekeeperService {
+  const _PassGatekeeper();
+  @override
+  bool isQualityAcceptable(pack,
+          {double minScore = 0.7, seedIssues = const {}}) =>
+      true;
+}
 
 void main() {
   setUp(() {
-    SharedPreferences.setMockInitialValues({});
+    SharedPreferences.setMockInitialValues({'planner.budgetPaddingMins': 0});
   });
 
-  test('planAndInjectForUser creates modules and is idempotent', () async {
+  test('planAndInjectForUser creates modules with artifacts and is idempotent',
+      () async {
     const user = 'u3';
     await UserSkillModelService.instance
         .recordAttempt(user, ['tag'], correct: false);
     await UserSkillModelService.instance
         .recordAttempt(user, ['tag'], correct: false);
 
+    final tempDir = await Directory.systemTemp.createTemp('e2e');
+    final store = LearningPathStore(rootDir: tempDir.path);
+    final planExec = AdaptivePlanExecutor(
+      boosterEngine: _FakeBoosterEngine(),
+      formatSelector: _FakeFormatSelector(),
+      gatekeeper: const _PassGatekeeper(),
+      store: store,
+    );
     final exec = AutogenPipelineExecutor();
-    await exec.planAndInjectForUser(user, durationMinutes: 40);
-    final store = const LearningPathStore();
+    await exec.planAndInjectForUser(
+      user,
+      durationMinutes: 40,
+      executor: planExec,
+    );
     final modules1 = await store.listModules(user);
     expect(modules1, isNotEmpty);
+    final m = modules1.first;
+    expect(m.boosterPackIds, isNotEmpty);
+    expect(m.assessmentPackId, isNotEmpty);
+    expect(m.itemsDurations?['boosterMins'], greaterThan(0));
+    expect(m.itemsDurations?['assessmentMins'], greaterThan(0));
 
     final prefs = await SharedPreferences.getInstance();
     final lastRun = prefs.getString('theoryScheduler.lastRun.$user');
@@ -32,9 +95,14 @@ void main() {
         AutogenStatusDashboardService.instance.getStatus('AdaptivePlanner');
     expect(status, isNotNull);
 
-    await exec.planAndInjectForUser(user, durationMinutes: 40);
+    await exec.planAndInjectForUser(
+      user,
+      durationMinutes: 40,
+      executor: planExec,
+    );
     final modules2 = await store.listModules(user);
     expect(modules2.length, modules1.length);
+    await tempDir.delete(recursive: true);
   });
 }
 

--- a/test/services/adaptive_plan_executor_budget_test.dart
+++ b/test/services/adaptive_plan_executor_budget_test.dart
@@ -1,0 +1,98 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/services/adaptive_plan_executor.dart';
+import 'package:poker_analyzer/services/learning_path_store.dart';
+import 'package:poker_analyzer/services/targeted_pack_booster_engine.dart';
+import 'package:poker_analyzer/services/auto_format_selector.dart';
+import 'package:poker_analyzer/services/pack_quality_gatekeeper_service.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+
+class _FakeBoosterEngine extends TargetedPackBoosterEngine {
+  @override
+  Future<List<TrainingPackTemplateV2>> generateClusterBoosterPacks({
+    required List<SkillTagCluster> clusters,
+    String triggerReason = 'cluster',
+  }) async {
+    List<TrainingPackTemplateV2> build(String id, List<String> tags) => [
+          TrainingPackTemplateV2(
+            id: id,
+            name: id,
+            trainingType: TrainingType.booster,
+            tags: tags,
+            spots: [
+              TrainingPackSpot(id: '${id}s', tags: tags, board: const ['Ah']),
+            ],
+            spotCount: 10,
+            meta: const {'qualityScore': 1.0},
+          ),
+        ];
+    return [
+      build('b1', ['a']).first,
+      build('b2', ['b']).first,
+      build('b3', ['a', 'b']).first,
+    ];
+  }
+}
+
+class _FakeFormatSelector extends AutoFormatSelector {
+  @override
+  FormatMeta effectiveFormat({String? audience}) =>
+      const FormatMeta(spotsPerPack: 10, streets: 1, theoryRatio: 0.5);
+}
+
+class _PassGatekeeper extends PackQualityGatekeeperService {
+  const _PassGatekeeper();
+  @override
+  bool isQualityAcceptable(pack, {double minScore = 0.7, seedIssues = const {}}) {
+    return true;
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempDir;
+  late LearningPathStore store;
+  late AdaptivePlanExecutor exec;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({'planner.budgetPaddingMins': 0});
+    tempDir = await Directory.systemTemp.createTemp('plan');
+    store = LearningPathStore(rootDir: tempDir.path);
+    exec = AdaptivePlanExecutor(
+      boosterEngine: _FakeBoosterEngine(),
+      formatSelector: _FakeFormatSelector(),
+      gatekeeper: const _PassGatekeeper(),
+      store: store,
+    );
+  });
+
+  tearDown(() async {
+    await tempDir.delete(recursive: true);
+  });
+
+  test('honors budget and drops lowest-EV booster first', () async {
+    final cluster =
+        SkillTagCluster(tags: ['a', 'b'], clusterId: 'c1', themeName: 'T');
+    final plan = AdaptivePlan(
+      clusters: [cluster],
+      estMins: 0,
+      tagWeights: const {'a': 2.0, 'b': 1.0},
+    );
+    final modules = await exec.execute(
+      userId: 'u1',
+      plan: plan,
+      budgetMinutes: 14,
+    );
+    expect(modules, hasLength(1));
+    final m = modules.first;
+    expect(m.boosterPackIds, ['b3']);
+    expect(m.itemsDurations?['boosterMins'], 6);
+    expect(m.itemsDurations?['assessmentMins'], 3);
+  });
+}

--- a/test/services/adaptive_plan_executor_idempotency_test.dart
+++ b/test/services/adaptive_plan_executor_idempotency_test.dart
@@ -1,0 +1,151 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/services/adaptive_plan_executor.dart';
+import 'package:poker_analyzer/services/learning_path_store.dart';
+import 'package:poker_analyzer/services/targeted_pack_booster_engine.dart';
+import 'package:poker_analyzer/services/auto_format_selector.dart';
+import 'package:poker_analyzer/services/pack_quality_gatekeeper_service.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+import 'package:poker_analyzer/models/injected_path_module.dart';
+
+class _FakeBoosterEngine extends TargetedPackBoosterEngine {
+  @override
+  Future<List<TrainingPackTemplateV2>> generateClusterBoosterPacks({
+    required List<SkillTagCluster> clusters,
+    String triggerReason = 'cluster',
+  }) async {
+    final c = clusters.first;
+    final id = 'boost_${c.clusterId}_${c.tags.join()}';
+    return [
+      TrainingPackTemplateV2(
+        id: id,
+        name: id,
+        trainingType: TrainingType.booster,
+        tags: c.tags,
+        spots: [
+          TrainingPackSpot(id: '${id}s', tags: c.tags, board: const ['As']),
+        ],
+        spotCount: 4,
+        meta: const {'qualityScore': 1.0},
+      ),
+    ];
+  }
+}
+
+class _FakeFormatSelector extends AutoFormatSelector {
+  @override
+  FormatMeta effectiveFormat({String? audience}) =>
+      const FormatMeta(spotsPerPack: 4, streets: 1, theoryRatio: 0.5);
+}
+
+class _PassGatekeeper extends PackQualityGatekeeperService {
+  const _PassGatekeeper();
+  @override
+  bool isQualityAcceptable(pack, {double minScore = 0.7, seedIssues = const {}}) {
+    return true;
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempDir;
+  late LearningPathStore store;
+  late AdaptivePlanExecutor exec;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({'planner.budgetPaddingMins': 0});
+    tempDir = await Directory.systemTemp.createTemp('idem');
+    store = LearningPathStore(rootDir: tempDir.path);
+    exec = AdaptivePlanExecutor(
+      boosterEngine: _FakeBoosterEngine(),
+      formatSelector: _FakeFormatSelector(),
+      gatekeeper: const _PassGatekeeper(),
+      store: store,
+    );
+  });
+
+  tearDown(() async {
+    await tempDir.delete(recursive: true);
+  });
+
+  test('identical plan within window is skipped', () async {
+    final cluster =
+        SkillTagCluster(tags: ['a'], clusterId: 'c1', themeName: 'T');
+    final plan = AdaptivePlan(
+      clusters: [cluster],
+      estMins: 0,
+      tagWeights: const {'a': 1.0},
+    );
+    final first = await exec.execute(
+      userId: 'u1',
+      plan: plan,
+      budgetMinutes: 20,
+    );
+    expect(first, hasLength(1));
+    final second = await exec.execute(
+      userId: 'u1',
+      plan: plan,
+      budgetMinutes: 20,
+    );
+    expect(second, isEmpty);
+  });
+
+  test('creates module when tags change or window elapsed', () async {
+    final cluster =
+        SkillTagCluster(tags: ['a'], clusterId: 'c1', themeName: 'T');
+    final plan = AdaptivePlan(
+      clusters: [cluster],
+      estMins: 0,
+      tagWeights: const {'a': 1.0},
+    );
+    await exec.execute(userId: 'u1', plan: plan, budgetMinutes: 20);
+    final changed = AdaptivePlan(
+      clusters: [
+        SkillTagCluster(tags: ['a', 'b'], clusterId: 'c1', themeName: 'T')
+      ],
+      estMins: 0,
+      tagWeights: const {'a': 1.0, 'b': 1.0},
+    );
+    final res1 = await exec.execute(
+      userId: 'u1',
+      plan: changed,
+      budgetMinutes: 20,
+    );
+    expect(res1, hasLength(1));
+
+    var modules = await store.listModules('u1');
+    final aged = modules
+        .map((m) => InjectedPathModule(
+              moduleId: m.moduleId,
+              clusterId: m.clusterId,
+              themeName: m.themeName,
+              theoryIds: m.theoryIds,
+              boosterPackIds: m.boosterPackIds,
+              assessmentPackId: m.assessmentPackId,
+              createdAt: m.createdAt.subtract(const Duration(days: 15)),
+              triggerReason: m.triggerReason,
+              status: m.status,
+              metrics: m.metrics,
+              itemsDurations: m.itemsDurations,
+            ))
+        .toList();
+    for (final m in modules) {
+      await store.removeModule('u1', m.moduleId);
+    }
+    for (final m in aged) {
+      await store.upsertModule('u1', m);
+    }
+    final res2 = await exec.execute(
+      userId: 'u1',
+      plan: plan,
+      budgetMinutes: 20,
+    );
+    expect(res2, hasLength(1));
+  });
+}


### PR DESCRIPTION
## Summary
- add AdaptivePlanExecutor to turn AdaptivePlan clusters into real modules under time budget with quality gating and deduplication
- replace placeholder logic in AutogenPipelineExecutor with AdaptivePlanExecutor and optional injection
- cover budget trimming and idempotent execution with new tests

## Testing
- `bash tool/test_all.sh` *(fails: flutter: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_689567ce753c832aad240648cd817069