### PR TITLE
fix(android): move clean task out of settings.gradle.kts

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -16,6 +16,6 @@ subprojects {
     project.evaluationDependsOn(":app")
 }
 
-tasks.register<Delete>("clean") {
-    delete(rootProject.layout.buildDirectory)
+tasks.register("clean", Delete::class) {
+    delete(rootProject.buildDir)
 }

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -15,7 +15,3 @@ dependencyResolutionManagement {
 
 rootProject.name = "Poker_Analyzer"
 include(":app")
-
-tasks.register<Delete>("clean") {
-    delete(rootProject.layout.buildDirectory)
-}


### PR DESCRIPTION
## Summary
- move Gradle clean task out of `settings.gradle.kts`
- register clean task in root `build.gradle.kts` using `Delete`

## Testing
- `gradle -p android tasks` *(fails: Plugin [id: 'dev.flutter.flutter-gradle-plugin'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895d43e99b4832aa703002437a1451f