### PR TITLE
feat: add soft verify mode for CI report

### DIFF
--- a/.github/workflows/theory-integrity.yml
+++ b/.github/workflows/theory-integrity.yml
@@ -80,10 +80,10 @@ jobs:
           fi
           # Предпочтительно использовать внутренний репортёр, если он есть
           if [[ -f "bin/ci_report.dart" ]]; then
-            dart run bin/ci_report.dart --mode soft
+            dart run bin/ci_report.dart --mode=soft
           else
             # Fallback на прямой CLI, если репортёра нет
-            dart run bin/poker_analyzer.dart verify --mode soft --manifest theory_manifest.json || true
+            dart run bin/poker_analyzer.dart verify --mode=soft --manifest theory_manifest.json || true
           fi
 
       # Строгая проверка только на PR (ломаем сборку, если есть ошибки)
@@ -97,9 +97,9 @@ jobs:
             exit 0
           fi
           if [[ -f "bin/ci_report.dart" ]]; then
-            dart run bin/ci_report.dart --mode strict
+            dart run bin/ci_report.dart --mode=strict
           else
-            dart run bin/poker_analyzer.dart verify --mode strict --manifest theory_manifest.json
+            dart run bin/poker_analyzer.dart verify --mode=strict --manifest theory_manifest.json
           fi
 
       # Опционально: подсказка в логах, по каким путям шла проверка

--- a/bin/ci_report.dart
+++ b/bin/ci_report.dart
@@ -7,18 +7,38 @@ import 'package:path/path.dart' as p;
 Future<void> main(List<String> args) async {
   final parser = ArgParser()
     ..addOption('report', defaultsTo: 'theory_sweep_report.json')
-    ..addFlag('markdown', negatable: false);
+    ..addFlag('markdown', negatable: false)
+    ..addOption('mode',
+        allowed: ['soft', 'strict'], defaultsTo: 'strict');
   final opts = parser.parse(args);
+
+  final mode = opts['mode'] as String;
+  stdout.writeln('mode=$mode');
 
   final reportFile = File(opts['report'] as String);
   if (!reportFile.existsSync()) {
-    stdout.writeln('no report');
+    if (mode == 'soft') {
+      stdout.writeln('\x1B[33mSOFT OK: no YAML to verify\x1B[0m');
+      return;
+    }
+    stderr.writeln('no report');
+    exitCode = 1;
     return;
   }
   final data =
       jsonDecode(await reportFile.readAsString()) as Map<String, dynamic>;
   final entries =
       (data['entries'] as List? ?? []).cast<Map<String, dynamic>>();
+
+  if (entries.isEmpty) {
+    if (mode == 'soft') {
+      stdout.writeln('\x1B[33mSOFT OK: no YAML to verify\x1B[0m');
+      return;
+    }
+    stderr.writeln('no entries');
+    exitCode = 1;
+    return;
+  }
 
   final issues = <String, List<String>>{
     'needs_upgrade': [],
@@ -38,8 +58,14 @@ Future<void> main(List<String> args) async {
     issues[action]!.add(file);
   }
 
+  final hasIssues = issues.values.any((l) => l.isNotEmpty);
+  if (hasIssues && mode == 'strict') {
+    exitCode = 1;
+  }
+
   if (opts['markdown'] as bool) {
-    final buffer = StringBuffer('### Theory Sweep Summary\n');
+    final buffer = StringBuffer('### Theory Sweep Summary\n')
+      ..writeln('- mode=$mode');
     for (final entry in issues.entries) {
       if (entry.value.isEmpty) continue;
       buffer.writeln('- **${entry.key}**');

--- a/test/ci_report_soft_test.dart
+++ b/test/ci_report_soft_test.dart
@@ -1,0 +1,16 @@
+import 'dart:io';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+void main() {
+  test('ci_report soft mode exits 0 when no report', () async {
+    final tempDir = await Directory.systemTemp.createTemp();
+    final missing = p.join(tempDir.path, 'missing.json');
+    final result = await Process.run(
+      'dart',
+      ['run', 'bin/ci_report.dart', '--mode=soft', '--report', missing],
+      workingDirectory: Directory.current.path,
+    );
+    expect(result.exitCode, 0, reason: 'soft mode should not fail');
+  });
+}


### PR DESCRIPTION
## Summary
- add `--mode` flag to `ci_report.dart` to support `soft` and `strict` runs
- wire `--mode` option in theory integrity workflow
- add smoke test for `ci_report` soft mode

## Testing
- `dart format bin/ci_report.dart test/ci_report_soft_test.dart` *(fails: command not found)*
- `dart test test/ci_report_soft_test.dart` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6896a880b71c832aa9bfeb04c4d62948