### PR TITLE
feat: deterministic multi-output generation

### DIFF
--- a/assets/training/templates/test_multi_output.yaml
+++ b/assets/training/templates/test_multi_output.yaml
@@ -11,10 +11,15 @@ baseSpot:
   villainAction: check
 variations:
   - {}
+seed: 7
 outputVariants:
-  - targetStreet: flop
+  flop:
+    targetStreet: flop
+    seed: 1
     boardConstraints:
       - targetStreet: flop
-  - targetStreet: turn
+  turn:
+    targetStreet: turn
+    seed: 2
     boardConstraints:
       - targetStreet: turn

--- a/docs/training_pack_template_schema.md
+++ b/docs/training_pack_template_schema.md
@@ -1,0 +1,30 @@
+# Training Pack Template Schema
+
+## outputVariants
+
+`outputVariants` splits a template into multiple deterministic outputs. It is a
+map where each key identifies a variant and its value contains constraint
+overrides.
+
+```yaml
+seed: 7
+outputVariants:
+  flop:
+    targetStreet: flop
+    seed: 1
+    boardConstraints:
+      - targetStreet: flop
+  turn:
+    targetStreet: turn
+    seed: 2
+    boardConstraints:
+      - targetStreet: turn
+```
+
+Each variant may override high-level fields such as `targetStreet` or
+`boardConstraints` and can provide its own `seed`.
+
+## seed
+
+The optional `seed` field at the template or variant level makes spot and pack
+IDs deterministic. Runs with the same seed produce identical IDs and ordering.

--- a/lib/services/training_pack_template_set_validator.dart
+++ b/lib/services/training_pack_template_set_validator.dart
@@ -1,0 +1,68 @@
+class TrainingPackTemplateSetValidator {
+  const TrainingPackTemplateSetValidator._();
+
+  static void validate(Map<String, dynamic> json, {String source = ''}) {
+    final outputs = json['outputVariants'];
+    if (outputs == null) return;
+    if (outputs is! Map) {
+      _fail('outputVariants must be a map', source);
+    }
+    final allowed = {
+      'targetStreet',
+      'boardConstraints',
+      'requiredTags',
+      'excludedTags',
+      'seed',
+    };
+    outputs.forEach((key, value) {
+      if (value is! Map) {
+        _fail('outputVariants.$key must be a map', source);
+      }
+      for (final k in value.keys) {
+        if (!allowed.contains(k)) {
+          _fail('Unknown field outputVariants.$key.$k', source);
+        }
+      }
+      final street = value['targetStreet'];
+      if (street != null) {
+        const streets = {'preflop', 'flop', 'turn', 'river'};
+        if (!streets.contains(street.toString().toLowerCase())) {
+          _fail(
+            'outputVariants.$key.targetStreet must be one of preflop, flop, turn, river',
+            source,
+          );
+        }
+      }
+      final bc = value['boardConstraints'];
+      if (bc != null) {
+        if (bc is! List) {
+          _fail('outputVariants.$key.boardConstraints must be a list', source);
+        }
+        for (var i = 0; i < (bc as List).length; i++) {
+          final entry = bc[i];
+          if (entry is! Map) {
+            _fail(
+              'outputVariants.$key.boardConstraints[$i] must be a map',
+              source,
+            );
+          }
+          final s = entry['targetStreet'];
+          if (s != null) {
+            const streets = {'preflop', 'flop', 'turn', 'river'};
+            if (!streets.contains(s.toString().toLowerCase())) {
+              _fail(
+                'outputVariants.$key.boardConstraints[$i].targetStreet must be one of preflop, flop, turn, river',
+                source,
+              );
+            }
+          }
+        }
+      }
+    });
+  }
+
+  static Never _fail(String message, String source) {
+    final prefix = source.isNotEmpty ? '$source: ' : '';
+    throw FormatException(prefix + message);
+  }
+}

--- a/test/headless/training_pack_multi_output_deterministic_test.dart
+++ b/test/headless/training_pack_multi_output_deterministic_test.dart
@@ -1,0 +1,38 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:test/test.dart';
+import 'package:poker_analyzer/models/training_pack_template_set.dart';
+import 'package:poker_analyzer/services/training_pack_auto_generator.dart';
+
+void main() {
+  test('multi-output expansion is deterministic', () async {
+    final path = 'assets/training/templates/test_multi_output.yaml';
+    final yaml = await File(path).readAsString();
+    final set = TrainingPackTemplateSet.fromYaml(yaml, source: path);
+    final gen = TrainingPackAutoGenerator();
+
+    final packsA = await gen.generateAll(set, deduplicate: false);
+    final packsB = await gen.generateAll(set, deduplicate: false);
+
+    expect(packsA.length, packsB.length);
+    for (var i = 0; i < packsA.length; i++) {
+      final a = packsA[i];
+      final b = packsB[i];
+      expect(a.spots.length, b.spots.length);
+      final idsA = [for (final s in a.spots) s.id];
+      final idsB = [for (final s in b.spots) s.id];
+      expect(idsA, idsB);
+      final jsonA = jsonEncode([for (final s in a.spots) s.toJson()]);
+      final jsonB = jsonEncode([for (final s in b.spots) s.toJson()]);
+      final hashA = sha1.convert(utf8.encode(jsonA)).toString();
+      final hashB = sha1.convert(utf8.encode(jsonB)).toString();
+      expect(hashA, hashB);
+      // Street assertion based on variant order
+      final street = i == 0 ? 1 : 2;
+      expect(a.spots.every((s) => s.street == street), isTrue);
+      expect(b.spots.every((s) => s.street == street), isTrue);
+    }
+  });
+}

--- a/test/services/training_pack_auto_generator_multi_output_test.dart
+++ b/test/services/training_pack_auto_generator_multi_output_test.dart
@@ -6,16 +6,18 @@ import 'package:poker_analyzer/services/training_pack_auto_generator.dart';
 
 void main() {
   test('generateAll produces multiple outputs', () async {
-    final yaml = await File('assets/training/templates/test_multi_output.yaml').readAsString();
+    final yaml = await File(
+      'assets/training/templates/test_multi_output.yaml',
+    ).readAsString();
     final set = TrainingPackTemplateSet.fromYaml(yaml);
     final gen = TrainingPackAutoGenerator();
-    final results = await gen.generateAll(set);
+    final results = await gen.generateAll(set, deduplicate: false);
     expect(results.length, 2);
-    expect(results[0].isNotEmpty, isTrue);
-    expect(results[1].isNotEmpty, isTrue);
+    expect(results[0].spots.isNotEmpty, isTrue);
+    expect(results[1].spots.isNotEmpty, isTrue);
     // First variant should target flop (street 1)
-    expect(results[0].every((s) => s.street == 1), isTrue);
+    expect(results[0].spots.every((s) => s.street == 1), isTrue);
     // Second variant should target turn (street 2)
-    expect(results[1].every((s) => s.street == 2), isTrue);
+    expect(results[1].spots.every((s) => s.street == 2), isTrue);
   });
 }


### PR DESCRIPTION
## Summary
- validate `outputVariants` structure and reject unknown fields
- seed-based pack/spot ids with stable variant naming and tags
- add deterministic multi-output test and schema documentation

## Testing
- `dart test test/headless/training_pack_multi_output_deterministic_test.dart` *(fails: Flutter SDK not available)*

------
https://chatgpt.com/codex/tasks/task_e_6896a3495a38832a9b8325d90b1e9b91