### PR TITLE
Add skill tag coverage guard to autogen pipeline

### DIFF
--- a/lib/models/coverage_report.dart
+++ b/lib/models/coverage_report.dart
@@ -1,0 +1,15 @@
+class CoverageReport {
+  final int totalTags;
+  final int uniqueTags;
+  final List<String> topTags;
+  final double coveragePct;
+  final bool passes;
+
+  const CoverageReport({
+    required this.totalTags,
+    required this.uniqueTags,
+    required this.topTags,
+    required this.coveragePct,
+    required this.passes,
+  });
+}

--- a/lib/services/skill_tag_coverage_guard_service.dart
+++ b/lib/services/skill_tag_coverage_guard_service.dart
@@ -1,0 +1,104 @@
+import 'dart:math';
+
+import '../models/coverage_report.dart';
+import '../models/v2/training_pack_template_v2.dart';
+import '../models/v2/training_pack_spot.dart';
+import 'preferences_service.dart';
+import '../utils/app_logger.dart';
+
+enum CoverageGuardMode { soft, strict }
+
+class _Thresholds {
+  final int minUniqueTags;
+  final double minCoveragePct;
+  const _Thresholds({
+    required this.minUniqueTags,
+    required this.minCoveragePct,
+  });
+}
+
+class SkillTagCoverageGuardService {
+  static const _defaultMinUniqueTags = 5;
+  static const _defaultMinCoveragePct = 0.35;
+  static const _uniqueKey = 'coverage.minUniqueTags';
+  static const _pctKey = 'coverage.minCoveragePct';
+
+  final CoverageGuardMode mode;
+  int rejectedCount = 0;
+
+  SkillTagCoverageGuardService({this.mode = CoverageGuardMode.soft});
+
+  Future<CoverageReport> evaluate(TrainingPackTemplateV2 pack) async {
+    final tags = <String>[];
+    for (final TrainingPackSpot s in pack.spots) {
+      for (final t in s.tags) {
+        final norm = t.trim().toLowerCase();
+        if (norm.isEmpty) continue;
+        tags.add(norm);
+      }
+    }
+    final counts = <String, int>{};
+    for (final t in tags) {
+      counts[t] = (counts[t] ?? 0) + 1;
+    }
+    final total = counts.values.fold(0, (a, b) => a + b);
+    final unique = counts.length;
+    final sorted = counts.entries.toList()
+      ..sort((a, b) => b.value.compareTo(a.value));
+    final topTags = [for (final e in sorted.take(5)) e.key];
+    final pct = total == 0 ? 0.0 : unique / total;
+    final audience = pack.audience ?? pack.meta['audience']?.toString();
+    final th = await getThresholds(audience: audience);
+    var passes = unique >= th.minUniqueTags && pct >= th.minCoveragePct;
+    if (!passes) {
+      AppLogger.warn(
+          'skill_tag_coverage_guard: pack=${pack.id} unique=$unique coverage=${pct.toStringAsFixed(2)}');
+      if (mode == CoverageGuardMode.strict) {
+        rejectedCount++;
+      } else {
+        passes = true;
+      }
+    }
+    return CoverageReport(
+      totalTags: total,
+      uniqueTags: unique,
+      topTags: topTags,
+      coveragePct: pct,
+      passes: passes,
+    );
+  }
+
+  static String _audKey(String base, String audience) => '$base.$audience';
+
+  static Future<void> setThresholds({
+    int? minUniqueTags,
+    double? minCoveragePct,
+    String? audience,
+  }) async {
+    final prefs = await PreferencesService.getInstance();
+    final keyUnique =
+        audience == null ? _uniqueKey : _audKey(_uniqueKey, audience);
+    final keyPct = audience == null ? _pctKey : _audKey(_pctKey, audience);
+    if (minUniqueTags != null) {
+      await prefs.setInt(keyUnique, minUniqueTags);
+    }
+    if (minCoveragePct != null) {
+      await prefs.setDouble(keyPct, minCoveragePct);
+    }
+  }
+
+  static Future<_Thresholds> getThresholds({String? audience}) async {
+    final prefs = await PreferencesService.getInstance();
+    final unique = prefs.getInt(
+          audience == null ? _uniqueKey : _audKey(_uniqueKey, audience),
+        ) ??
+        prefs.getInt(_uniqueKey) ??
+        _defaultMinUniqueTags;
+    final pct = prefs.getDouble(
+          audience == null ? _pctKey : _audKey(_pctKey, audience),
+        ) ??
+        prefs.getDouble(_pctKey) ??
+        _defaultMinCoveragePct;
+    return _Thresholds(minUniqueTags: unique, minCoveragePct: pct);
+  }
+}

