### PR TITLE
chore(ci): audit & stabilize Theory Integrity pipeline

### DIFF
--- a/.github/workflows/theory-integrity.yml
+++ b/.github/workflows/theory-integrity.yml
@@ -126,6 +126,16 @@ PY
               await github.rest.issues.createComment({ ...context.issue, body });
             }
 
+      - name: Upload sweep report artifacts
+        if: steps.changes.outputs.dirs != '' && always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: theory-sweep-report
+          path: |
+            theory_sweep_report.json
+            theory_sweep_report.csv
+          if-no-files-found: ignore
+
   theory-fix:
     if: contains(github.event.pull_request.labels.*.name, 'theory-fix') && github.event.pull_request.head.repo.fork == false
     needs: verify

--- a/scripts/changed_theory_paths.sh
+++ b/scripts/changed_theory_paths.sh
@@ -1,12 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
-
 BASE=${1:-main}
 THEORY_DIRS=${THEORY_DIRS:-"theory,yaml_out"}
 IFS=',' read -ra WATCH <<< "$THEORY_DIRS"
-
 git fetch origin "$BASE" >/dev/null 2>&1 || true
-FILES=$(git diff --name-only "origin/${BASE}"...HEAD -- "${WATCH[@]}" | grep -E '\.ya?ml$' || true)
+FILES=$(git diff --name-only "origin/${BASE}"...HEAD -- "${WATCH[@]}" | grep '\.yaml$' || true)
 [ -z "$FILES" ] && exit 0
-
 echo "$FILES" | xargs -r dirname | sort -u


### PR DESCRIPTION
## Summary
- upload Theory Integrity sweep reports as artifacts
- narrow theory change detection to `.yaml`

## Testing
- `bash -n scripts/changed_theory_paths.sh`
- `dart format bin/ci_report.dart scripts/changed_theory_paths.sh` *(fails: command not found: dart)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `snap install flutter --classic` *(fails: cannot communicate with server)*
- `flutter pub get` *(fails: command not found: flutter)*
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68965a1aa0d0832aad3ffa9259b87c59