### PR TITLE
chore: add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{dart,yaml,yml,json,md}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
## Summary
- add root-level .editorconfig to standardize charset, line endings, trailing whitespace, final newline, and 2-space indentation for Dart, YAML, JSON, and Markdown files

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68960114b67c832a9516b24cc4295d75