### PR TITLE
feat: add audience and format aware planner

### DIFF
--- a/lib/services/adaptive_training_planner.dart
+++ b/lib/services/adaptive_training_planner.dart
@@ -14,11 +14,13 @@ class AdaptivePlan {
   final List<SkillTagCluster> clusters;
   final int estMins;
   final Map<String, double> tagWeights;
+  final Map<String, int> mix;
 
   const AdaptivePlan({
     required this.clusters,
     required this.estMins,
     required this.tagWeights,
+    required this.mix,
   });
 }
 
@@ -41,37 +43,50 @@ class AdaptiveTrainingPlanner {
   Future<AdaptivePlan> plan({
     required String userId,
     required int durationMinutes,
-    String? audience,
+    String audience = 'regular',
+    String format = 'standard',
   }) async {
     final prefs = await SharedPreferences.getInstance();
     final wErr = prefs.getDouble('planner.weight.error') ?? 0.55;
     final wDecay = prefs.getDouble('planner.weight.decay') ?? 0.30;
     final wImpact = prefs.getDouble('planner.weight.impact') ?? 0.15;
-    final maxTags = prefs.getInt('planner.maxTagsPerPlan') ?? 6;
+    var maxTags = prefs.getInt('planner.maxTagsPerPlan') ?? 6;
+    switch (format) {
+      case 'quick':
+        if (maxTags > 2) maxTags = 2;
+        break;
+      case 'deep':
+        maxTags += 2;
+        break;
+    }
     final padding = prefs.getInt('planner.budgetPaddingMins') ?? 5;
 
     final skills = await skillService.getSkills(userId);
     final decays = await retention.getAllDecayScores();
     final tagScores = <String, double>{};
-    final impacts = await BanditWeightLearner.instance.getAllImpacts(userId);
     final allTags = {...skills.keys, ...decays.keys};
     for (final tag in allTags) {
       final mastery = skills[tag]?.mastery ?? 0.0;
       final decay = decays[tag] ?? 1.0;
-      final impact = (impacts[tag] ??
-              prefs.getDouble('planner.impact.$tag') ??
-              1.0)
-          .clamp(0.0, 2.0);
+      var impact = await BanditWeightLearner.instance.getImpact(userId, tag);
+      impact = impact.isNaN
+          ? (prefs.getDouble('planner.impact.$tag') ?? 1.0)
+          : impact;
       tagScores[tag] =
-          wErr * (1 - mastery) + wDecay * decay + wImpact * impact;
+          wErr * (1 - mastery) + wDecay * decay + wImpact * impact.clamp(0.0, 2.0);
     }
     final sorted = tagScores.entries.toList()
-      ..sort((a, b) => b.value.compareTo(a.value));
+      ..sort((a, b) {
+        final cmp = b.value.compareTo(a.value);
+        if (cmp != 0) return cmp;
+        return a.key.compareTo(b.key);
+      });
 
     // Estimate average durations
     final modules = await store.listModules(userId);
     var boosterSum = 0, boosterCount = 0;
     var assessSum = 0, assessCount = 0;
+    var theorySum = 0, theoryCount = 0;
     for (final m in modules) {
       final d = m.itemsDurations;
       if (d != null) {
@@ -83,43 +98,95 @@ class AdaptiveTrainingPlanner {
           assessSum += d['assessmentMins']!;
           assessCount++;
         }
+        if (d['theoryMins'] != null) {
+          theorySum += d['theoryMins']!;
+          theoryCount++;
+        }
       }
     }
     final boosterAvg =
         boosterCount > 0 ? (boosterSum / boosterCount).round() : 10;
     final assessAvg =
         assessCount > 0 ? (assessSum / assessCount).round() : 8;
-    final perTag = boosterAvg + assessAvg;
+    final theoryAvg = theoryCount > 0
+        ? (theorySum / theoryCount).round()
+        : (prefs.getInt('path.inject.theoryMins') ?? 5);
+
     final budget = durationMinutes - padding;
-    var used = 0;
     final selected = <String>[];
     for (final e in sorted) {
       if (selected.length >= maxTags) break;
-      if (used + perTag > budget) continue;
+      final mastery = skills[e.key]?.mastery ?? 0.0;
+      if (audience == 'novice' && mastery > 0.6) continue;
       selected.add(e.key);
-      used += perTag;
     }
+
+    Map<String, int> mix = mixFor(selected.length, audience, format);
+    int estMins =
+        mix['theory']! * theoryAvg + mix['booster']! * boosterAvg + mix['assessment']! * assessAvg;
+    while (estMins > budget && selected.isNotEmpty) {
+      selected.removeLast();
+      mix = mixFor(selected.length, audience, format);
+      estMins = mix['theory']! * theoryAvg +
+          mix['booster']! * boosterAvg +
+          mix['assessment']! * assessAvg;
+    }
+
     final clusters = clusterer.clusterWeakTags(
       weakTags: selected,
       spotTags: const {},
     );
 
     AutogenStatusDashboardService.instance.update(
-      'AdaptivePlanner',
+      'PlannerV2',
       AutogenStatus(
         isRunning: false,
         currentStage: jsonEncode({
-          'budget': durationMinutes,
-          'tags': selected,
-          'clusters': clusters.length,
+          'audience': audience,
+          'format': format,
+          'chosenTags': selected,
+          'mix': mix,
+          'estMins': estMins,
         }),
       ),
     );
 
-    final weights = {
-      for (final t in selected) t: tagScores[t]!,
+    final weights = {for (final t in selected) t: tagScores[t]!};
+    return AdaptivePlan(
+        clusters: clusters, estMins: estMins, tagWeights: weights, mix: mix);
+  }
+
+  static Map<String, int> mixFor(
+      int tagCount, String audience, String format) {
+    final base = <String, Map<String, int>>{
+      'novice': const {'theory': 4, 'booster': 3, 'assessment': 1},
+      'regular': const {'theory': 2, 'booster': 3, 'assessment': 1},
+      'advanced': const {'theory': 1, 'booster': 2, 'assessment': 3},
     };
-    return AdaptivePlan(clusters: clusters, estMins: used, tagWeights: weights);
+    final ratios = Map<String, double>.from(
+        base[audience] ?? base['regular']!); // default regular
+    final bias = <String, double>{
+      'theory': 1.0,
+      'booster': 1.0,
+      'assessment': 1.0,
+    };
+    if (format == 'quick') {
+      bias['booster'] = 1.5;
+      bias['assessment'] = 0.5;
+    } else if (format == 'deep') {
+      bias['assessment'] = 1.5;
+    }
+    final weights = {
+      for (final k in ratios.keys) k: ratios[k]! * bias[k]!
+    };
+    final total = weights.values.fold<double>(0, (a, b) => a + b);
+    if (total == 0 || tagCount == 0) {
+      return const {'theory': 0, 'booster': 0, 'assessment': 0};
+    }
+    return {
+      for (final k in weights.keys)
+        k: ((weights[k]! / total) * tagCount).round()
+    };
   }
 }
 

--- a/lib/services/autogen_pipeline_executor.dart
+++ b/lib/services/autogen_pipeline_executor.dart
@@ -458,13 +458,15 @@ class AutogenPipelineExecutor {
     String userId, {
     required int durationMinutes,
     String? audience,
+    String? format,
     AdaptivePlanExecutor? executor,
   }) async {
     final planner = AdaptiveTrainingPlanner();
     final plan = await planner.plan(
       userId: userId,
       durationMinutes: durationMinutes,
-      audience: audience,
+      audience: audience ?? 'regular',
+      format: format ?? 'standard',
     );
     final exec = executor ?? const AdaptivePlanExecutor();
     await exec.execute(

--- a/test/e2e_adaptive_closed_loop_test.dart
+++ b/test/e2e_adaptive_closed_loop_test.dart
@@ -37,7 +37,8 @@ void main() {
     }));
     await prefs.setInt('planner.maxTagsPerPlan', 1);
     await prefs.setInt('planner.budgetPaddingMins', 0);
-    await prefs.setDouble('planner.impact.b', 1.1);
+    await prefs.setDouble('bandit.alpha.user.b', 5.0);
+    await prefs.setDouble('bandit.beta.user.b', 1.0);
 
     final planner = AdaptiveTrainingPlanner();
     final store = LearningPathStore(rootDir: 'test_lp');

--- a/test/e2e_adaptive_plan_injection_test.dart
+++ b/test/e2e_adaptive_plan_injection_test.dart
@@ -92,7 +92,7 @@ void main() {
     expect(lastRun, isNotNull);
 
     final status =
-        AutogenStatusDashboardService.instance.getStatus('AdaptivePlanner');
+        AutogenStatusDashboardService.instance.getStatus('PlannerV2');
     expect(status, isNotNull);
 
     await exec.planAndInjectForUser(

--- a/test/e2e_adaptive_training_planner_v2_test.dart
+++ b/test/e2e_adaptive_training_planner_v2_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/services/adaptive_training_planner.dart';
+import 'package:poker_analyzer/services/user_skill_model_service.dart';
+
+void main() {
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('novice quick produces ≤2 clusters booster-heavy', () async {
+    const user = 'u1';
+    final skills = UserSkillModelService.instance;
+    await skills.recordAttempt(user, ['a'], correct: false);
+    await skills.recordAttempt(user, ['b'], correct: false);
+    await skills.recordAttempt(user, ['c'], correct: false);
+
+    final planner = AdaptiveTrainingPlanner();
+    final plan = await planner.plan(
+      userId: user,
+      durationMinutes: 15,
+      audience: 'novice',
+      format: 'quick',
+    );
+    expect(plan.clusters.length <= 2, true);
+    expect(plan.mix['booster']! >= plan.mix['assessment']!, true);
+  });
+
+  test('advanced deep skews to assessments', () async {
+    const user = 'u2';
+    final skills = UserSkillModelService.instance;
+    await skills.recordAttempt(user, ['a'], correct: false);
+    await skills.recordAttempt(user, ['b'], correct: false);
+    await skills.recordAttempt(user, ['c'], correct: false);
+
+    final planner = AdaptiveTrainingPlanner();
+    final plan = await planner.plan(
+      userId: user,
+      durationMinutes: 40,
+      audience: 'advanced',
+      format: 'deep',
+    );
+    expect(plan.clusters.length >= 2, true);
+    expect(plan.mix['assessment']! >= plan.mix['booster']!, true);
+  });
+
+  test('bandit impact >1.0 tag is preferred under equal mastery/decay', () async {
+    const user = 'u3';
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt('planner.maxTagsPerPlan', 1);
+    await prefs.setDouble('bandit.alpha.$user.b', 5.0);
+    await prefs.setDouble('bandit.beta.$user.b', 1.0);
+
+    final skills = UserSkillModelService.instance;
+    await skills.recordAttempt(user, ['a'], correct: false);
+    await skills.recordAttempt(user, ['b'], correct: false);
+
+    final planner = AdaptiveTrainingPlanner();
+    final plan = await planner.plan(
+      userId: user,
+      durationMinutes: 20,
+    );
+    expect(plan.tagWeights.keys.single, 'b');
+  });
+}

--- a/test/services/adaptive_plan_executor_budget_test.dart
+++ b/test/services/adaptive_plan_executor_budget_test.dart
@@ -83,6 +83,7 @@ void main() {
       clusters: [cluster],
       estMins: 0,
       tagWeights: const {'a': 2.0, 'b': 1.0},
+      mix: const {'theory': 0, 'booster': 2, 'assessment': 1},
     );
     final modules = await exec.execute(
       userId: 'u1',

--- a/test/services/adaptive_plan_executor_idempotency_test.dart
+++ b/test/services/adaptive_plan_executor_idempotency_test.dart
@@ -81,6 +81,7 @@ void main() {
       clusters: [cluster],
       estMins: 0,
       tagWeights: const {'a': 1.0},
+      mix: const {'theory': 0, 'booster': 1, 'assessment': 1},
     );
     final first = await exec.execute(
       userId: 'u1',
@@ -103,6 +104,7 @@ void main() {
       clusters: [cluster],
       estMins: 0,
       tagWeights: const {'a': 1.0},
+      mix: const {'theory': 0, 'booster': 1, 'assessment': 1},
     );
     await exec.execute(userId: 'u1', plan: plan, budgetMinutes: 20);
     final changed = AdaptivePlan(
@@ -111,6 +113,7 @@ void main() {
       ],
       estMins: 0,
       tagWeights: const {'a': 1.0, 'b': 1.0},
+      mix: const {'theory': 0, 'booster': 2, 'assessment': 1},
     );
     final res1 = await exec.execute(
       userId: 'u1',

--- a/test/services/adaptive_training_planner_test.dart
+++ b/test/services/adaptive_training_planner_test.dart
@@ -36,5 +36,12 @@ void main() {
     expect(plan.tagWeights.keys, containsAll(['a', 'c']));
     expect(plan.tagWeights.keys, isNot(contains('b')));
   });
+
+  test('mix mapping respects audience and format', () {
+    final m1 = AdaptiveTrainingPlanner.mixFor(2, 'novice', 'quick');
+    expect(m1['booster']! >= m1['assessment']!, true);
+    final m2 = AdaptiveTrainingPlanner.mixFor(3, 'advanced', 'deep');
+    expect(m2['assessment']! >= m2['booster']!, true);
+  });
 }
 


### PR DESCRIPTION
## Summary
- extend AdaptiveTrainingPlanner with audience/format awareness and bandit impact prioritization
- expose new mix mapping and PlannerV2 telemetry
- add coverage for planner mixes and bandit impact preference

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68956fc62080832a8371a5f0f7ffc083