### PR TITLE
chore: harden theory integrity CI

### DIFF
--- a/.github/workflows/theory-integrity.yml
+++ b/.github/workflows/theory-integrity.yml
@@ -21,15 +21,11 @@ jobs:
           path: ~/.pub-cache
           key: ${{ runner.os }}-pub-${{ hashFiles('pubspec.lock') }}
 
-      - name: Setup Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          flutter-version: stable
-          channel: stable
-          cache: true
+      - name: Setup Dart
+        uses: dart-lang/setup-dart@v1
 
       - name: Install dependencies
-        run: flutter pub get
+        run: dart pub get
 
       - name: Determine changed theory paths
         id: changes
@@ -56,7 +52,13 @@ jobs:
 
       - name: Report sweep results
         if: steps.changes.outputs.dirs != '' && always()
-        run: dart run bin/ci_report.dart --report theory_sweep_report.json --markdown > sweep_summary.md
+        run: |
+          if [ ! -f theory_sweep_report.json ]; then
+            echo "no report"
+            exit 0
+          fi
+          dart run bin/ci_report.dart --report theory_sweep_report.json --markdown | tee sweep_summary.md
+          cat sweep_summary.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Comment sweep summary
         if: steps.changes.outputs.dirs != '' && always()
@@ -64,12 +66,25 @@ jobs:
         with:
           script: |
             const fs = require('fs');
+            const marker = '<!-- theory-sweep-summary -->';
+            if (!fs.existsSync('theory_sweep_report.json') || !fs.existsSync('sweep_summary.md')) {
+              core.info('no report to comment');
+              return;
+            }
             const report = JSON.parse(fs.readFileSync('theory_sweep_report.json', 'utf8'));
             const c = report.counters || {};
             const count = (c.needs_upgrade || 0) + (c.needs_heal || 0) + (c.failed || 0);
-            if (count > 0) {
-              const body = fs.readFileSync('sweep_summary.md', 'utf8');
-              github.rest.issues.createComment({ ...context.issue, body });
+            if (count === 0) {
+              core.info('no issues, skipping comment');
+              return;
+            }
+            const body = fs.readFileSync('sweep_summary.md', 'utf8') + '\n' + marker;
+            const { data: comments } = await github.rest.issues.listComments({ ...context.issue });
+            const existing = comments.find(comment => comment.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ ...context.repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ ...context.issue, body });
             }
 
       - name: Upload sweep reports
@@ -98,15 +113,11 @@ jobs:
           path: ~/.pub-cache
           key: ${{ runner.os }}-pub-${{ hashFiles('pubspec.lock') }}
 
-      - name: Setup Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          flutter-version: stable
-          channel: stable
-          cache: true
+      - name: Setup Dart
+        uses: dart-lang/setup-dart@v1
 
       - name: Install dependencies
-        run: flutter pub get
+        run: dart pub get
 
       - name: Determine changed theory paths
         id: changes

--- a/bin/ci_report.dart
+++ b/bin/ci_report.dart
@@ -11,7 +11,10 @@ Future<void> main(List<String> args) async {
   final opts = parser.parse(args);
 
   final reportFile = File(opts['report'] as String);
-  if (!reportFile.existsSync()) return;
+  if (!reportFile.existsSync()) {
+    stdout.writeln('no report');
+    return;
+  }
   final data =
       jsonDecode(await reportFile.readAsString()) as Map<String, dynamic>;
   final entries =

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -50,7 +50,7 @@ packages:
     source: hosted
     version: "4.0.7"
   args:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: args
       sha256: d0481093c50b1da8910eb0bb301626d4d8eb7284aa739614d2b394ee09e3ea04

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   flutter:
     sdk: flutter
 
+  args: ^2.7.0
   cupertino_icons: ^1.0.2
   shared_preferences: ^2.2.0
   path_provider: ^2.0.15


### PR DESCRIPTION
## Summary
- switch theory integrity workflow to Dart tooling, add step summary and upserted PR comment
- add `args` as a direct dependency
- let `ci_report` exit cleanly when report missing

## Testing
- `./tool/test_all.sh` *(fails: flutter: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895c8dd8c34832a95e1b2acd85680f2