### PR TITLE
Fix write lock cleanup and cross-platform timeout test

### DIFF
--- a/lib/services/file_write_lock_service.dart
+++ b/lib/services/file_write_lock_service.dart
@@ -11,8 +11,7 @@ class FileWriteLockService {
 
   Future<RandomAccessFile> acquire() async {
     final prefs = await SharedPreferences.getInstance();
-    final timeout =
-        Duration(seconds: prefs.getInt('theory.lock.timeoutSec') ?? 10);
+    final timeout = Duration(seconds: prefs.getInt('theory.lock.timeoutSec') ?? 10);
 
     // Open (creates if missing), then try to acquire an exclusive advisory lock.
     final raf = await _lockFile.open(mode: FileMode.write);
@@ -34,10 +33,6 @@ class FileWriteLockService {
     } catch (_) {
       // ignore unlock errors (e.g., already unlocked)
     }
-    try {
-      await raf.close();
-    } catch (_) {
-      // ignore close errors (e.g., already closed)
-    }
+    await raf.close();
   }
 }

--- a/test/services/file_write_lock_service_test.dart
+++ b/test/services/file_write_lock_service_test.dart
@@ -7,9 +7,26 @@ import 'package:poker_analyzer/services/file_write_lock_service.dart';
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  test('second lock times out while first is held', () async {
+  test('second process times out while first holds the lock', () async {
     SharedPreferences.setMockInitialValues({'theory.lock.timeoutSec': 1});
-    final lock1 = await FileWriteLockService.instance.acquire();
+
+    final script = '''
+import 'dart:io';
+Future<void> main() async {
+  final f = File('theory.write.lock');
+  final raf = await f.open(mode: FileMode.write);
+  await raf.lock(FileLock.exclusive);
+  await Future.delayed(Duration(seconds: 2));
+  await raf.unlock();
+  await raf.close();
+}
+''';
+    final dir = await Directory.systemTemp.createTemp('lock-test');
+    final scriptFile = File('${dir.path}/hold_lock.dart');
+    await scriptFile.writeAsString(script);
+
+    final dart = Platform.resolvedExecutable;
+    final p = await Process.start(dart, [scriptFile.path]);
 
     final sw = Stopwatch()..start();
     await expectLater(
@@ -19,8 +36,9 @@ void main() {
     sw.stop();
     expect(sw.elapsedMilliseconds, greaterThanOrEqualTo(900));
 
-    await FileWriteLockService.instance.release(lock1);
-  }, skip: Platform.isLinux);
+    await p.exitCode.timeout(const Duration(seconds: 5), onTimeout: () => p.kill());
+    await dir.delete(recursive: true);
+  });
 
   test('release is idempotent-ish (ignores unlock errors)', () async {
     SharedPreferences.setMockInitialValues({'theory.lock.timeoutSec': 1});


### PR DESCRIPTION
## Summary
- simplify FileWriteLockService by computing timeout once and closing file handles cleanly
- add cross-process timeout test to ensure lock behavior is consistent across platforms

## Testing
- `flutter test test/services/file_write_lock_service_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68958c79906c832aae2d9389d3b34f20