### PR TITLE
feat: add autogen status dashboard

### DIFF
--- a/lib/models/autogen_status.dart
+++ b/lib/models/autogen_status.dart
@@ -1,4 +1,8 @@
+enum AutogenRunState { idle, running, paused }
+
+/// Status information for the autogen pipeline.
 class AutogenStatus {
+  /// Legacy fields kept for backwards compatibility.
   final bool isRunning;
   final String currentStage;
   final double progress;
@@ -7,6 +11,17 @@ class AutogenStatus {
   final String? action;
   final String? prevHash;
   final String? newHash;
+
+  // New dashboard fields.
+  final AutogenRunState state;
+  final String currentStep;
+  final int queueDepth;
+  final int processed;
+  final int errorsCount;
+  final DateTime? startedAt;
+  final DateTime? updatedAt;
+  final Duration? eta;
+  final String? lastErrorMsg;
 
   const AutogenStatus({
     this.isRunning = false,
@@ -17,6 +32,15 @@ class AutogenStatus {
     this.action,
     this.prevHash,
     this.newHash,
+    this.state = AutogenRunState.idle,
+    this.currentStep = '',
+    this.queueDepth = 0,
+    this.processed = 0,
+    this.errorsCount = 0,
+    this.startedAt,
+    this.updatedAt,
+    this.eta,
+    this.lastErrorMsg,
   });
 
   AutogenStatus copyWith({
@@ -28,6 +52,15 @@ class AutogenStatus {
     String? action,
     String? prevHash,
     String? newHash,
+    AutogenRunState? state,
+    String? currentStep,
+    int? queueDepth,
+    int? processed,
+    int? errorsCount,
+    DateTime? startedAt,
+    DateTime? updatedAt,
+    Duration? eta,
+    String? lastErrorMsg,
   }) {
     return AutogenStatus(
       isRunning: isRunning ?? this.isRunning,
@@ -38,6 +71,51 @@ class AutogenStatus {
       action: action ?? this.action,
       prevHash: prevHash ?? this.prevHash,
       newHash: newHash ?? this.newHash,
+      state: state ?? this.state,
+      currentStep: currentStep ?? this.currentStep,
+      queueDepth: queueDepth ?? this.queueDepth,
+      processed: processed ?? this.processed,
+      errorsCount: errorsCount ?? this.errorsCount,
+      startedAt: startedAt ?? this.startedAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+      eta: eta ?? this.eta,
+      lastErrorMsg: lastErrorMsg ?? this.lastErrorMsg,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'state': state.name,
+        'currentStep': currentStep,
+        'queueDepth': queueDepth,
+        'processed': processed,
+        'errorsCount': errorsCount,
+        'startedAt': startedAt?.toIso8601String(),
+        'updatedAt': updatedAt?.toIso8601String(),
+        'eta': eta?.inMilliseconds,
+        'lastErrorMsg': lastErrorMsg,
+      };
+
+  factory AutogenStatus.fromJson(Map<String, dynamic> json) {
+    return AutogenStatus(
+      state: AutogenRunState.values.firstWhere(
+        (e) => e.name == json['state'],
+        orElse: () => AutogenRunState.idle,
+      ),
+      currentStep: json['currentStep'] ?? '',
+      queueDepth: json['queueDepth'] ?? 0,
+      processed: json['processed'] ?? 0,
+      errorsCount: json['errorsCount'] ?? 0,
+      startedAt: json['startedAt'] != null
+          ? DateTime.parse(json['startedAt'])
+          : null,
+      updatedAt: json['updatedAt'] != null
+          ? DateTime.parse(json['updatedAt'])
+          : null,
+      eta: json['eta'] != null
+          ? Duration(milliseconds: json['eta'] as int)
+          : null,
+      lastErrorMsg: json['lastErrorMsg'] as String?,
     );
   }
 }
+

--- a/lib/screens/autogen_debug_screen.dart
+++ b/lib/screens/autogen_debug_screen.dart
@@ -11,6 +11,7 @@ import '../services/autogen_stats_dashboard_service.dart';
 import '../services/autogen_status_dashboard_service.dart';
 import '../widgets/seed_lint_panel_widget.dart';
 import '../services/autogen_pipeline_executor.dart';
+import '../widgets/autogen_status_panel.dart';
 import '../services/training_pack_auto_generator.dart';
 import '../services/training_pack_template_set_library_service.dart';
 import '../services/yaml_pack_exporter.dart';
@@ -79,7 +80,7 @@ class _AutogenDebugScreenState extends State<AutogenDebugScreen> {
     });
   }
 
-  void _startAutogen() {
+  Future<void> _startAutogen() async {
     if (_status == _AutogenStatus.running) return;
     final dashboard = AutogenStatsDashboardService.instance;
     dashboard.start();
@@ -101,9 +102,9 @@ class _AutogenDebugScreenState extends State<AutogenDebugScreen> {
     final executor = AutogenPipelineExecutor(
       generator: generator,
       dashboard: dashboard,
-      status: status,
       exporter: exporter,
     );
+    await status.bindExecutor(executor);
     setState(() {
       _status = _AutogenStatus.running;
       _sessionId = sessionId;
@@ -170,6 +171,7 @@ class _AutogenDebugScreenState extends State<AutogenDebugScreen> {
               ],
             ),
           ),
+          const AutogenStatusPanel(),
           const AutogenPipelineDebugControlPanel(),
           Padding(
             padding: const EdgeInsets.all(16),
@@ -179,7 +181,7 @@ class _AutogenDebugScreenState extends State<AutogenDebugScreen> {
                 ElevatedButton(
                   onPressed: _status == _AutogenStatus.running
                       ? null
-                      : _startAutogen,
+                      : () => _startAutogen(),
                   child: const Text('Start Autogen'),
                 ),
                 OutlinedButton(

--- a/lib/services/autogen_pipeline_executor_status_service.dart
+++ b/lib/services/autogen_pipeline_executor_status_service.dart
@@ -3,6 +3,7 @@ import 'package:flutter/foundation.dart';
 import 'autogen_pipeline_executor.dart';
 import 'training_pack_auto_generator.dart';
 import 'training_pack_template_set_library_service.dart';
+import 'autogen_status_dashboard_service.dart';
 
 /// Service exposing start/stop controls and running status for the
 /// [AutogenPipelineExecutor].
@@ -28,6 +29,7 @@ class AutogenPipelineExecutorStatusService {
     final generator = TrainingPackAutoGenerator();
     _generator = generator;
     final executor = AutogenPipelineExecutor(generator: generator);
+    await AutogenStatusDashboardService.instance.bindExecutor(executor);
     try {
       await executor.execute(sets, existingYamlPath: 'packs/generated');
     } finally {

--- a/lib/widgets/autogen_status_panel.dart
+++ b/lib/widgets/autogen_status_panel.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+
+import '../services/autogen_status_dashboard_service.dart';
+import '../services/autogen_pipeline_executor_status_service.dart';
+import '../models/autogen_status.dart';
+
+/// Displays real-time status of the autogen pipeline and basic controls.
+class AutogenStatusPanel extends StatefulWidget {
+  const AutogenStatusPanel({super.key});
+
+  @override
+  State<AutogenStatusPanel> createState() => _AutogenStatusPanelState();
+}
+
+class _AutogenStatusPanelState extends State<AutogenStatusPanel> {
+  final _service = AutogenStatusDashboardService.instance;
+  final _execService = AutogenPipelineExecutorStatusService.instance;
+
+  @override
+  void initState() {
+    super.initState();
+    _service.loadSummaries();
+  }
+
+  String _formatDuration(Duration? d) {
+    if (d == null) return '--';
+    final h = d.inHours;
+    final m = d.inMinutes.remainder(60).toString().padLeft(2, '0');
+    final s = d.inSeconds.remainder(60).toString().padLeft(2, '0');
+    return h > 0 ? '$h:$m:$s' : '$m:$s';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<AutogenStatus>(
+      valueListenable: _service.pipelineStatus,
+      builder: (context, status, _) {
+        return Card(
+          margin: const EdgeInsets.all(8),
+          child: Padding(
+            padding: const EdgeInsets.all(8),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text('State: ${status.state.name}'),
+                Text('Step: ${status.currentStep}'),
+                Text('Queue: ${status.queueDepth}'),
+                Text('Processed: ${status.processed}'),
+                Text('Errors: ${status.errorsCount}'),
+                Text('ETA: ${_formatDuration(status.eta)}'),
+                const SizedBox(height: 8),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                  children: [
+                    ElevatedButton(
+                      onPressed: status.state == AutogenRunState.idle
+                          ? _execService.startAutogen
+                          : null,
+                      child: const Text('Start'),
+                    ),
+                    ElevatedButton(
+                      onPressed: status.state == AutogenRunState.running
+                          ? _execService.stopAutogen
+                          : null,
+                      child: const Text('Stop'),
+                    ),
+                    ElevatedButton(
+                      onPressed: status.state == AutogenRunState.paused
+                          ? _execService.startAutogen
+                          : null,
+                      child: const Text('Resume'),
+                    ),
+                  ],
+                ),
+                ExpansionTile(
+                  title: const Text('Details'),
+                  children: [
+                    if (_service.recentErrors.isNotEmpty) ...[
+                      const Text('Recent Errors'),
+                      for (final e in _service.recentErrors)
+                        Text(e, style: const TextStyle(color: Colors.red)),
+                    ],
+                    if (_service.runSummaries.isNotEmpty) ...[
+                      const SizedBox(height: 8),
+                      const Text('Run Summaries'),
+                      for (final r in _service.runSummaries)
+                        Text(
+                            '${r.startedAt?.toIso8601String() ?? ''}: processed ${r.processed}, errors ${r.errorsCount}'),
+                    ],
+                  ],
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/test/models/autogen_status_serialization_test.dart
+++ b/test/models/autogen_status_serialization_test.dart
@@ -1,0 +1,26 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/models/autogen_status.dart';
+
+void main() {
+  test('serializes and deserializes', () {
+    final original = AutogenStatus(
+      state: AutogenRunState.running,
+      currentStep: 'step1',
+      queueDepth: 3,
+      processed: 2,
+      errorsCount: 1,
+      startedAt: DateTime(2024, 1, 1),
+      updatedAt: DateTime(2024, 1, 1, 0, 1),
+      eta: const Duration(seconds: 30),
+      lastErrorMsg: 'boom',
+    );
+    final json = original.toJson();
+    final restored = AutogenStatus.fromJson(json);
+    expect(restored.state, original.state);
+    expect(restored.currentStep, original.currentStep);
+    expect(restored.queueDepth, original.queueDepth);
+    expect(restored.processed, original.processed);
+    expect(restored.errorsCount, original.errorsCount);
+    expect(restored.lastErrorMsg, original.lastErrorMsg);
+  });
+}

--- a/test/services/autogen_status_dashboard_service_stream_test.dart
+++ b/test/services/autogen_status_dashboard_service_stream_test.dart
@@ -1,0 +1,28 @@
+import 'dart:async';
+
+import 'package:test/test.dart';
+import 'package:poker_analyzer/services/autogen_status_dashboard_service.dart';
+import 'package:poker_analyzer/models/autogen_status.dart';
+
+void main() {
+  final service = AutogenStatusDashboardService.instance;
+
+  setUp(() {
+    service.clear();
+  });
+
+  tearDown(() {
+    service.clear();
+  });
+
+  test('bindStream updates pipeline status', () async {
+    final controller = StreamController<AutogenStatus>();
+    await service.bindStream(controller.stream);
+    controller.add(
+      AutogenStatus(state: AutogenRunState.running, currentStep: 's1'),
+    );
+    await Future.delayed(const Duration(milliseconds: 10));
+    expect(service.pipelineStatus.value.currentStep, 's1');
+    await controller.close();
+  });
+}


### PR DESCRIPTION
## Summary
- add AutogenRunState model with serialization helpers
- stream pipeline status through AutogenStatusDashboardService
- show realtime state in new AutogenStatusPanel with basic controls

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896abf7da7c832aa9bd4e9951dc6056