### PR TITLE
Add safe theory YAML reader with auto-heal

### DIFF
--- a/lib/core/training/generation/yaml_reader.dart
+++ b/lib/core/training/generation/yaml_reader.dart
@@ -5,6 +5,7 @@ import 'package:yaml/yaml.dart';
 import '../../models/v2/training_pack_template_v2.dart';
 import '../../models/v2/training_pack_template_set.dart';
 import '../../services/training_pack_template_set_generator.dart';
+import '../../services/theory_yaml_safe_reader.dart';
 import '../../../utils/yaml_utils.dart';
 
 class YamlReader {
@@ -18,10 +19,13 @@ class YamlReader {
   /// Loads a training pack template from [path]. The path can point to an asset
   /// (starting with `assets/`) or to a file on disk.
   Future<TrainingPackTemplateV2> loadTemplate(String path) async {
-    final source = path.startsWith('assets/')
-        ? await rootBundle.loadString(path)
-        : await File(path).readAsString();
-    return TrainingPackTemplateV2.fromYamlAuto(source);
+    if (path.startsWith('assets/')) {
+      final source = await rootBundle.loadString(path);
+      return TrainingPackTemplateV2.fromYamlAuto(source);
+    }
+    final map =
+        await TheoryYamlSafeReader().read(path: path, schema: 'TemplateSet');
+    return TrainingPackTemplateV2.fromJson(map);
   }
 
   /// Loads all templates defined in [path]. The file may contain either a
@@ -29,17 +33,29 @@ class YamlReader {
   /// When a set is provided, it expands into multiple [TrainingPackTemplateV2]
   /// instances using the variant values.
   Future<List<TrainingPackTemplateV2>> loadTemplates(String path) async {
-    final source = path.startsWith('assets/')
-        ? await rootBundle.loadString(path)
-        : await File(path).readAsString();
-    final map = read(source);
+    if (path.startsWith('assets/')) {
+      final source = await rootBundle.loadString(path);
+      final map = read(source);
+      if ((map['template'] is Map && map['variants'] is List) ||
+          map['templateSet'] is List ||
+          (map['base'] is Map && map['variations'] is List)) {
+        final set = TrainingPackTemplateSet.fromJson(map);
+        return const TrainingPackTemplateSetGenerator().generate(set);
+      }
+      final tpl =
+          TrainingPackTemplateV2.fromJson(Map<String, dynamic>.from(map));
+      return [tpl];
+    }
+    final map =
+        await TheoryYamlSafeReader().read(path: path, schema: 'TemplateSet');
     if ((map['template'] is Map && map['variants'] is List) ||
         map['templateSet'] is List ||
         (map['base'] is Map && map['variations'] is List)) {
       final set = TrainingPackTemplateSet.fromJson(map);
       return const TrainingPackTemplateSetGenerator().generate(set);
     }
-    final tpl = TrainingPackTemplateV2.fromJson(Map<String, dynamic>.from(map));
+    final tpl =
+        TrainingPackTemplateV2.fromJson(Map<String, dynamic>.from(map));
     return [tpl];
   }
 }

--- a/lib/services/theory_auto_injector.dart
+++ b/lib/services/theory_auto_injector.dart
@@ -3,12 +3,12 @@ import 'dart:io';
 
 import 'package:json2yaml/json2yaml.dart';
 import 'package:path/path.dart' as p;
-import 'package:yaml/yaml.dart';
 
 import '../models/autogen_status.dart';
 import 'autogen_status_dashboard_service.dart';
 import 'preferences_service.dart';
 import 'theory_yaml_safe_writer.dart';
+import 'theory_yaml_safe_reader.dart';
 import 'theory_write_scope.dart';
 import 'path_transaction_manager.dart';
 
@@ -83,9 +83,9 @@ class TheoryAutoInjector {
           errors[packId] = 'pack_missing';
           continue;
         }
+        final data = await TheoryYamlSafeReader()
+            .read(path: file.path, schema: 'TemplateSet');
         final yamlStr = await file.readAsString();
-        final data =
-            jsonDecode(jsonEncode(loadYaml(yamlStr))) as Map<String, dynamic>;
         final meta = Map<String, dynamic>.from(data['meta'] ?? {});
         final existing =
             (meta['theoryLinks'] as List?)?.cast<String>() ?? <String>[];

--- a/lib/services/theory_template_index.dart
+++ b/lib/services/theory_template_index.dart
@@ -4,6 +4,7 @@ import 'package:path/path.dart' as p;
 
 import '../models/v2/training_pack_template_v2.dart';
 import 'theory_pack_generator_service.dart';
+import 'theory_yaml_safe_reader.dart';
 
 /// Generates a JSON index for theory YAML packs in `yaml_out/`.
 class TheoryTemplateIndex {
@@ -25,8 +26,9 @@ class TheoryTemplateIndex {
     final list = <Map<String, dynamic>>[];
     for (final file in files) {
       try {
-        final yaml = await file.readAsString();
-        final tpl = TrainingPackTemplateV2.fromYamlAuto(yaml);
+        final map = await TheoryYamlSafeReader()
+            .read(path: file.path, schema: 'TemplateSet');
+        final tpl = TrainingPackTemplateV2.fromJson(map);
         list.add({
           'id': tpl.id,
           'tags': tpl.tags,

--- a/lib/services/theory_yaml_safe_reader.dart
+++ b/lib/services/theory_yaml_safe_reader.dart
@@ -1,0 +1,139 @@
+// lib/services/theory_yaml_safe_reader.dart
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:path/path.dart' as p;
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:yaml/yaml.dart';
+
+import '../models/autogen_status.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import 'autogen_status_dashboard_service.dart';
+import 'autogen_pipeline_event_logger_service.dart';
+
+class TheoryReadCorruption implements Exception {
+  final String message;
+  TheoryReadCorruption(this.message);
+  @override
+  String toString() => 'TheoryReadCorruption: $message';
+}
+
+/// Safely reads theory YAML files with checksum verification and auto-heal.
+class TheoryYamlSafeReader {
+  TheoryYamlSafeReader({AutogenStatusDashboardService? dashboard})
+      : _dashboard = dashboard ?? AutogenStatusDashboardService.instance;
+
+  final AutogenStatusDashboardService _dashboard;
+
+  static final _headerRe = RegExp(
+      r'^#\s*x-hash:\s*([0-9a-f]{64})\s*\|\s*x-ver:\s*(\d+).*$');
+
+  Future<Map<String, dynamic>> read({
+    required String path,
+    required String schema,
+    bool autoHeal = true,
+  }) async {
+    final prefs = await SharedPreferences.getInstance();
+    final healEnabled =
+        autoHeal && (prefs.getBool('theory.reader.autoHeal') ?? true);
+    final strict = prefs.getBool('theory.reader.strict') ?? true;
+    final file = File(path);
+    try {
+      final lines = await file.readAsLines();
+      if (lines.isEmpty) throw TheoryReadCorruption('empty_file');
+      final header = lines.first.trim();
+      final m = _headerRe.firstMatch(header);
+      if (m == null) throw TheoryReadCorruption('missing_header');
+      final expected = m.group(1)!;
+      final body = lines.skip(1).join('\n');
+      final hash = sha256.convert(utf8.encode(body)).toString();
+      if (hash != expected) {
+        AutogenPipelineEventLoggerService.log('theory.hash_mismatch', path);
+        if (healEnabled) {
+          final restored = await _tryHeal(path, schema, strict);
+          if (restored != null) {
+            AutogenPipelineEventLoggerService.log(
+                'theory.autoheal_success', path);
+            return restored;
+          }
+          AutogenPipelineEventLoggerService.log(
+              'theory.autoheal_failed', path);
+        }
+        _dashboard.update(
+          'TheoryReader',
+          AutogenStatus(
+            currentStage: 'corrupt',
+            action: 'corrupt',
+            file: path,
+            lastError: 'checksum_mismatch',
+          ),
+        );
+        throw TheoryReadCorruption('checksum_mismatch');
+      }
+      final map = _parse(body);
+      _enforceSchema(map, schema, strict);
+      AutogenPipelineEventLoggerService.log('theory.read_ok', path);
+      return map;
+    } catch (e) {
+      if (e is TheoryReadCorruption) rethrow;
+      AutogenPipelineEventLoggerService.log(
+          'theory.read_schema_error', '$path:$e');
+      rethrow;
+    }
+  }
+
+  Map<String, dynamic> _parse(String yaml) {
+    final doc = loadYaml(yaml);
+    return jsonDecode(jsonEncode(doc)) as Map<String, dynamic>;
+  }
+
+  void _enforceSchema(
+      Map<String, dynamic> map, String schema, bool strict) {
+    if (!strict) return;
+    if (schema == 'TemplateSet') {
+      // Throws if invalid
+      TrainingPackTemplateV2.fromJson(map);
+    }
+  }
+
+  Future<Map<String, dynamic>?> _tryHeal(
+      String path, String schema, bool strict) async {
+    final rel = p.relative(path);
+    final base = p.basename(rel);
+    final backupDir = Directory(p.join('theory_backups', p.dirname(rel)));
+    if (!backupDir.existsSync()) return null;
+    final files = backupDir
+        .listSync()
+        .whereType<File>()
+        .where((f) => p.basename(f.path).startsWith('$base.'))
+        .toList()
+      ..sort((a, b) => b.path.compareTo(a.path));
+    for (final f in files) {
+      try {
+        final lines = await f.readAsLines();
+        if (lines.isEmpty) continue;
+        final m = _headerRe.firstMatch(lines.first.trim());
+        if (m == null) continue;
+        final expected = m.group(1)!;
+        final body = lines.skip(1).join('\n');
+        final hash = sha256.convert(utf8.encode(body)).toString();
+        if (hash != expected) continue;
+        final map = _parse(body);
+        _enforceSchema(map, schema, strict);
+        try {
+          final corrupt = File(path);
+          if (corrupt.existsSync()) {
+            await corrupt.rename('$path.corrupt');
+          }
+          await f.rename(path);
+        } catch (_) {
+          await File(path).delete().catchError((_) {});
+          await f.rename(path);
+        }
+        return map;
+      } catch (_) {}
+    }
+    return null;
+  }
+}

--- a/test/services/theory_yaml_safe_reader_test.dart
+++ b/test/services/theory_yaml_safe_reader_test.dart
@@ -1,0 +1,81 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:test/test.dart';
+
+import 'package:poker_analyzer/services/theory_yaml_safe_reader.dart';
+import 'package:poker_analyzer/services/theory_yaml_safe_writer.dart';
+import 'package:poker_analyzer/services/autogen_pipeline_event_logger_service.dart';
+
+void main() {
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({
+      'theory.reader.autoHeal': true,
+      'theory.reader.strict': true,
+    });
+    final backupRoot = Directory('theory_backups');
+    if (backupRoot.existsSync()) backupRoot.deleteSync(recursive: true);
+    final tmp = Directory('tmp_reader_test');
+    if (tmp.existsSync()) tmp.deleteSync(recursive: true);
+    AutogenPipelineEventLoggerService.clearLog();
+  });
+
+  test('valid read passes', () async {
+    final dir = Directory('tmp_reader_test')..createSync();
+    final path = p.join(dir.path, 'pack.yaml');
+    const body = 'id: t1\nname: Test\ntrainingType: theory\ngameType: cash\nbb: 1\nspots: []\n';
+    await TheoryYamlSafeWriter().write(path: path, yaml: body, schema: 'TemplateSet');
+    final map = await TheoryYamlSafeReader().read(path: path, schema: 'TemplateSet');
+    expect(map['id'], 't1');
+    final log = AutogenPipelineEventLoggerService.getLog();
+    expect(log.any((e) => e.type == 'theory.read_ok'), isTrue);
+  });
+
+  test('tampered body heals from backup', () async {
+    final dir = Directory('tmp_reader_test')..createSync();
+    final path = p.join(dir.path, 'heal.yaml');
+    const body1 = 'id: a\nname: A\ntrainingType: theory\ngameType: cash\nbb: 1\nspots: []\n';
+    const body2 = 'id: b\nname: B\ntrainingType: theory\ngameType: cash\nbb: 1\nspots: []\n';
+    final writer = TheoryYamlSafeWriter();
+    await writer.write(path: path, yaml: body1, schema: 'TemplateSet');
+    final prev = TheoryYamlSafeWriter.extractHash(await File(path).readAsString());
+    await writer.write(path: path, yaml: body2, schema: 'TemplateSet', prevHash: prev);
+    final lines = await File(path).readAsLines();
+    lines[1] = 'id: corrupt';
+    await File(path).writeAsString(lines.join('\n'));
+    final map = await TheoryYamlSafeReader().read(path: path, schema: 'TemplateSet');
+    expect(map['id'], 'a');
+    final events = AutogenPipelineEventLoggerService.getLog();
+    expect(events.any((e) => e.type == 'theory.hash_mismatch'), isTrue);
+    expect(events.any((e) => e.type == 'theory.autoheal_success'), isTrue);
+  });
+
+  test('no backup throws', () async {
+    final dir = Directory('tmp_reader_test')..createSync();
+    final path = p.join(dir.path, 'nobak.yaml');
+    const body = 'id: x\nname: X\ntrainingType: theory\ngameType: cash\nbb: 1\nspots: []\n';
+    await TheoryYamlSafeWriter().write(path: path, yaml: body, schema: 'TemplateSet');
+    final lines = await File(path).readAsLines();
+    lines[1] = 'id: bad';
+    await File(path).writeAsString(lines.join('\n'));
+    expect(
+      () => TheoryYamlSafeReader().read(path: path, schema: 'TemplateSet'),
+      throwsA(isA<TheoryReadCorruption>()),
+    );
+    final events = AutogenPipelineEventLoggerService.getLog();
+    expect(events.any((e) => e.type == 'theory.autoheal_failed'), isTrue);
+  });
+
+  test('bad schema throws', () async {
+    final dir = Directory('tmp_reader_test')..createSync();
+    final path = p.join(dir.path, 'bad.yaml');
+    await TheoryYamlSafeWriter().write(path: path, yaml: 'id: 1', schema: 'raw');
+    expect(
+      () => TheoryYamlSafeReader().read(path: path, schema: 'TemplateSet'),
+      throwsA(anything),
+    );
+    final events = AutogenPipelineEventLoggerService.getLog();
+    expect(events.any((e) => e.type == 'theory.read_schema_error'), isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- implement `TheoryYamlSafeReader` to verify YAML checksums, enforce schema, log telemetry, and auto-heal from latest backups
- route theory file loads through the safe reader in training pack loader, auto injector, and template index
- add unit tests covering valid reads, corruption auto-heal, missing backups, and schema errors

## Testing
- `dart test test/services/theory_yaml_safe_reader_test.dart` *(failed: command not found)*
- `flutter test test/services/theory_yaml_safe_reader_test.dart` *(failed: command not found)*
- `apt-get install -y dart-sdk` *(failed: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895b45a9874832aa561affd8aa3a320