### PR TITLE
Stabilize theory writer with locking and rollback

### DIFF
--- a/lib/models/autogen_status.dart
+++ b/lib/models/autogen_status.dart
@@ -3,12 +3,20 @@ class AutogenStatus {
   final String currentStage;
   final double progress;
   final String? lastError;
+  final String? file;
+  final String? action;
+  final String? prevHash;
+  final String? newHash;
 
   const AutogenStatus({
     this.isRunning = false,
     this.currentStage = '',
     this.progress = 0.0,
     this.lastError,
+    this.file,
+    this.action,
+    this.prevHash,
+    this.newHash,
   });
 
   AutogenStatus copyWith({
@@ -16,12 +24,20 @@ class AutogenStatus {
     String? currentStage,
     double? progress,
     String? lastError,
+    String? file,
+    String? action,
+    String? prevHash,
+    String? newHash,
   }) {
     return AutogenStatus(
       isRunning: isRunning ?? this.isRunning,
       currentStage: currentStage ?? this.currentStage,
       progress: progress ?? this.progress,
       lastError: lastError ?? this.lastError,
+      file: file ?? this.file,
+      action: action ?? this.action,
+      prevHash: prevHash ?? this.prevHash,
+      newHash: newHash ?? this.newHash,
     );
   }
 }

--- a/lib/services/file_write_lock_service.dart
+++ b/lib/services/file_write_lock_service.dart
@@ -1,0 +1,37 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+class FileWriteLockService {
+  FileWriteLockService._();
+  static final FileWriteLockService instance = FileWriteLockService._();
+
+  final File _lockFile = File('theory.write.lock');
+
+  Future<RandomAccessFile> acquire() async {
+    final prefs = await SharedPreferences.getInstance();
+    final timeoutSec = prefs.getInt('theory.lock.timeoutSec') ?? 10;
+    final timeout = Duration(seconds: timeoutSec);
+    final start = DateTime.now();
+    while (true) {
+      try {
+        final raf = await _lockFile.open(mode: FileMode.write);
+        await raf.lock(FileLock.exclusive);
+        return raf;
+      } catch (_) {
+        if (DateTime.now().difference(start) > timeout) {
+          throw TimeoutException('Failed to acquire theory write lock');
+        }
+        await Future.delayed(const Duration(milliseconds: 100));
+      }
+    }
+  }
+
+  Future<void> release(RandomAccessFile raf) async {
+    try {
+      await raf.unlock();
+    } catch (_) {}
+    await raf.close();
+  }
+}

--- a/lib/services/theory_write_scope.dart
+++ b/lib/services/theory_write_scope.dart
@@ -1,0 +1,12 @@
+import 'file_write_lock_service.dart';
+
+class TheoryWriteScope {
+  static Future<T> run<T>(Future<T> Function() fn) async {
+    final lock = await FileWriteLockService.instance.acquire();
+    try {
+      return await fn();
+    } finally {
+      await FileWriteLockService.instance.release(lock);
+    }
+  }
+}

--- a/test/core/training/training_pack_exporter_v2_test.dart
+++ b/test/core/training/training_pack_exporter_v2_test.dart
@@ -1,0 +1,44 @@
+import 'dart:io';
+
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:test/test.dart';
+
+import 'package:poker_analyzer/core/training/export/training_pack_exporter_v2.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/models/game_type.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+import 'package:poker_analyzer/services/theory_yaml_safe_writer.dart';
+
+void main() {
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    final packsDir = Directory('packs');
+    if (packsDir.existsSync()) packsDir.deleteSync(recursive: true);
+  });
+
+  test('exporter uses safe writer and preserves header', () async {
+    final tpl = TrainingPackTemplateV2(
+      id: '1',
+      name: 'T',
+      description: '',
+      goal: '',
+      trainingType: TrainingType.pushFold,
+      spots: [],
+      spotCount: 0,
+      positions: [],
+      bb: 0,
+      gameType: GameType.cash,
+      tags: [],
+    );
+    final exporter = TrainingPackExporterV2();
+    final file = await exporter.exportToFile(tpl, fileName: 'test_pack');
+    final first = await file.readAsString();
+    final prev = TheoryYamlSafeWriter.extractHash(first);
+    expect(prev, isNotNull);
+    await exporter.exportToFile(tpl, fileName: 'test_pack');
+    final secondLines = await file.readAsLines();
+    expect(secondLines.first.contains('| x-ver: 1'), isTrue);
+    final hash2 = TheoryYamlSafeWriter.extractHash(await file.readAsString());
+    expect(hash2, equals(prev));
+  });
+}

--- a/test/services/theory_yaml_safe_writer_test.dart
+++ b/test/services/theory_yaml_safe_writer_test.dart
@@ -5,6 +5,8 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:test/test.dart';
 
 import 'package:poker_analyzer/services/theory_yaml_safe_writer.dart';
