### PR TITLE
Remove duplicate timeout declaration

### DIFF
--- a/lib/services/file_write_lock_service.dart
+++ b/lib/services/file_write_lock_service.dart
@@ -11,9 +11,7 @@ class FileWriteLockService {
 
   Future<RandomAccessFile> acquire() async {
     final prefs = await SharedPreferences.getInstance();
-    final timeout = Duration(
-      seconds: prefs.getInt('theory.lock.timeoutSec') ?? 10,
-    );
+    final timeout = Duration(seconds: prefs.getInt('theory.lock.timeoutSec') ?? 10);
 
     // Open (creates if missing), then try to acquire an exclusive advisory lock.
     final raf = await _lockFile.open(mode: FileMode.write);


### PR DESCRIPTION
## Summary
- simplify theory write lock acquisition with a single timeout declaration

## Testing
- `dart test` *(fails: Flutter SDK not available)*

------
https://chatgpt.com/codex/tasks/task_e_689594f39f04832abb5545dacde7a5d1