### PR TITLE
chore(ci): use flutter for theory workflows

### DIFF
--- a/.github/workflows/theory-integrity.yml
+++ b/.github/workflows/theory-integrity.yml
@@ -24,8 +24,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: stable
-          channel: stable
+          channel: 'stable'
           cache: true
 
       - name: Install dependencies
@@ -83,7 +82,7 @@ jobs:
           if-no-files-found: ignore
 
   theory-fix:
-    if: contains(github.event.pull_request.labels.*.name, 'theory-fix') && github.event.pull_request.head.repo.fork == false
+    if: contains(github.event.pull_request.labels.*.name, 'theory-fix') && github.event.pull_request.head.repo.fork == false && github.actor != 'github-actions[bot]'
     needs: verify
     runs-on: ubuntu-latest
     steps:
@@ -101,8 +100,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: stable
-          channel: stable
+          channel: 'stable'
           cache: true
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- rely on Flutter for dependency resolution in theory workflows
- prevent theory-fix job from looping when triggered by github-actions bot

## Testing
- `dart --version` *(fails: command not found)*
- `apt-get install -y dart` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_6895cd017384832ab0d63c7cae23ded3