### PR TITLE
chore: verify flutter in test script

### DIFF
--- a/tool/test_all.sh
+++ b/tool/test_all.sh
@@ -1,4 +1,13 @@
 #!/bin/bash
 set -e
+
+ensure_flutter() {
+  if ! command -v flutter >/dev/null 2>&1; then
+    echo "Flutter is not installed or not in PATH. Please install Flutter and try again." >&2
+    exit 1
+  fi
+}
+
+ensure_flutter
 flutter analyze
 flutter test


### PR DESCRIPTION
## Summary
- ensure `tool/test_all.sh` checks for Flutter in PATH before running analysis and tests

## Testing
- `shellcheck tool/test_all.sh`
- `apt-get update >/tmp/apt.log && apt-get install -y flutter >/tmp/flutter-install.log && tail -n 20 /tmp/flutter-install.log` (fails: Unable to locate package flutter)
- `snap install flutter --classic >/tmp/flutter-snap.log && tail -n 20 /tmp/flutter-snap.log` (fails: command not found)
- `bash tool/test_all.sh` (fails: Flutter is not installed or not in PATH. Please install Flutter and try again.)

------
https://chatgpt.com/codex/tasks/task_e_689601139ea0832a8751037ebace4165