### PR TITLE
feat: harden ab orchestrator

### DIFF
--- a/test/e2e_ab_exposure_test.dart
+++ b/test/e2e_ab_exposure_test.dart
@@ -1,15 +1,22 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'package:poker_analyzer/services/ab_orchestrator_service.dart';
+import 'package:poker_analyzer/services/adaptive_training_planner.dart';
 import 'package:poker_analyzer/services/autogen_pipeline_executor.dart';
 import 'package:poker_analyzer/services/autogen_pipeline_event_logger_service.dart';
+import 'package:poker_analyzer/services/plan_signature_builder.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   setUp(() {
-    SharedPreferences.setMockInitialValues({'ab.enabled': true});
+    SharedPreferences.setMockInitialValues({
+      'ab.enabled': true,
+      'planner.weight.impact': 0.15,
+    });
     AutogenPipelineEventLoggerService.clearLog();
+    ABOrchestratorService.instance.clearCache();
   });
 
   test('exposure logged once per run', () async {
@@ -18,5 +25,70 @@ void main() {
     final log = AutogenPipelineEventLoggerService.getLog();
     final exposures = log.where((e) => e.type == 'ab_exposure').length;
     expect(exposures, 1);
+  });
+
+  test('overrides are scoped and signatures depend on arm', () async {
+    final exec = AutogenPipelineExecutor();
+    final svc = ABOrchestratorService.instance;
+    final prefs = await SharedPreferences.getInstance();
+
+    // find users for different arms
+    String? hiUser;
+    String? ctrlUser;
+    for (var i = 0; i < 100 && (hiUser == null || ctrlUser == null); i++) {
+      final uid = 'user$i';
+      final arms = await svc.resolveActiveArms(uid, 'regular');
+      if (arms.isEmpty) continue;
+      if (arms.first.armId == 'hiImpact' && hiUser == null) hiUser = uid;
+      if (arms.first.armId == 'control' && ctrlUser == null) ctrlUser = uid;
+    }
+    expect(hiUser, isNotNull);
+    expect(ctrlUser, isNotNull);
+
+    await exec.planAndInjectForUser(hiUser!, durationMinutes: 10);
+    expect(prefs.getDouble('planner.weight.impact'), 0.15);
+
+    await exec.planAndInjectForUser(ctrlUser!, durationMinutes: 10);
+    expect(prefs.getDouble('planner.weight.impact'), 0.15);
+
+    final arms1 = await svc.resolveActiveArms(hiUser!, 'regular');
+    final arms2 = await svc.resolveActiveArms(hiUser!, 'regular');
+    expect(arms1.single.armId, arms2.single.armId);
+
+    final planner = AdaptiveTrainingPlanner();
+    final abHi = arms1.map((a) => '${a.expId}:${a.armId}').join(',');
+    final planHi = await planner.plan(
+      userId: hiUser!,
+      durationMinutes: 10,
+      audience: 'regular',
+      format: 'standard',
+      abArm: abHi,
+    );
+    final sigHi = await PlanSignatureBuilder().build(
+      userId: hiUser!,
+      plan: planHi,
+      audience: 'regular',
+      format: 'standard',
+      budgetMinutes: 10,
+      abArm: abHi,
+    );
+    final armsCtrl = await svc.resolveActiveArms(ctrlUser!, 'regular');
+    final abCtrl = armsCtrl.map((a) => '${a.expId}:${a.armId}').join(',');
+    final planCtrl = await planner.plan(
+      userId: ctrlUser!,
+      durationMinutes: 10,
+      audience: 'regular',
+      format: 'standard',
+      abArm: abCtrl,
+    );
+    final sigCtrl = await PlanSignatureBuilder().build(
+      userId: ctrlUser!,
+      plan: planCtrl,
+      audience: 'regular',
+      format: 'standard',
+      budgetMinutes: 10,
+      abArm: abCtrl,
+    );
+    expect(sigHi, isNot(sigCtrl));
   });
 }

