### PR TITLE
Refine theory writer and lock handling

### DIFF
--- a/lib/services/autogen_pipeline_executor.dart
+++ b/lib/services/autogen_pipeline_executor.dart
@@ -540,6 +540,7 @@ class AutogenPipelineExecutor {
         );
         if (!should) {
           await txn.rollback(userId, txId);
+          await PathTransactionManager(rootDir: '.').rollbackFileBackups();
           AutogenStatusDashboardService.instance.update(
             'PathHardening',
             AutogenStatus(
@@ -590,10 +591,11 @@ class AutogenPipelineExecutor {
           ),
         );
         return <File>[];
-      } catch (e) {
-        await txn.rollback(userId, txId);
-        AutogenStatusDashboardService.instance.update(
-          'PathHardening',
+        } catch (e) {
+          await txn.rollback(userId, txId);
+          await PathTransactionManager(rootDir: '.').rollbackFileBackups();
+          AutogenStatusDashboardService.instance.update(
+            'PathHardening',
           AutogenStatus(
             isRunning: false,
             currentStage: jsonEncode({


### PR DESCRIPTION
## Summary
- overhaul TheoryYamlSafeWriter to validate YAML, manage backups, and ensure atomic writes with proper hashing
- fix global write lock to respect timeout via exclusive open and ensure release
- rollback file backups during autogen pipeline failures

## Testing
- `dart analyze` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_689580cc1268832a9034a45ebc4de27f