### PR TITLE
Enable strict mode in shell scripts

### DIFF
--- a/tool/test_all.sh
+++ b/tool/test_all.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
-set -e
+set -euo pipefail
+# Enable strict mode to exit on errors, unset variables, and pipeline failures.
 flutter analyze
 flutter test

--- a/tools/check_head_refs.sh
+++ b/tools/check_head_refs.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
+set -euo pipefail
+# Enable strict mode to exit on errors, unset variables, and pipeline failures.
 # Check for hidden characters in git HEAD and ref files.
-
-set -e
 
 echo "Checking git HEAD and ref files for hidden characters..."
 
@@ -18,12 +18,12 @@ check_file() {
 }
 
 error=0
-check_file .git/HEAD || error=1
+check_file ".git/HEAD" || error=1
 for ref in .git/refs/heads/*; do
   check_file "$ref" || error=1
 done
 
-if [ $error -eq 0 ]; then
+if [ "$error" -eq 0 ]; then
   echo "No hidden characters found."
 else
   echo "Hidden characters were found. Consider rewriting the affected ref file(s)."


### PR DESCRIPTION
## Summary
- enable strict mode and document it in shell scripts
- quote variable expansions in check_head_refs.sh

## Testing
- `bash tools/check_head_refs.sh`
- `bash tool/test_all.sh` *(fails: flutter: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68960114bcac832a9cce0fbad371b12c