+import 'package:poker_analyzer/services/theory_write_scope.dart';
+import 'package:poker_analyzer/services/path_transaction_manager.dart';
 
 void main() {
   setUp(() async {
@@ -22,13 +24,27 @@ void main() {
     final path = p.join(dir.path, 'file.yaml');
     final writer = TheoryYamlSafeWriter();
     await writer.write(path: path, yaml: 'id: 1', schema: 'raw');
-    final hash = TheoryYamlSafeWriter.extractHash(await File(path).readAsString());
+    final hash = TheoryYamlSafeWriter.extractHash(
+      await File(path).readAsString(),
+    );
     expect(hash, isNotNull);
     expect(
-      () async =>
-          writer.write(path: path, yaml: 'id: 2', schema: 'raw', prevHash: 'dead'),
+      () async => writer.write(
+        path: path,
+        yaml: 'id: 2',
+        schema: 'raw',
+        prevHash: 'dead',
+      ),
       throwsA(isA<TheoryWriteConflict>()),
     );
+  });
+
+  test('extractHash parsing', () {
+    final valid = '# x-hash: ${'a' * 64} | x-ver: 1 | x-ts: now';
+    expect(TheoryYamlSafeWriter.extractHash(valid), 'a' * 64);
+    final invalid = '# x-hash: 123 | x-ver: 1 | x-ts: now';
+    expect(TheoryYamlSafeWriter.extractHash(invalid), isNull);
+    expect(TheoryYamlSafeWriter.extractHash('no header'), isNull);
   });
 
   test('bad schema -> reject', () async {
@@ -47,19 +63,21 @@ void main() {
     final path = p.join(dir.path, 'keep.yaml');
     final writer = TheoryYamlSafeWriter();
     await writer.write(path: path, yaml: 'a: 1', schema: 'raw');
-    var hash = TheoryYamlSafeWriter.extractHash(await File(path).readAsString());
+    var hash = TheoryYamlSafeWriter.extractHash(
+      await File(path).readAsString(),
+    );
     for (var i = 0; i < 3; i++) {
       await writer.write(
-          path: path,
-          yaml: 'a: ${i + 2}',
-          schema: 'raw',
-          prevHash: hash);
+        path: path,
+        yaml: 'a: ${i + 2}',
+        schema: 'raw',
+        prevHash: hash,
+      );
       hash = TheoryYamlSafeWriter.extractHash(await File(path).readAsString());
     }
-    final backups = Directory('theory_backups')
-        .listSync(recursive: true)
-        .whereType<File>()
-        .toList();
+    final backups = Directory(
+      'theory_backups',
+    ).listSync(recursive: true).whereType<File>().toList();
     expect(backups.length, 2);
   });
 
@@ -75,5 +93,59 @@ void main() {
     await writer.write(path: path, yaml: 'x: 1', schema: 'raw', prevHash: hash);
     final lines2 = await File(path).readAsLines();
     expect(lines2.first.contains('| x-ver: 1'), isTrue);
+  });
+
+  test('concurrent writes serialize', () async {
+    final dir = Directory('tmp_test')..createSync();
+    final path = p.join(dir.path, 'concurrent.yaml');
+    final sw = Stopwatch()..start();
+    final f1 = TheoryWriteScope.run(() async {
+      await Future.delayed(const Duration(milliseconds: 300));
+      await TheoryYamlSafeWriter().write(
+        path: path,
+        yaml: 'a: 1',
+        schema: 'raw',
+      );
+    });
+    final f2 = TheoryWriteScope.run(() async {
+      await TheoryYamlSafeWriter().write(
+        path: path,
+        yaml: 'a: 2',
+        schema: 'raw',
+      );
+    });
+    await Future.wait([f1, f2]);
+    sw.stop();
+    expect(sw.elapsedMilliseconds, greaterThanOrEqualTo(300));
+  });
+
+  test('rollback restores from backup', () async {
+    final dir = Directory('tmp_test')..createSync();
+    final path = p.join(dir.path, 'rollback.yaml');
+    final writer = TheoryYamlSafeWriter();
+    await writer.write(path: path, yaml: 'x: 1', schema: 'raw');
+    final prev = TheoryYamlSafeWriter.extractHash(
+      await File(path).readAsString(),
+    );
+    try {
+      await TheoryWriteScope.run(() async {
+        await writer.write(
+          path: path,
+          yaml: 'x: 2',
+          schema: 'raw',
+          prevHash: prev,
+          onBackup: (p0, backup, h, p1) async {
+            await PathTransactionManager(
+              rootDir: '.',
+            ).recordFileBackup(p0, backup);
+          },
+        );
+        throw Exception('boom');
+      });
+    } catch (_) {
+      await PathTransactionManager(rootDir: '.').rollbackFileBackups();
+    }
+    final content = await File(path).readAsString();
+    expect(content.contains('x: 1'), isTrue);
   });
 }


### PR DESCRIPTION
## Summary
- tighten theory YAML header parsing and checksum handling
- serialize theory writes with file locks and journaled backups
- wrap exporter and auto-injector writes in scoped lock

## Testing
- `flutter test` *(fails: file_picker plugin missing & missing file errors)*

------
https://chatgpt.com/codex/tasks/task_e_68957cade1fc832a96f21faf5cddbbac