### PR TITLE
Streamline file write lock service and test

### DIFF
--- a/lib/services/file_write_lock_service.dart
+++ b/lib/services/file_write_lock_service.dart
@@ -11,7 +11,9 @@ class FileWriteLockService {
 
   Future<RandomAccessFile> acquire() async {
     final prefs = await SharedPreferences.getInstance();
-    final timeout = Duration(seconds: prefs.getInt('theory.lock.timeoutSec') ?? 10);
+    final timeout = Duration(
+      seconds: prefs.getInt('theory.lock.timeoutSec') ?? 10,
+    );
 
     // Open (creates if missing), then try to acquire an exclusive advisory lock.
     final raf = await _lockFile.open(mode: FileMode.write);

--- a/test/services/file_write_lock_service_test.dart
+++ b/test/services/file_write_lock_service_test.dart
@@ -39,13 +39,10 @@ Future<void> main() async {
     expect(sw.elapsedMilliseconds, greaterThanOrEqualTo(900));
 
     // Cleanup
-    await child.exitCode.timeout(
-      const Duration(seconds: 5),
-      onTimeout: () {
-        child.kill();
-        return -1;
-      },
-    );
+    await child.exitCode.timeout(const Duration(seconds: 5), onTimeout: () {
+      child.kill();
+      return -1;
+    });
     await dir.delete(recursive: true);
   });
 


### PR DESCRIPTION
## Summary
- Replace stray timeout line in FileWriteLockService with cleaned up Duration initialization
- Simplify cross-platform file write lock test cleanup

## Testing
- `flutter test test/services/file_write_lock_service_test.dart` *(fails: command not found: flutter)*
- `dart test test/services/file_write_lock_service_test.dart` *(fails: command not found: dart)*


------
https://chatgpt.com/codex/tasks/task_e_689590d16968832a9cbed132f2d8c73d