### PR TITLE
Refactor YAML writer and file lock

### DIFF
--- a/lib/services/file_write_lock_service.dart
+++ b/lib/services/file_write_lock_service.dart
@@ -1,3 +1,4 @@
+// lib/services/file_write_lock_service.dart
 import 'dart:async';
 import 'dart:io';
 
@@ -11,13 +12,15 @@ class FileWriteLockService {
 
   Future<RandomAccessFile> acquire() async {
     final prefs = await SharedPreferences.getInstance();
-    final timeout =
-        Duration(seconds: prefs.getInt('theory.lock.timeoutSec') ?? 10);
+    final timeout = Duration(
+      seconds: prefs.getInt('theory.lock.timeoutSec') ?? 10,
+    );
     final start = DateTime.now();
+
     while (true) {
       try {
-        final raf =
-            _lockFile.openSync(mode: FileMode.writeOnlyExclusive);
+        // Fails if another process/thread holds it
+        final raf = _lockFile.openSync(mode: FileMode.writeOnlyExclusive);
         return raf;
       } catch (_) {
         if (DateTime.now().difference(start) > timeout) {
@@ -29,6 +32,8 @@ class FileWriteLockService {
   }
 
   Future<void> release(RandomAccessFile raf) async {
+    // No advisory lock held, just close
     await raf.close();
   }
 }
+


### PR DESCRIPTION
## Summary
- rework TheoryYamlSafeWriter to remove duplicates and ensure atomic write with backups
- simplify FileWriteLockService to use exclusive open with timeout

## Testing
- `dart format lib/services/theory_yaml_safe_writer.dart lib/services/file_write_lock_service.dart lib/services/autogen_pipeline_executor.dart` (command not found)
- `dart analyze` (command not found)
- `dart test test/services/theory_yaml_safe_writer_test.dart test/core/training/training_pack_exporter_v2_test.dart` (command not found)


------
https://chatgpt.com/codex/tasks/task_e_68958358adcc832a9407408c39e0e32a