### PR TITLE
fix: stabilize planner v2 and ensure deterministic mix

### DIFF
--- a/test/e2e_adaptive_training_planner_v2_test.dart
+++ b/test/e2e_adaptive_training_planner_v2_test.dart
@@ -63,4 +63,17 @@ void main() {
     );
     expect(plan.tagWeights.keys.single, 'b');
   });
+
+  test('planner deterministic with stable inputs', () async {
+    const user = 'u4';
+    final skills = UserSkillModelService.instance;
+    await skills.recordAttempt(user, ['a'], correct: false);
+    await skills.recordAttempt(user, ['b'], correct: false);
+
+    final planner = AdaptiveTrainingPlanner();
+    final plan1 = await planner.plan(userId: user, durationMinutes: 25);
+    final plan2 = await planner.plan(userId: user, durationMinutes: 25);
+    expect(plan1.tagWeights, equals(plan2.tagWeights));
+    expect(plan1.mix, equals(plan2.mix));
+  });
 }


### PR DESCRIPTION
## Summary
- stabilize AdaptiveTrainingPlanner v2 and remove duplicate impact read
- make mixFor pure and deterministic with remainder redistribution
- extend planner tests for deterministic ordering and mix sums

## Testing
- `dart format lib/services/adaptive_training_planner.dart` *(fails: command not found)*
- `dart format test/services/adaptive_training_planner_test.dart test/e2e_adaptive_training_planner_v2_test.dart` *(fails: command not found)*
- `apt-get install -y dart` *(fails: unable to locate package)*
- `apt-get install -y flutter` *(fails: unable to locate package)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689572000924832aa8dd40d97176095a