### PR TITLE
chore: add editorconfig and harden test script

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/tool/test_all.sh
+++ b/tool/test_all.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
-set -e
+set -euo pipefail
+
 flutter analyze
 flutter test


### PR DESCRIPTION
## Summary
- add project-wide .editorconfig for consistent formatting
- harden `tool/test_all.sh` with `set -euo pipefail`

## Testing
- `bash tool/test_all.sh` *(fails: command not found: flutter)*


------
https://chatgpt.com/codex/tasks/task_e_6895fe53cbf0832ab643c0362ac3d164