### PR TITLE
feat: add theory integrity sweeper

### DIFF
--- a/bin/poker_analyzer.dart
+++ b/bin/poker_analyzer.dart
@@ -1,0 +1,16 @@
+import 'package:args/args.dart';
+import 'package:poker_analyzer/services/theory_integrity_sweeper.dart';
+
+Future<void> main(List<String> args) async {
+  if (args.isEmpty || args.first != 'sweep') {
+    print('Usage: poker_analyzer sweep --dir <path> [--fix]');
+    return;
+  }
+  final parser = ArgParser()
+    ..addMultiOption('dir')
+    ..addFlag('fix', negatable: false);
+  final result = parser.parse(args.skip(1));
+  final dirs = result['dir'] as List<String>;
+  final fix = result['fix'] as bool;
+  await TheoryIntegritySweeper().run(dirs: dirs, dryRun: !fix);
+}

--- a/lib/services/app_init_service.dart
+++ b/lib/services/app_init_service.dart
@@ -1,5 +1,6 @@
 import 'yaml_pack_archive_auto_cleaner_service.dart';
 import 'theory_injection_scheduler_service.dart';
+import 'theory_integrity_sweep_scheduler_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class AppInitService {
@@ -15,5 +16,6 @@ class AppInitService {
       }
     }
     await TheoryInjectionSchedulerService.instance.start();
+    await TheoryIntegritySweepSchedulerService.instance.start();
   }
 }

--- a/lib/services/theory_integrity_sweep_scheduler_service.dart
+++ b/lib/services/theory_integrity_sweep_scheduler_service.dart
@@ -1,0 +1,35 @@
+import 'dart:async';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'theory_integrity_sweeper.dart';
+
+class TheoryIntegritySweepSchedulerService {
+  TheoryIntegritySweepSchedulerService._({TheoryIntegritySweeper? sweeper})
+    : _sweeper = sweeper ?? TheoryIntegritySweeper();
+
+  static final TheoryIntegritySweepSchedulerService instance =
+      TheoryIntegritySweepSchedulerService._();
+
+  final TheoryIntegritySweeper _sweeper;
+  Timer? _timer;
+
+  Future<void> start() async {
+    final prefs = await SharedPreferences.getInstance();
+    if (!(prefs.getBool('theory.sweep.enabled') ?? true)) return;
+    final dirs = prefs.getStringList('theory.sweep.dirs') ?? const [];
+    if (dirs.isEmpty) return;
+    final intervalHours = prefs.getInt('theory.sweep.intervalHours') ?? 24;
+    await _sweeper.run(dirs: dirs, dryRun: true);
+    _timer?.cancel();
+    _timer = Timer.periodic(
+      Duration(hours: intervalHours),
+      (_) => _sweeper.run(dirs: dirs, dryRun: true),
+    );
+  }
+
+  Future<void> stop() async {
+    _timer?.cancel();
+    _timer = null;
+  }
+}

