### PR TITLE
Add safe theory YAML writer with atomic, checksum-guarded writes

### DIFF
--- a/lib/core/training/export/training_pack_exporter_v2.dart
+++ b/lib/core/training/export/training_pack_exporter_v2.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import '../../../models/v2/training_pack_template_v2.dart';
+import '../../../services/theory_yaml_safe_writer.dart';
 
 class TrainingPackExporterV2 {
   const TrainingPackExporterV2();
@@ -19,7 +20,16 @@ class TrainingPackExporterV2 {
         .replaceAll(RegExp(r'[\\/:*?"<>|]'), '_')
         .replaceAll(' ', '_');
     final file = File('${dir.path}/$safeName.yaml');
-    await file.writeAsString(exportYaml(pack));
+    String? prevHash;
+    if (await file.exists()) {
+      prevHash = TheoryYamlSafeWriter.extractHash(await file.readAsString());
+    }
+    await TheoryYamlSafeWriter().write(
+      path: file.path,
+      yaml: exportYaml(pack),
+      schema: 'TemplateSet',
+      prevHash: prevHash,
+    );
     return file;
   }
 }

--- a/lib/services/theory_auto_injector.dart
+++ b/lib/services/theory_auto_injector.dart
@@ -8,6 +8,7 @@ import 'package:yaml/yaml.dart';
 import '../models/autogen_status.dart';
 import 'autogen_status_dashboard_service.dart';
 import 'preferences_service.dart';
