### PR TITLE
chore(ci): update manifest workflow

### DIFF
--- a/.github/workflows/theory-manifest-generate.yml
+++ b/.github/workflows/theory-manifest-generate.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary
- update manifest baseline workflow to use checkout v4
- lint workflow with actionlint

## Testing
- `./actionlint .github/workflows/theory-manifest-generate.yml`


------
https://chatgpt.com/codex/tasks/task_e_6895fae0ad74832aa0d5c49c004fe01a