### PR TITLE
chore: ignore sweep exit code when manifest missing

### DIFF
--- a/.github/workflows/theory-integrity.yml
+++ b/.github/workflows/theory-integrity.yml
@@ -73,7 +73,7 @@ jobs:
           for d in $dirs; do args="$args --dir $d"; done
           echo "Soft verify (no manifest) theory paths: $dirs"
           # Dry-run sweep to produce annotations/summary, but do not fail CI
-          dart run bin/poker_analyzer.dart sweep $args --manifest theory_manifest.json
+          dart run bin/poker_analyzer.dart sweep $args --manifest theory_manifest.json || true
 
       - name: Report sweep results
         if: steps.changes.outputs.dirs != '' && always()


### PR DESCRIPTION
## Summary
- avoid failing theory sweep when manifest is absent

## Testing
- `flutter pub get`
- `dart run bin/poker_analyzer.dart sweep --dir assets/theory_tracks --manifest theory_manifest.json 2>&1 | head -n 20` *(fails: missing Flutter types)*

------
https://chatgpt.com/codex/tasks/task_e_6895fae02cdc832ab8387d72e621a334