### PR TITLE
feat: add theory manifest and CI verify mode

### DIFF
--- a/bin/poker_analyzer.dart
+++ b/bin/poker_analyzer.dart
@@ -1,42 +1,103 @@
+import 'dart:io';
+
 import 'package:args/args.dart';
 import 'package:poker_analyzer/services/config_source.dart';
 import 'package:poker_analyzer/services/theory_integrity_sweeper.dart';
+import 'package:poker_analyzer/services/theory_manifest_service.dart';
 import 'package:poker_analyzer/services/theory_yaml_safe_reader.dart';
 
 Future<void> main(List<String> args) async {
-  if (args.isEmpty || args.first != 'sweep') {
-    print('Usage: poker_analyzer sweep --dir <path> [--fix] [--config <file>]');
+  if (args.isEmpty) {
+    print('Usage: poker_analyzer <sweep|verify|manifest> ...');
     return;
   }
-  final parser = ArgParser()
-    ..addOption('config')
-    ..addMultiOption('dir')
-    ..addFlag('fix', negatable: false)
-    ..addOption('max-parallel')
-    ..addOption('keep')
-    ..addFlag('strict', defaultsTo: true)
-    ..addFlag('auto-heal', defaultsTo: true);
-  final result = parser.parse(args.skip(1));
-  final dirs = result['dir'] as List<String>;
-  final fix = result['fix'] as bool;
-  final cli = <String, dynamic>{};
-  if (result['max-parallel'] != null) {
-    cli['theory.sweep.maxParallel'] = int.parse(result['max-parallel']);
+  final cmd = args.first;
+  if (cmd == 'sweep') {
+    final parser = ArgParser()
+      ..addOption('config')
+      ..addMultiOption('dir')
+      ..addFlag('fix', negatable: false)
+      ..addOption('max-parallel')
+      ..addOption('keep')
+      ..addFlag('strict', defaultsTo: true)
+      ..addFlag('auto-heal', defaultsTo: true)
+      ..addOption('manifest');
+    final result = parser.parse(args.skip(1));
+    final dirs = result['dir'] as List<String>;
+    final fix = result['fix'] as bool;
+    final cli = <String, dynamic>{};
+    if (result['max-parallel'] != null) {
+      cli['theory.sweep.maxParallel'] = int.parse(result['max-parallel']);
+    }
+    if (result['keep'] != null) {
+      cli['theory.backups.keep'] = int.parse(result['keep']);
+    }
+    if (result.wasParsed('strict')) {
+      cli['theory.reader.strict'] = result['strict'] as bool;
+    }
+    if (result.wasParsed('auto-heal')) {
+      cli['theory.reader.autoHeal'] = result['auto-heal'] as bool;
+    }
+    final config = await ConfigSource.from(
+      cli: cli,
+      configFile: result['config'] as String?,
+    );
+    final reader = TheoryYamlSafeReader(config: config);
+    final sweeper = TheoryIntegritySweeper(config: config, reader: reader);
+    await sweeper.run(
+      dirs: dirs,
+      dryRun: !fix,
+      manifestPath: result['manifest'] as String?,
+    );
+  } else if (cmd == 'verify') {
+    final parser = ArgParser()
+      ..addOption('config')
+      ..addMultiOption('dir')
+      ..addOption('manifest', defaultsTo: 'theory_manifest.json')
+      ..addFlag('ci', negatable: false)
+      ..addFlag('strict', defaultsTo: true);
+    final result = parser.parse(args.skip(1));
+    final cli = <String, dynamic>{};
+    if (result.wasParsed('strict')) {
+      cli['theory.reader.strict'] = result['strict'] as bool;
+    }
+    final config = await ConfigSource.from(
+      cli: cli,
+      configFile: result['config'] as String?,
+    );
+    final reader = TheoryYamlSafeReader(config: config);
+    final sweeper = TheoryIntegritySweeper(config: config, reader: reader);
+    final report = await sweeper.run(
+      dirs: (result['dir'] as List<String>),
+      dryRun: true,
+      heal: false,
+      manifestPath: result['manifest'] as String?,
+      check: true,
+    );
+    final bad = (report.counters['needs_upgrade'] ?? 0) +
+        (report.counters['needs_heal'] ?? 0) +
+        (report.counters['failed'] ?? 0);
+    if (result['ci'] as bool && bad > 0) {
+      exit(1);
+    }
+  } else if (cmd == 'manifest' && args.length >= 2) {
+    final sub = args[1];
+    final parser = ArgParser()
+      ..addMultiOption('dir')
+      ..addOption('out', defaultsTo: 'theory_manifest.json');
+    final result = parser.parse(args.skip(2));
+    final service = TheoryManifestService(path: result['out'] as String);
+    if (sub == 'generate') {
+      await service.generate(result['dir'] as List<String>);
+    } else if (sub == 'update') {
+      await service.load();
+      await service.update(result['dir'] as List<String>);
+    } else {
+      print('Usage: poker_analyzer manifest <generate|update> --dir <path>');
+      return;
+    }
+    await service.save();
+  } else {
+    print('Usage: poker_analyzer <sweep|verify|manifest> ...');
   }
-  if (result['keep'] != null) {
-    cli['theory.backups.keep'] = int.parse(result['keep']);
-  }
-  if (result.wasParsed('strict')) {
-    cli['theory.reader.strict'] = result['strict'] as bool;
-  }
-  if (result.wasParsed('auto-heal')) {
-    cli['theory.reader.autoHeal'] = result['auto-heal'] as bool;
-  }
-  final config = await ConfigSource.from(
-    cli: cli,
-    configFile: result['config'] as String?,
-  );
-  final reader = TheoryYamlSafeReader(config: config);
-  final sweeper = TheoryIntegritySweeper(config: config, reader: reader);
-  await sweeper.run(dirs: dirs, dryRun: !fix);
 }

--- a/lib/services/theory_manifest_service.dart
+++ b/lib/services/theory_manifest_service.dart
@@ -1,0 +1,113 @@
+// lib/services/theory_manifest_service.dart
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:path/path.dart' as p;
+import 'package:yaml/yaml.dart';
+
+import 'theory_yaml_canonicalizer.dart';
+
+class ManifestEntry {
+  final String algo;
+  final String hash;
+  final int ver;
+  final DateTime ts;
+
+  ManifestEntry({
+    required this.algo,
+    required this.hash,
+    required this.ver,
+    required this.ts,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'algo': algo,
+        'hash': hash,
+        'ver': ver,
+        'ts': ts.toIso8601String(),
+      };
+
+  static ManifestEntry fromJson(Map<String, dynamic> json) => ManifestEntry(
+        algo: json['algo'] as String,
+        hash: json['hash'] as String,
+        ver: json['ver'] as int,
+        ts: DateTime.parse(json['ts'] as String),
+      );
+}
+
+class TheoryManifestService {
+  TheoryManifestService({String? path}) : _path = path ?? 'theory_manifest.json';
+
+  final String _path;
+  int version = 1;
+  final Map<String, ManifestEntry> files = {};
+
+  Future<void> load() async {
+    final f = File(_path);
+    if (!await f.exists()) return;
+    final map = jsonDecode(await f.readAsString()) as Map<String, dynamic>;
+    version = map['version'] as int? ?? 1;
+    final fileMap = map['files'] as Map<String, dynamic>? ?? {};
+    files
+      ..clear()
+      ..addAll(fileMap.map((k, v) => MapEntry(k, ManifestEntry.fromJson(v))));
+  }
+
+  Future<void> save() async {
+    final f = File(_path);
+    final map = {
+      'version': version,
+      'files': files.map((k, v) => MapEntry(k, v.toJson())),
+    };
+    await f.writeAsString(const JsonEncoder.withIndent('  ').convert(map));
+  }
+
+  Future<Map<String, ManifestEntry>> _scan(List<String> dirs) async {
+    final result = <String, ManifestEntry>{};
+    for (final dir in dirs) {
+      final d = Directory(dir);
+      if (!await d.exists()) continue;
+      for (final f in d
+          .listSync(recursive: true)
+          .whereType<File>()
+          .where((e) => e.path.endsWith('.yaml'))) {
+        final rel = p.relative(f.path);
+        final lines = await f.readAsLines();
+        final body = lines.skip(1).join('\n');
+        final map =
+            jsonDecode(jsonEncode(loadYaml(body))) as Map<String, dynamic>;
+        final canon = const TheoryYamlCanonicalizer().canonicalize(map);
+        final hash = sha256.convert(utf8.encode(canon)).toString();
+        final header = lines.isEmpty ? '' : lines.first;
+        final verMatch = RegExp(r'x-ver:\s*(\d+)').firstMatch(header);
+        final ver = verMatch == null ? 0 : int.parse(verMatch.group(1)!);
+        final stat = await f.stat();
+        result[rel] = ManifestEntry(
+          algo: 'sha256-canon@v1',
+          hash: hash,
+          ver: ver,
+          ts: stat.modified,
+        );
+      }
+    }
+    return result;
+  }
+
+  Future<void> generate(List<String> dirs) async {
+    files
+      ..clear()
+      ..addAll(await _scan(dirs));
+  }
+
+  Future<void> update(List<String> dirs) async {
+    files.addAll(await _scan(dirs));
+  }
+
+  ManifestEntry? entry(String relPath) => files[relPath];
+
+  void updateEntry(String relPath, ManifestEntry entry) {
+    files[relPath] = entry;
+  }
+}
+

--- a/test/services/theory_manifest_service_test.dart
+++ b/test/services/theory_manifest_service_test.dart
@@ -1,0 +1,138 @@
+import 'dart:io';
+import 'dart:convert';
+
+import 'package:crypto/crypto.dart';
+import 'package:path/path.dart' as p;
+import 'package:poker_analyzer/services/config_source.dart';
+import 'package:poker_analyzer/services/theory_integrity_sweeper.dart';
+import 'package:poker_analyzer/services/theory_manifest_service.dart';
+import 'package:poker_analyzer/services/theory_yaml_canonicalizer.dart';
+import 'package:poker_analyzer/services/theory_yaml_safe_reader.dart';
+import 'package:test/test.dart';
+
+void main() {
+  Future<ConfigSource> _config() async {
+    final cfg = File('config.yaml')..writeAsStringSync('theory.reader.strict: false\n');
+    return ConfigSource.from(configFile: cfg.path);
+  }
+
+  test('generate and verify pass', () async {
+    final tmp = await Directory.systemTemp.createTemp();
+    Directory.current = tmp.path;
+    final dir = Directory('packs')..createSync();
+    final file = File(p.join(dir.path, 'pack.yaml'));
+    final body = 'name: good\n';
+    final canon = const TheoryYamlCanonicalizer().canonicalize({'name': 'good'});
+    final hash = sha256.convert(utf8.encode(canon)).toString();
+    file.writeAsStringSync(
+        '# x-hash: $hash | x-ver: 1 | x-ts: 0 | x-hash-algo: sha256-canon@v1\n$body');
+
+    final manifest = TheoryManifestService();
+    await manifest.generate([dir.path]);
+    await manifest.save();
+
+    // touch file without changing content
+    file.writeAsStringSync(file.readAsStringSync());
+
+    final config = await _config();
+    final sweeper = TheoryIntegritySweeper(
+      config: config,
+      reader: TheoryYamlSafeReader(config: config),
+    );
+    final report = await sweeper.run(
+      dirs: [dir.path],
+      dryRun: true,
+      heal: false,
+      manifestPath: 'theory_manifest.json',
+      check: true,
+    );
+    expect(
+      (report.counters['needs_heal'] ?? 0) +
+          (report.counters['needs_upgrade'] ?? 0) +
+          (report.counters['failed'] ?? 0),
+      0,
+    );
+  });
+
+  test('corrupt file fails verify', () async {
+    final tmp = await Directory.systemTemp.createTemp();
+    Directory.current = tmp.path;
+    final dir = Directory('packs')..createSync();
+    final file = File(p.join(dir.path, 'pack.yaml'));
+    final body = 'name: good\n';
+    final canon = const TheoryYamlCanonicalizer().canonicalize({'name': 'good'});
+    final hash = sha256.convert(utf8.encode(canon)).toString();
+    file.writeAsStringSync(
+        '# x-hash: $hash | x-ver: 1 | x-ts: 0 | x-hash-algo: sha256-canon@v1\n$body');
+
+    final manifest = TheoryManifestService();
+    await manifest.generate([dir.path]);
+    await manifest.save();
+
+    // corrupt file
+    file.writeAsStringSync(
+        '# x-hash: $hash | x-ver: 1 | x-ts: 0 | x-hash-algo: sha256-canon@v1\nname: bad\n');
+
+    final config = await _config();
+    final sweeper = TheoryIntegritySweeper(
+      config: config,
+      reader: TheoryYamlSafeReader(config: config),
+    );
+    final report = await sweeper.run(
+      dirs: [dir.path],
+      dryRun: true,
+      heal: false,
+      manifestPath: 'theory_manifest.json',
+      check: true,
+    );
+    expect(report.counters['failed'], greaterThan(0));
+  });
+
+  test('needs_upgrade then fix and update manifest', () async {
+    final tmp = await Directory.systemTemp.createTemp();
+    Directory.current = tmp.path;
+    final dir = Directory('packs')..createSync();
+    final file = File(p.join(dir.path, 'legacy.yaml'));
+    final body = 'name: test\n';
+    final legacyHash = sha256.convert(utf8.encode(body)).toString();
+    file.writeAsStringSync('# x-hash: $legacyHash | x-ver: 1 | x-ts: 0\n$body');
+
+    final manifest = TheoryManifestService();
+    await manifest.generate([dir.path]);
+    await manifest.save();
+
+    var config = await _config();
+    var sweeper = TheoryIntegritySweeper(
+      config: config,
+      reader: TheoryYamlSafeReader(config: config),
+    );
+    var report = await sweeper.run(
+      dirs: [dir.path],
+      dryRun: true,
+      heal: false,
+      manifestPath: 'theory_manifest.json',
+      check: true,
+    );
+    expect(report.counters['needs_upgrade'], greaterThan(0));
+
+    // fix
+    await sweeper.run(dirs: [dir.path], dryRun: false);
+    await manifest.load();
+    await manifest.update([dir.path]);
+    await manifest.save();
+
+    config = await _config();
+    sweeper = TheoryIntegritySweeper(
+      config: config,
+      reader: TheoryYamlSafeReader(config: config),
+    );
+    report = await sweeper.run(
+      dirs: [dir.path],
+      dryRun: true,
+      heal: false,
+      manifestPath: 'theory_manifest.json',
+      check: true,
+    );
+    expect(report.counters['needs_upgrade'], 0);
+  });
+}


### PR DESCRIPTION
## Summary
- add manifest service to record canonical theory hashes
- extend sweeper and writer with manifest-aware verification and auto-update
- introduce CLI commands for verify and manifest generation/update
- cover workflows with new tests

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: Unable to locate package)*
- `dart test test/services/theory_manifest_service_test.dart test/services/theory_integrity_sweeper_test.dart` *(fails: command not found)*
- `dart format bin/poker_analyzer.dart lib/services/theory_integrity_sweeper.dart lib/services/theory_yaml_safe_writer.dart lib/services/theory_manifest_service.dart test/services/theory_manifest_service_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895c389bd84832a8392dfba6ac30ed3