--- a/test/services/ab_orchestrator_service_test.dart
+++ b/test/services/ab_orchestrator_service_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -8,33 +10,81 @@ void main() {
 
   setUp(() {
     SharedPreferences.setMockInitialValues({'ab.enabled': true});
+    ABOrchestratorService.instance.clearCache();
   });
 
-  test('deterministic assignment and overrides applied', () async {
+  test('unbiased assignment under traffic<1', () async {
     final svc = ABOrchestratorService.instance;
-    ResolvedArm? target;
-    String? user;
-    for (var i = 0; i < 50; i++) {
-      final u = 'user$i';
-      final arms = await svc.resolveActiveArms(u, 'regular');
-      if (arms.isNotEmpty) {
-        target = arms.first;
-        user = u;
-        if (target!.prefs.isNotEmpty) break;
+    final file = File('assets/ab_experiments.json');
+    final orig = await file.readAsString();
+    await file.writeAsString(orig.replaceFirst('"traffic": 1.0', '"traffic": 0.5'));
+    addTearDown(() async {
+      await file.writeAsString(orig);
+      svc.clearCache();
+    });
+    svc.clearCache();
+
+    final counts = <String, int>{'control': 0, 'hiImpact': 0, 'none': 0};
+    for (var i = 0; i < 1000; i++) {
+      final uid = 'u$i';
+      final arms = await svc.resolveActiveArms(uid, 'regular');
+      if (arms.isEmpty) {
+        final prefs = await SharedPreferences.getInstance();
+        final a = prefs.getString('ab.assignment.wImpactTest.$uid')!;
+        counts[a] = (counts[a] ?? 0) + 1;
+      } else {
+        counts[arms.first.armId] = counts[arms.first.armId]! + 1;
       }
     }
-    expect(target, isNotNull);
-    final arms2 = await svc.resolveActiveArms(user!, 'regular');
-    expect(arms2.single.armId, target!.armId);
-    await svc.applyOverrides(target!);
+    final assigned = counts['control']! + counts['hiImpact']!;
+    expect(assigned, greaterThan(0));
+    final ratio = counts['control']! / assigned;
+    expect(ratio, closeTo(0.5, 0.1));
+    expect(counts['none']! / 1000, closeTo(0.5, 0.1));
+  });
+
+  test('assignment sticks even if traffic changes', () async {
+    final svc = ABOrchestratorService.instance;
+    final file = File('assets/ab_experiments.json');
+    final orig = await file.readAsString();
+    await file.writeAsString(orig.replaceFirst('"traffic": 1.0', '"traffic": 1.0'));
+    svc.clearCache();
+    final user = 'sticky';
+    final first = await svc.resolveActiveArms(user, 'regular');
+    final armId = first.isEmpty ? 'none' : first.first.armId;
+    await file.writeAsString(orig.replaceFirst('"traffic": 1.0', '"traffic": 0.0'));
+    svc.clearCache();
+    final second = await svc.resolveActiveArms(user, 'regular');
+    final armId2 = second.isEmpty ? 'none' : second.first.armId;
+    expect(armId2, armId);
+    await file.writeAsString(orig);
+    svc.clearCache();
+  });
+
+  test('withOverrides restores on success and throw', () async {
+    final svc = ABOrchestratorService.instance;
     final prefs = await SharedPreferences.getInstance();
-    for (final e in target!.prefs.entries) {
-      if (e.value is double) {
-        expect(prefs.getDouble(e.key), e.value);
-      }
-      if (e.value is int) {
-        expect(prefs.getInt(e.key), e.value);
-      }
+    await prefs.setInt('x', 1);
+    final arm = ResolvedArm(expId: 'e', armId: 'a', prefs: {'x': 2, 'y': 3});
+
+    await svc.withOverrides(arm, () async {
+      expect(prefs.getInt('x'), 2);
+      expect(prefs.getInt('y'), 3);
+    });
+    expect(prefs.getInt('x'), 1);
+    expect(prefs.getInt('y'), isNull);
+
+    var threw = false;
+    try {
+      await svc.withOverrides(arm, () async {
+        expect(prefs.getInt('x'), 2);
+        throw Exception('boom');
+      });
+    } catch (_) {
+      threw = true;
     }
+    expect(threw, true);
+    expect(prefs.getInt('x'), 1);
+    expect(prefs.getInt('y'), isNull);
   });
 }


### PR DESCRIPTION
## Summary
- ensure AB spec loads safely and logs errors
- introduce unbiased experiment assignment with counters and scoped overrides
- wrap planner execution with reversible per-arm overrides and telemetry

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6895780bf118832a8cba57f6f7de7c82