+import 'theory_yaml_safe_writer.dart';
 
 class TheoryInjectReport {
   final int packsUpdated;
@@ -102,7 +103,14 @@ class TheoryAutoInjector {
           meta['theoryLinks'] = [...existing, ...needed];
           data['meta'] = meta;
           final out = json2yaml(data);
-          await file.writeAsString(out);
+          final prevHash =
+              TheoryYamlSafeWriter.extractHash(yamlStr);
+          await TheoryYamlSafeWriter().write(
+            path: file.path,
+            yaml: out,
+            schema: 'TemplateSet',
+            prevHash: prevHash,
+          );
         }
         packsUpdated++;
         linksAdded += needed.length;

--- a/lib/services/theory_yaml_safe_writer.dart
+++ b/lib/services/theory_yaml_safe_writer.dart
@@ -1,0 +1,133 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:path/path.dart' as p;
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:yaml/yaml.dart';
+
+import '../models/autogen_status.dart';
+import 'autogen_status_dashboard_service.dart';
+import '../models/v2/training_pack_template_v2.dart';
+
+class TheoryWriteConflict implements Exception {
+  final String message;
+  TheoryWriteConflict(this.message);
+  @override
+  String toString() => 'TheoryWriteConflict: ' + message;
+}
+
+class TheoryYamlSafeWriter {
+  TheoryYamlSafeWriter({AutogenStatusDashboardService? dashboard})
+      : _dashboard = dashboard ?? AutogenStatusDashboardService.instance;
+
+  final AutogenStatusDashboardService _dashboard;
+
+  static final _headerRe = RegExp(
+      r'^#\s*x-hash:\s*([0-9a-f]+)\s*\|\s*x-ver:\s*(\d+)\s*\|\s*x-ts:\s*([^|]+)(?:\|\s*(.*))?\$');
+
+  Future<void> write({
+    required String path,
+    required String yaml,
+    required String schema,
+    Map<String, String>? meta,
+    String? prevHash,
+  }) async {
+    final prefs = await SharedPreferences.getInstance();
+    final dryRun = prefs.getBool('theory.safeWriter.dryRun') ?? false;
+    final keep = prefs.getInt('theory.backups.keep') ?? 10;
+    final strict = prefs.getBool('theory.safeWriter.strict') ?? true;
+
+    try {
+      if (strict) {
+        final map =
+            jsonDecode(jsonEncode(loadYaml(yaml))) as Map<String, dynamic>;
+        if (schema == 'TemplateSet') {
+          TrainingPackTemplateV2.fromJson(map);
+        }
+      } else {
+        loadYaml(yaml);
+      }
+
+      final newHash = sha256.convert(utf8.encode(yaml)).toString();
+      final file = File(path);
+      String? oldHash;
+      var version = 0;
+      if (file.existsSync()) {
+        final lines = file.readAsLinesSync();
+        final firstLine = lines.isEmpty ? null : lines.first;
+        final match = firstLine != null ? _headerRe.firstMatch(firstLine) : null;
+        if (match != null) {
+          oldHash = match.group(1);
+          version = int.parse(match.group(2)!);
+          if (oldHash != null && (prevHash == null || prevHash != oldHash)) {
+            _dashboard.update(
+                'TheoryWriter',
+                AutogenStatus(
+                    currentStage: 'conflict', lastError: 'checksum_mismatch'));
+            throw TheoryWriteConflict('checksum_mismatch');
+          }
+        }
+        if (oldHash == newHash) {
+          _dashboard.update(
+              'TheoryWriter', AutogenStatus(currentStage: 'no-op', progress: 1));
+          return;
+        }
+        final rel = p.relative(path);
+        final backupPath = p.join(
+            'theory_backups',
+            '$rel.${DateTime.now().millisecondsSinceEpoch}.yaml');
+        final backupFile = File(backupPath);
+        backupFile.parent.createSync(recursive: true);
+        await file.copy(backupFile.path);
+        final backupDir = backupFile.parent;
+        final base = p.basename(rel);
+        final backups = backupDir
+            .listSync()
+            .whereType<File>()
+            .where((f) => p.basename(f.path).startsWith('$base.'))
+            .toList()
+          ..sort((a, b) => a.path.compareTo(b.path));
+        if (backups.length > keep) {
+          for (final f in backups.take(backups.length - keep)) {
+            f.deleteSync();
+          }
+        }
+      }
+
+      if (dryRun) {
+        _dashboard.update(
+            'TheoryWriter', AutogenStatus(currentStage: 'dryRun', progress: 1));
+        return;
+      }
+
+      final headerParts = <String>[
+        'x-hash: $newHash',
+        'x-ver: ${version + 1}',
+        'x-ts: ${DateTime.now().toIso8601String()}',
+        if (meta != null) ...meta.entries.map((e) => '${e.key}: ${e.value}')
+      ];
+      final header = '# ' + headerParts.join(' | ');
+      final content = header + '\n' + yaml;
+      final tmp = File(path + '.tmp');
+      tmp.parent.createSync(recursive: true);
+      final raf = tmp.openSync(mode: FileMode.write);
+      raf.writeStringSync(content);
+      raf.flushSync();
+      await raf.close();
+      await tmp.rename(file.path);
+      _dashboard.update(
+          'TheoryWriter', AutogenStatus(currentStage: 'ok', progress: 1));
+    } catch (e) {
+      _dashboard.update('TheoryWriter',
+          AutogenStatus(currentStage: 'rollback', lastError: e.toString()));
+      rethrow;
+    }
+  }
+
+  static String? extractHash(String content) {
+    final first = content.split('\n').first;
+    final match = _headerRe.firstMatch(first);
+    return match?.group(1);
+  }
+}

--- a/test/services/theory_yaml_safe_writer_test.dart
+++ b/test/services/theory_yaml_safe_writer_test.dart
@@ -1,0 +1,79 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:test/test.dart';
+
+import 'package:poker_analyzer/services/theory_yaml_safe_writer.dart';
+
+void main() {
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    final backupRoot = Directory('theory_backups');
+    if (backupRoot.existsSync()) {
+      backupRoot.deleteSync(recursive: true);
+    }
+    final tmp = Directory('tmp_test');
+    if (tmp.existsSync()) tmp.deleteSync(recursive: true);
+  });
+
+  test('checksum mismatch -> conflict', () async {
+    final dir = Directory('tmp_test')..createSync();
+    final path = p.join(dir.path, 'file.yaml');
+    final writer = TheoryYamlSafeWriter();
+    await writer.write(path: path, yaml: 'id: 1', schema: 'raw');
+    final hash = TheoryYamlSafeWriter.extractHash(await File(path).readAsString());
+    expect(hash, isNotNull);
+    expect(
+      () async =>
+          writer.write(path: path, yaml: 'id: 2', schema: 'raw', prevHash: 'dead'),
+      throwsA(isA<TheoryWriteConflict>()),
+    );
+  });
+
+  test('bad schema -> reject', () async {
+    final dir = Directory('tmp_test')..createSync();
+    final path = p.join(dir.path, 'bad.yaml');
+    final writer = TheoryYamlSafeWriter();
+    await expectLater(
+      writer.write(path: path, yaml: '::bad::', schema: 'raw'),
+      throwsA(anything),
+    );
+  });
+
+  test('backup retention', () async {
+    SharedPreferences.setMockInitialValues({'theory.backups.keep': 2});
+    final dir = Directory('tmp_test')..createSync();
+    final path = p.join(dir.path, 'keep.yaml');
+    final writer = TheoryYamlSafeWriter();
+    await writer.write(path: path, yaml: 'a: 1', schema: 'raw');
+    var hash = TheoryYamlSafeWriter.extractHash(await File(path).readAsString());
+    for (var i = 0; i < 3; i++) {
+      await writer.write(
+          path: path,
+          yaml: 'a: ${i + 2}',
+          schema: 'raw',
+          prevHash: hash);
+      hash = TheoryYamlSafeWriter.extractHash(await File(path).readAsString());
+    }
+    final backups = Directory('theory_backups')
+        .listSync(recursive: true)
+        .whereType<File>()
+        .toList();
+    expect(backups.length, 2);
+  });
+
+  test('deterministic header & ordering', () async {
+    final dir = Directory('tmp_test')..createSync();
+    final path = p.join(dir.path, 'hdr.yaml');
+    final writer = TheoryYamlSafeWriter();
+    await writer.write(path: path, yaml: 'x: 1', schema: 'raw');
+    final lines1 = await File(path).readAsLines();
+    expect(lines1.first.startsWith('# x-hash:'), isTrue);
+    expect(lines1.first.contains('| x-ver: 1'), isTrue);
+    final hash = TheoryYamlSafeWriter.extractHash(lines1.join('\n'));
+    await writer.write(path: path, yaml: 'x: 1', schema: 'raw', prevHash: hash);
+    final lines2 = await File(path).readAsLines();
+    expect(lines2.first.contains('| x-ver: 1'), isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- Implement TheoryYamlSafeWriter for atomic YAML writes with checksum validation and backups
- Route YamlPackExporter and TheoryAutoInjector through the safe writer
- Add unit tests for conflicts, schema validation, backup retention, and deterministic headers

## Testing
- `dart test test/services/theory_yaml_safe_writer_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68957af6d884832aa682175afcf9efc9