### PR TITLE
feat: support multi-output training pack templates

### DIFF
--- a/assets/training/templates/test_multi_output.yaml
+++ b/assets/training/templates/test_multi_output.yaml
@@ -1,0 +1,20 @@
+baseSpot:
+  id: multi_base
+  title: Multi Base
+  hand:
+    heroCards: Ah Ad
+    position: btn
+    heroIndex: 0
+    playerCount: 2
+    board: []
+  board: []
+  villainAction: check
+variations:
+  - {}
+outputVariants:
+  - targetStreet: flop
+    boardConstraints:
+      - targetStreet: flop
+  - targetStreet: turn
+    boardConstraints:
+      - targetStreet: turn

--- a/lib/models/training_pack_template_set.dart
+++ b/lib/models/training_pack_template_set.dart
@@ -16,6 +16,14 @@ class TrainingPackTemplateSet {
   /// and additional tagging/metadata rules.
   final List<ConstraintSet> variations;
 
+  /// Optional pack-level variants that split generation into multiple outputs.
+  ///
+  /// Each entry inherits [variations] and may override high-level constraints
+  /// such as [ConstraintSet.targetStreet], [ConstraintSet.boardConstraints],
+  /// [ConstraintSet.requiredTags], and [ConstraintSet.excludedTags]. A separate
+  /// training pack is produced for every variant.
+  final List<ConstraintSet> outputVariants;
+
   /// Optional player type variants to apply to generated templates.
   ///
   /// Each entry is written to `spot.meta['playerType']` for the resulting
@@ -74,6 +82,7 @@ class TrainingPackTemplateSet {
   const TrainingPackTemplateSet({
     required this.baseSpot,
     List<ConstraintSet>? variations,
+    List<ConstraintSet>? outputVariants,
     List<String>? playerTypeVariations,
     this.suitAlternation = false,
     List<int>? stackDepthMods,
@@ -86,6 +95,7 @@ class TrainingPackTemplateSet {
     this.expandAllLines = false,
     this.postflopLineSeed,
   }) : variations = variations ?? const [],
+       outputVariants = outputVariants ?? const [],
        playerTypeVariations = playerTypeVariations ?? const [],
        stackDepthMods = stackDepthMods ?? const [],
        linePatterns = linePatterns ?? const [],
@@ -101,6 +111,10 @@ class TrainingPackTemplateSet {
     final base = TrainingPackSpot.fromJson(baseMap);
     final vars = <ConstraintSet>[
       for (final v in (json['variations'] as List? ?? []))
+        ConstraintSet.fromJson(Map<String, dynamic>.from(v as Map)),
+    ];
+    final outputs = <ConstraintSet>[
+      for (final v in (json['outputVariants'] as List? ?? []))
         ConstraintSet.fromJson(Map<String, dynamic>.from(v as Map)),
     ];
     final pTypes = <String>[
@@ -144,6 +158,7 @@ class TrainingPackTemplateSet {
     return TrainingPackTemplateSet(
       baseSpot: base,
       variations: vars,
+      outputVariants: outputs,
       playerTypeVariations: pTypes,
       suitAlternation: suitAlt,
       stackDepthMods: depthMods,
@@ -167,6 +182,8 @@ class TrainingPackTemplateSet {
     'baseSpot': baseSpot.toJson(),
     if (variations.isNotEmpty)
       'variations': [for (final v in variations) v.toJson()],
+    if (outputVariants.isNotEmpty)
+      'outputVariants': [for (final v in outputVariants) v.toJson()],
     if (playerTypeVariations.isNotEmpty)
       'playerTypeVariations': playerTypeVariations,
     if (suitAlternation) 'suitAlternation': true,

--- a/lib/services/training_pack_template_expander_service.dart
+++ b/lib/services/training_pack_template_expander_service.dart
@@ -75,6 +75,66 @@ class TrainingPackTemplateExpanderService {
     return spots;
   }
 
+  /// Expands [set] into multiple output variants.
+  ///
+  /// Each entry in [TrainingPackTemplateSet.outputVariants] produces a separate
+  /// list of spots with its constraints merged onto every variation. When no
+  /// output variants are defined, a single list containing [expand] results is
+  /// returned.
+  List<List<TrainingPackSpot>> expandOutputs(TrainingPackTemplateSet set) {
+    if (set.outputVariants.isEmpty) {
+      return [expand(set)];
+    }
+    final results = <List<TrainingPackSpot>>[];
+    for (final variant in set.outputVariants) {
+      final merged = [
+        for (final v in set.variations) _mergeConstraints(v, variant),
+      ];
+      final copy = TrainingPackTemplateSet(
+        baseSpot: set.baseSpot,
+        variations: merged,
+        playerTypeVariations: set.playerTypeVariations,
+        suitAlternation: set.suitAlternation,
+        stackDepthMods: set.stackDepthMods,
+        linePatterns: set.linePatterns,
+        postflopLines: set.postflopLines,
+        boardTexturePreset: set.boardTexturePreset,
+        excludeBoardTexturePresets: set.excludeBoardTexturePresets,
+        requiredBoardClusters: set.requiredBoardClusters,
+        excludedBoardClusters: set.excludedBoardClusters,
+        expandAllLines: set.expandAllLines,
+        postflopLineSeed: set.postflopLineSeed,
+      );
+      results.add(expand(copy));
+    }
+    return results;
+  }
+
+  ConstraintSet _mergeConstraints(ConstraintSet base, ConstraintSet variant) {
+    return ConstraintSet(
+      boardTags: base.boardTags,
+      positions: base.positions,
+      handGroup: base.handGroup,
+      villainActions: base.villainActions,
+      targetStreet: variant.targetStreet ?? base.targetStreet,
+      requiredTags: {...base.requiredTags, ...variant.requiredTags}.toList(),
+      excludedTags: {...base.excludedTags, ...variant.excludedTags}.toList(),
+      position: base.position,
+      opponentPosition: base.opponentPosition,
+      boardTexture: base.boardTexture,
+      minStack: base.minStack,
+      maxStack: base.maxStack,
+      boardConstraints: [...base.boardConstraints, ...variant.boardConstraints],
+      linePattern: base.linePattern,
+      overrides: base.overrides,
+      tags: base.tags,
+      tagMergeMode: base.tagMergeMode,
+      metadata: base.metadata,
+      metaMergeMode: base.metaMergeMode,
+      theoryLink: base.theoryLink,
+    );
+  }
+
   ConstraintSet _expandBoards(
     ConstraintSet set, {
     List<String> requiredBoardClusters = const [],

--- a/test/services/training_pack_auto_generator_multi_output_test.dart
+++ b/test/services/training_pack_auto_generator_multi_output_test.dart
@@ -1,0 +1,21 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+import 'package:poker_analyzer/models/training_pack_template_set.dart';
+import 'package:poker_analyzer/services/training_pack_auto_generator.dart';
+
+void main() {
+  test('generateAll produces multiple outputs', () async {
+    final yaml = await File('assets/training/templates/test_multi_output.yaml').readAsString();
+    final set = TrainingPackTemplateSet.fromYaml(yaml);
+    final gen = TrainingPackAutoGenerator();
+    final results = await gen.generateAll(set);
+    expect(results.length, 2);
+    expect(results[0].isNotEmpty, isTrue);
+    expect(results[1].isNotEmpty, isTrue);
+    // First variant should target flop (street 1)
+    expect(results[0].every((s) => s.street == 1), isTrue);
+    // Second variant should target turn (street 2)
+    expect(results[1].every((s) => s.street == 2), isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- allow training pack templates to declare `outputVariants` for multi-pack expansion
- expand template variants in the expander service and generator engine
- support generating multiple spot lists in TrainingPackAutoGenerator
- add test template and coverage for multi-output generation

## Testing
- `dart test test/services/training_pack_auto_generator_multi_output_test.dart` *(fails: command not found: dart)*


------
https://chatgpt.com/codex/tasks/task_e_6896a0c42a54832abe82b4459c6a0fe0