### PR TITLE
chore: allow theory-fix to push changes

### DIFF
--- a/.github/workflows/theory-integrity.yml
+++ b/.github/workflows/theory-integrity.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 env:
   THEORY_DIRS: theory,yaml_out
 


### PR DESCRIPTION
## Summary
- allow theory-fix job to push commits by granting workflow contents: write

## Testing
- `flutter pub get`
- `dart run bin/poker_analyzer.dart manifest generate --dir theory --out theory_manifest.json` *(fails: Color not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895e18b0eb4832ab52dfffdcb27916e