--- a/lib/widgets/autogen_status_panel.dart
+++ b/lib/widgets/autogen_status_panel.dart
@@ -48,6 +48,20 @@ class _AutogenStatusPanelState extends State<AutogenStatusPanel> {
                 Text('Processed: ${status.processed}'),
                 Text('Errors: ${status.errorsCount}'),
                 Text('ETA: ${_formatDuration(status.eta)}'),
+                ValueListenableBuilder<Map<String, int>>(
+                  valueListenable: _service.coverageHistogramNotifier,
+                  builder: (context, hist, _) {
+                    final summary = hist.entries
+                        .map((e) => '${e.key}:${e.value}')
+                        .join(', ');
+                    return Text('Coverage: $summary');
+                  },
+                ),
+                ValueListenableBuilder<int>(
+                  valueListenable: _service.rejectedByCoverageNotifier,
+                  builder: (context, count, _) =>
+                      Text('Rejected by coverage: $count'),
+                ),
                 const SizedBox(height: 8),
                 Row(
                   mainAxisAlignment: MainAxisAlignment.spaceEvenly,
@@ -86,6 +100,14 @@ class _AutogenStatusPanelState extends State<AutogenStatusPanel> {
                       for (final r in _service.runSummaries)
                         Text(
                             '${r.startedAt?.toIso8601String() ?? ''}: processed ${r.processed}, errors ${r.errorsCount}'),
+                    ],
+                    if (_service.coverageSummaries.isNotEmpty) ...[
+                      const SizedBox(height: 8),
+                      const Text('Coverage Summaries'),
+                      for (final h in _service.coverageSummaries)
+                        Text(h.entries
+                            .map((e) => '${e.key}:${e.value}')
+                            .join(', ')),
                     ],
                   ],
                 ),

--- a/test/services/skill_tag_coverage_guard_service_test.dart
+++ b/test/services/skill_tag_coverage_guard_service_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/services/skill_tag_coverage_guard_service.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template_v2.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/core/training/engine/training_type_engine.dart';
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  TrainingPackTemplateV2 _packWithTags(List<List<String>> tags,
+      {String? audience}) {
+    final spots = [
+      for (var i = 0; i < tags.length; i++)
+        TrainingPackSpot(id: 's$i', tags: tags[i])
+    ];
+    return TrainingPackTemplateV2(
+      id: 'p',
+      name: 'P',
+      trainingType: TrainingType.quiz,
+      spots: spots,
+      spotCount: spots.length,
+      audience: audience,
+    );
+  }
+
+  test('rejects pack with zero tags', () async {
+    final guard = SkillTagCoverageGuardService(mode: CoverageGuardMode.strict);
+    final pack = _packWithTags([[]]);
+    final report = await guard.evaluate(pack);
+    expect(report.coveragePct, 0);
+    expect(report.passes, isFalse);
+  });
+
+  test('single tag dominance fails coverage pct', () async {
+    final guard = SkillTagCoverageGuardService(mode: CoverageGuardMode.strict);
+    final pack = _packWithTags([
+      for (var i = 0; i < 10; i++) ['a']
+    ]);
+    final report = await guard.evaluate(pack);
+    expect(report.uniqueTags, 1);
+    expect(report.passes, isFalse);
+  });
+
+  test('audience override applies', () async {
+    await SkillTagCoverageGuardService.setThresholds(
+        minUniqueTags: 1, minCoveragePct: 0.1, audience: 'pro');
+    final guard = SkillTagCoverageGuardService(mode: CoverageGuardMode.strict);
+    final pack = _packWithTags([
+      for (var i = 0; i < 10; i++) ['a']
+    ], audience: 'pro');
+    final report = await guard.evaluate(pack);
+    expect(report.passes, isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- add CoverageReport model and SkillTagCoverageGuardService with configurable thresholds
- integrate coverage guard into AutogenPipelineExecutor and dashboard tracking
- display coverage histogram and rejections in status panel and add unit tests

## Testing
- `flutter test test/services/skill_tag_coverage_guard_service_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896b67c86f8832a848e640790961a24