--- a/lib/services/theory_integrity_sweeper.dart
+++ b/lib/services/theory_integrity_sweeper.dart
@@ -1,0 +1,259 @@
+// lib/services/theory_integrity_sweeper.dart
+import 'dart:async';
+import 'dart:collection';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:path/path.dart' as p;
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:synchronized/synchronized.dart';
+import 'package:yaml/yaml.dart';
+
+import '../models/autogen_status.dart';
+import 'autogen_status_dashboard_service.dart';
+import 'theory_yaml_safe_reader.dart';
+import 'theory_write_scope.dart';
+import 'theory_yaml_canonicalizer.dart';
+
+class SweepEntry {
+  final String file;
+  final String action;
+  final String? oldHash;
+  final String? newHash;
+  final int? headerVersion;
+  final int pruned;
+
+  const SweepEntry({
+    required this.file,
+    required this.action,
+    this.oldHash,
+    this.newHash,
+    this.headerVersion,
+    this.pruned = 0,
+  });
+
+  Map<String, dynamic> toJson() => {
+    'file': file,
+    'action': action,
+    'oldHash': oldHash,
+    'newHash': newHash,
+    'headerVersion': headerVersion,
+    'pruned': pruned,
+  };
+}
+
+class SweepReport {
+  final List<SweepEntry> entries;
+  final Map<String, int> counters;
+
+  SweepReport({List<SweepEntry>? entries, Map<String, int>? counters})
+    : entries = entries ?? [],
+      counters = counters ?? {'ok': 0, 'upgraded': 0, 'healed': 0, 'failed': 0};
+
+  Map<String, dynamic> toJson() => {
+    'entries': entries.map((e) => e.toJson()).toList(),
+    'counters': counters,
+  };
+}
+
+class TheoryIntegritySweeper {
+  TheoryIntegritySweeper({
+    AutogenStatusDashboardService? dashboard,
+    TheoryYamlSafeReader? reader,
+  }) : _dashboard = dashboard ?? AutogenStatusDashboardService.instance,
+       _reader = reader ?? TheoryYamlSafeReader();
+
+  final AutogenStatusDashboardService _dashboard;
+  final TheoryYamlSafeReader _reader;
+
+  Future<SweepReport> run({
+    required List<String> dirs,
+    bool dryRun = true,
+    bool heal = true,
+  }) async {
+    final prefs = await SharedPreferences.getInstance();
+    final maxParallel = prefs.getInt('theory.sweep.maxParallel') ?? 2;
+    final keep = prefs.getInt('theory.backups.keep') ?? 10;
+
+    final files = <String>[];
+    for (final dir in dirs) {
+      final d = Directory(dir);
+      if (!d.existsSync()) continue;
+      files.addAll(
+        d
+            .listSync(recursive: true)
+            .whereType<File>()
+            .where((f) => f.path.endsWith('.yaml'))
+            .map((f) => f.path),
+      );
+    }
+    files.sort();
+    final total = files.length;
+
+    final queue = Queue<String>.from(files);
+    final report = SweepReport();
+    final lock = Lock();
+    var processed = 0;
+
+    Future<void> worker() async {
+      while (true) {
+        String? path;
+        await lock.synchronized(() {
+          if (queue.isNotEmpty) {
+            path = queue.removeFirst();
+          }
+        });
+        if (path == null) break;
+        final entry = await _process(
+          path!,
+          dryRun: dryRun,
+          heal: heal,
+          keep: keep,
+        );
+        await lock.synchronized(() {
+          report.entries.add(entry);
+          report.counters[entry.action] =
+              (report.counters[entry.action] ?? 0) + 1;
+          processed++;
+          _dashboard.update(
+            'TheorySweep',
+            AutogenStatus(
+              currentStage: 'running',
+              progress: total == 0 ? 1 : processed / total,
+              file: path,
+              action: entry.action,
+            ),
+          );
+        });
+      }
+    }
+
+    final workers = [for (var i = 0; i < maxParallel; i++) worker()];
+    await Future.wait(workers);
+
+    await _writeReport(report);
+    return report;
+  }
+
+  Future<SweepEntry> _process(
+    String path, {
+    required bool dryRun,
+    required bool heal,
+    required int keep,
+  }) async {
+    return TheoryWriteScope.run(() async {
+      final file = File(path);
+      if (!file.existsSync()) {
+        return SweepEntry(file: path, action: 'failed');
+      }
+      final lines = await file.readAsLines();
+      final headerMap = _parseHeader(lines.isEmpty ? '' : lines.first);
+      final oldHash = headerMap['x-hash'];
+      final oldAlgo = headerMap['x-hash-algo'];
+      final version = int.tryParse(headerMap['x-ver'] ?? '');
+
+      try {
+        await _reader.read(
+          path: path,
+          schema: 'TemplateSet',
+          autoHeal: !dryRun && heal,
+        );
+      } catch (_) {
+        return SweepEntry(
+          file: path,
+          action: 'failed',
+          oldHash: oldHash,
+          newHash: oldHash,
+          headerVersion: version,
+        );
+      }
+
+      final afterLines = await file.readAsLines();
+      final newHeader = _parseHeader(afterLines.first);
+      var newHash = newHeader['x-hash'];
+      final newAlgo = newHeader['x-hash-algo'];
+      final newVersion = int.tryParse(newHeader['x-ver'] ?? '');
+
+      var action = 'ok';
+      if (oldHash != newHash) {
+        if (oldAlgo != newAlgo) {
+          action = 'upgraded';
+        } else {
+          action = 'healed';
+        }
+      }
+
+      var pruned = 0;
+      if (!dryRun && action != 'failed') {
+        pruned = _pruneBackups(path, keep);
+      }
+
+      if (dryRun && action == 'upgraded') {
+        final body = lines.skip(1).join('\n');
+        final canon = const TheoryYamlCanonicalizer().canonicalize(
+          jsonDecode(jsonEncode(loadYaml(body))) as Map<String, dynamic>,
+        );
+        newHash = sha256.convert(utf8.encode(canon)).toString();
+      }
+
+      return SweepEntry(
+        file: path,
+        action: action,
+        oldHash: oldHash,
+        newHash: newHash,
+        headerVersion: newVersion,
+        pruned: pruned,
+      );
+    });
+  }
+
+  Map<String, String> _parseHeader(String line) {
+    if (!line.startsWith('#')) return {};
+    final map = <String, String>{};
+    final parts = line.substring(1).split('|');
+    for (final part in parts) {
+      final kv = part.split(':');
+      if (kv.length >= 2) {
+        map[kv[0].trim()] = kv.sublist(1).join(':').trim();
+      }
+    }
+    return map;
+  }
+
+  int _pruneBackups(String path, int keep) {
+    final rel = p.relative(path);
+    final base = p.basename(rel);
+    final dir = Directory(p.join('theory_backups', p.dirname(rel)));
+    if (!dir.existsSync()) return 0;
+    final backups =
+        dir
+            .listSync()
+            .whereType<File>()
+            .where((f) => p.basename(f.path).startsWith('$base.'))
+            .toList()
+          ..sort((a, b) => a.path.compareTo(b.path));
+    final over = backups.length - keep;
+    if (over > 0) {
+      for (final f in backups.take(over)) {
+        f.deleteSync();
+      }
+      return over;
+    }
+    return 0;
+  }
+
+  Future<void> _writeReport(SweepReport report) async {
+    final jsonFile = File('theory_sweep_report.json');
+    await jsonFile.writeAsString(jsonEncode(report.toJson()));
+    final csvFile = File('theory_sweep_report.csv');
+    final lines = [
+      'file,action,oldHash,newHash,headerVersion,pruned',
+      ...report.entries.map(
+        (e) =>
+            '${e.file},${e.action},${e.oldHash ?? ''},${e.newHash ?? ''},${e.headerVersion ?? ''},${e.pruned}',
+      ),
+    ];
+    await csvFile.writeAsString(lines.join('\n'));
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
 
 executables:
   batch_generate: bin/batch_generate.dart
+  poker_analyzer: bin/poker_analyzer.dart
 
 dependencies:
   flutter:

--- a/test/services/theory_integrity_sweeper_test.dart
+++ b/test/services/theory_integrity_sweeper_test.dart
@@ -1,0 +1,114 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:path/path.dart' as p;
+import 'package:poker_analyzer/services/theory_integrity_sweeper.dart';
+import 'package:poker_analyzer/services/theory_yaml_canonicalizer.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:test/test.dart';
+import 'package:yaml/yaml.dart';
+
+void main() {
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  test('upgrades legacy headers and prunes backups', () async {
+    final tmp = await Directory.systemTemp.createTemp();
+    Directory.current = tmp.path;
+    SharedPreferences prefs = await SharedPreferences.getInstance();
+    await prefs.setInt('theory.backups.keep', 1);
+    await prefs.setInt('theory.sweep.maxParallel', 2);
+    await prefs.setBool('theory.reader.strict', false);
+
+    final dir = Directory('theory')..createSync(recursive: true);
+    final file = File(p.join(dir.path, 'legacy.yaml'));
+    final body = 'name: test\n';
+    final legacyHash = sha256.convert(utf8.encode(body)).toString();
+    file.writeAsStringSync('# x-hash: $legacyHash | x-ver: 1 | x-ts: 0\n$body');
+
+    // create extra backups to prune
+    final backupDir = Directory(p.join('theory_backups', 'theory'))
+      ..createSync(recursive: true);
+    File(
+      p.join(backupDir.path, 'legacy.yaml.1.yaml'),
+    ).writeAsStringSync('# backup\n');
+    File(
+      p.join(backupDir.path, 'legacy.yaml.2.yaml'),
+    ).writeAsStringSync('# backup\n');
+
+    final sweeper = TheoryIntegritySweeper();
+    final report = await sweeper.run(dirs: [dir.path], dryRun: false);
+    final entry = report.entries.firstWhere((e) => e.file == file.path);
+    expect(entry.action, 'upgraded');
+    final firstLine = file.readAsLinesSync().first;
+    expect(firstLine.contains('x-hash-algo'), isTrue);
+    // backups pruned to keep
+    final remaining = backupDir
+        .listSync()
+        .whereType<File>()
+        .where((f) => f.path.contains('legacy.yaml'))
+        .length;
+    expect(remaining, 1);
+  });
+
+  test('heals corrupt file from backup and is idempotent', () async {
+    final tmp = await Directory.systemTemp.createTemp();
+    Directory.current = tmp.path;
+    SharedPreferences prefs = await SharedPreferences.getInstance();
+    await prefs.setInt('theory.backups.keep', 1);
+    await prefs.setBool('theory.reader.strict', false);
+
+    final dir = Directory('packs')..createSync();
+    final file = File(p.join(dir.path, 'pack.yaml'));
+    final goodBody = 'name: good\n';
+    final canon = const TheoryYamlCanonicalizer().canonicalize({
+      'name': 'good',
+    });
+    final goodHash = sha256.convert(utf8.encode(canon)).toString();
+    file.writeAsStringSync(
+      '# x-hash: $goodHash | x-ver: 1 | x-ts: 0 | x-hash-algo: sha256-canon@v1\n$goodBody',
+    );
+
+    // corrupt main file
+    file.writeAsStringSync(
+      '# x-hash: $goodHash | x-ver: 1 | x-ts: 0 | x-hash-algo: sha256-canon@v1\nname: bad\n',
+    );
+
+    // good backup
+    final backupDir = Directory(p.join('theory_backups', 'packs'))
+      ..createSync(recursive: true);
+    File(p.join(backupDir.path, 'pack.yaml.1.yaml')).writeAsStringSync(
+      '# x-hash: $goodHash | x-ver: 1 | x-ts: 0 | x-hash-algo: sha256-canon@v1\n$goodBody',
+    );
+
+    final sweeper = TheoryIntegritySweeper();
+    var report = await sweeper.run(dirs: [dir.path], dryRun: false);
+    final entry = report.entries.firstWhere((e) => e.file == file.path);
+    expect(entry.action, 'healed');
+    expect(file.readAsLinesSync()[1], 'name: good');
+
+    // re-run should be no-op
+    report = await sweeper.run(dirs: [dir.path], dryRun: false);
+    expect(report.entries.first.action, 'ok');
+  });
+
+  test('dryRun does not mutate', () async {
+    final tmp = await Directory.systemTemp.createTemp();
+    Directory.current = tmp.path;
+    SharedPreferences prefs = await SharedPreferences.getInstance();
+    await prefs.setBool('theory.reader.strict', false);
+
+    final dir = Directory('theory')..createSync();
+    final file = File(p.join(dir.path, 'legacy.yaml'));
+    final body = 'name: test\n';
+    final legacyHash = sha256.convert(utf8.encode(body)).toString();
+    file.writeAsStringSync('# x-hash: $legacyHash | x-ver: 1 | x-ts: 0\n$body');
+
+    final sweeper = TheoryIntegritySweeper();
+    final report = await sweeper.run(dirs: [dir.path], dryRun: true);
+    final entry = report.entries.firstWhere((e) => e.file == file.path);
+    expect(entry.action, 'upgraded');
+    final firstLine = file.readAsLinesSync().first;
+    expect(firstLine.contains('x-hash-algo'), isFalse);
+  });
+}


### PR DESCRIPTION
## Summary
- add TheoryIntegritySweeper to verify, heal and prune theory YAML files
- expose `poker_analyzer sweep` CLI and periodic scheduler hook
- cover sweeper with upgrade, heal, and dry-run tests

## Testing
- `dart test` *(fails: Flutter SDK is not available)*

------
https://chatgpt.com/codex/tasks/task_e_6895bd90d734832abc486c64945f65c1