### PR TITLE
ci: enable PR workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,9 +3,14 @@ name: CI
 on:
   push:
     branches: [ main ]
-  # Временно отключаем pull_request, чтобы избежать сбоев при мердже Codex
-  # pull_request:
-  #   branches: [ main ]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+  pull_request:
+    branches: [ main ]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- enable `pull_request` trigger in CI workflow
- skip docs-only changes

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68960115ec08832a9ba072e4a7960c26