### PR TITLE
Point theory checks to assets and enforce manifest only when non-empty

### DIFF
--- a/.github/workflows/theory-integrity.yml
+++ b/.github/workflows/theory-integrity.yml
@@ -8,7 +8,7 @@ permissions:
   contents: write
 
 env:
-  THEORY_DIRS: theory,yaml_out
+  THEORY_DIRS: assets
 
 jobs:
   verify:
@@ -46,7 +46,7 @@ jobs:
       - name: Check manifest presence
         id: manifest
         run: |
-          if [ -f theory_manifest.json ] && grep -q '"files"' theory_manifest.json; then
+          if [ -f theory_manifest.json ] && grep -q '"files"' theory_manifest.json && ! grep -q '"files": {}' theory_manifest.json; then
             echo "has_manifest=1" >> "$GITHUB_OUTPUT"
           else
             echo "has_manifest=0" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/theory-manifest-generate.yml
+++ b/.github/workflows/theory-manifest-generate.yml
@@ -6,6 +6,9 @@ on:
 permissions:
   contents: write
 
+env:
+  THEORY_DIRS: assets
+
 jobs:
   generate:
     runs-on: ubuntu-latest
@@ -29,18 +32,29 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          CHANGED=0
-          if [ -d theory ]; then
-            echo "Generating manifest for ./theory"
-            dart run bin/poker_analyzer.dart manifest generate --dir theory --out theory_manifest.json
-            CHANGED=1
+          IFS=',' read -ra DIRS <<< "${THEORY_DIRS:-assets}"
+          first=1
+          for d in "${DIRS[@]}"; do
+            [ -d "$d" ] || continue
+            echo "Processing dir: $d"
+            if [ "$first" -eq 1 ]; then
+              dart run bin/poker_analyzer.dart manifest generate --dir "$d" --out theory_manifest.json
+              first=0
+            else
+              dart run bin/poker_analyzer.dart manifest update --dir "$d"
+            fi
+          done
+          if [ "$first" -eq 1 ]; then
+            echo "No theory dirs present; nothing to generate"
+            echo "changed=0" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
-          if [ -d yaml_out ]; then
-            echo "Updating manifest for ./yaml_out"
-            dart run bin/poker_analyzer.dart manifest update --dir yaml_out
-            CHANGED=1
+          # отметим, есть ли реальный diff по файлу
+          if git diff --quiet -- theory_manifest.json; then
+            echo "changed=0" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=1" >> "$GITHUB_OUTPUT"
           fi
-          echo "changed=$CHANGED" >> "$GITHUB_OUTPUT"
 
       - name: Create PR with baseline
         if: steps.gen.outputs.changed == '1'
@@ -48,6 +62,8 @@ jobs:
         with:
           commit-message: "chore: add baseline theory manifest"
           title: "chore: add baseline theory manifest"
-          body: "Generated/updated theory_manifest.json to enable strict CI verification."
+          body: |
+            Generated/updated theory_manifest.json to enable strict CI verification.
+            This PR was created by the one-shot workflow.
           branch: manifest/baseline
           signoff: false


### PR DESCRIPTION
## Summary
- Direct theory integrity and manifest generation workflows to scan `assets`
- Only treat `theory_manifest.json` as present when its `files` map has entries
- Skip manifest PRs when generation yields no diff

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `yamllint .github/workflows/theory-integrity.yml .github/workflows/theory-manifest-generate.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68964aa8c8d4832ab8b3713205248851