### PR TITLE
ci: use Flutter SDK for theory integrity workflow

### DIFF
--- a/.github/workflows/theory-integrity.yml
+++ b/.github/workflows/theory-integrity.yml
@@ -21,11 +21,14 @@ jobs:
           path: ~/.pub-cache
           key: ${{ runner.os }}-pub-${{ hashFiles('pubspec.lock') }}
 
-      - name: Setup Dart
-        uses: dart-lang/setup-dart@v1
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
 
       - name: Install dependencies
-        run: dart pub get
+        run: flutter pub get
 
       - name: Determine changed theory paths
         id: changes
@@ -113,11 +116,14 @@ jobs:
           path: ~/.pub-cache
           key: ${{ runner.os }}-pub-${{ hashFiles('pubspec.lock') }}
 
-      - name: Setup Dart
-        uses: dart-lang/setup-dart@v1
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
 
       - name: Install dependencies
-        run: dart pub get
+        run: flutter pub get
 
       - name: Determine changed theory paths
         id: changes


### PR DESCRIPTION
## Summary
- install Flutter stable SDK with caching in theory-integrity workflow
- resolve dependency install using `flutter pub get`

## Testing
- `flutter pub get`
- `flutter analyze` *(fails: analysis server exited with code -2)*

------
https://chatgpt.com/codex/tasks/task_e_6895d17f0888832a962f5e258aa40194