### PR TITLE
ci: enable flutter tests with env-driven coverage guard

### DIFF
--- a/.github/workflows/theory-integrity.yml
+++ b/.github/workflows/theory-integrity.yml
@@ -11,6 +11,8 @@ permissions:
 env:
   # Каталоги, где лежат реальные YAML
   THEORY_DIRS: assets,yaml_out,theory
+  COVERAGE_MIN_UNIQUE_TAGS: 5
+  COVERAGE_MIN_PCT: 0.35
 
 jobs:
   verify:
@@ -99,6 +101,9 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         env:
           THEORY_DIRS: ${{ env.THEORY_DIRS }}
+          COVERAGE_MODE: strict
+          COVERAGE_MIN_UNIQUE_TAGS: ${{ env.COVERAGE_MIN_UNIQUE_TAGS }}
+          COVERAGE_MIN_PCT: ${{ env.COVERAGE_MIN_PCT }}
         run: |
           if [[ "${{ steps.changed.outputs.has_yaml }}" != "1" ]]; then
             echo "No YAML to verify (strict). Skipping."

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,40 @@
+name: Unit tests
+
+on:
+  push:
+    branches: [ main ]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+  pull_request:
+    branches: [ main ]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      COVERAGE_MODE: soft
+      COVERAGE_MIN_UNIQUE_TAGS: 5
+      COVERAGE_MIN_PCT: 0.35
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+          cache-key: ${{ runner.os }}-flutter-${{ hashFiles('pubspec.lock') }}
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Run unit tests
+        run: flutter test --no-pub
+        env:
+          COVERAGE_MODE: ${{ github.event_name == 'pull_request' && 'strict' || env.COVERAGE_MODE }}
+          COVERAGE_MIN_UNIQUE_TAGS: ${{ env.COVERAGE_MIN_UNIQUE_TAGS }}
+          COVERAGE_MIN_PCT: ${{ env.COVERAGE_MIN_PCT }}

--- a/README.md
+++ b/README.md
@@ -65,6 +65,15 @@ echo 'ref: refs/heads/main' > .git/HEAD
 ## CI & QA
 GitHub Actions run unit tests, build the demo APK, and enforce theory integrity.
 
+### CI configuration
+Environment variables can tune the skill tag coverage gate:
+
+- `COVERAGE_MODE` – `soft` (default) or `strict`.
+- `COVERAGE_MIN_UNIQUE_TAGS` – minimal distinct tags (default `5`).
+- `COVERAGE_MIN_PCT` – minimal tag coverage fraction (default `0.35`).
+
+Set these in CI to adjust thresholds or switch modes (PRs run with `COVERAGE_MODE=strict`).
+
 ## License & Credits
 © 2024 Poker Analyzer contributors. License pending.
 

--- a/lib/services/skill_tag_coverage_guard_service.dart
+++ b/lib/services/skill_tag_coverage_guard_service.dart
@@ -1,4 +1,5 @@
 import 'dart:math';
+import 'dart:io';
 
 import '../models/coverage_report.dart';
 import '../models/v2/training_pack_template_v2.dart';
@@ -26,7 +27,14 @@ class SkillTagCoverageGuardService {
   final CoverageGuardMode mode;
   int rejectedCount = 0;
 
-  SkillTagCoverageGuardService({this.mode = CoverageGuardMode.soft});
+  final int? minUniqueTagsOverride;
+  final double? minCoveragePctOverride;
+
+  SkillTagCoverageGuardService({
+    this.mode = CoverageGuardMode.soft,
+    this.minUniqueTagsOverride,
+    this.minCoveragePctOverride,
+  });
 
   Future<CoverageReport> evaluate(TrainingPackTemplateV2 pack) async {
     final tags = <String>[];
@@ -48,11 +56,17 @@ class SkillTagCoverageGuardService {
     final topTags = [for (final e in sorted.take(5)) e.key];
     final pct = total == 0 ? 0.0 : unique / total;
     final audience = pack.audience ?? pack.meta['audience']?.toString();
-    final th = await getThresholds(audience: audience);
+    final th = (minUniqueTagsOverride != null || minCoveragePctOverride != null)
+        ? _Thresholds(
+            minUniqueTags: minUniqueTagsOverride ?? _defaultMinUniqueTags,
+            minCoveragePct: minCoveragePctOverride ?? _defaultMinCoveragePct,
+          )
+        : await getThresholds(audience: audience);
     var passes = unique >= th.minUniqueTags && pct >= th.minCoveragePct;
     if (!passes) {
       AppLogger.warn(
-          'skill_tag_coverage_guard: pack=${pack.id} unique=$unique coverage=${pct.toStringAsFixed(2)}');
+        'skill_tag_coverage_guard: pack=${pack.id} unique=$unique coverage=${pct.toStringAsFixed(2)}',
+      );
       if (mode == CoverageGuardMode.strict) {
         rejectedCount++;
       } else {
@@ -70,14 +84,52 @@ class SkillTagCoverageGuardService {
 
   static String _audKey(String base, String audience) => '$base.$audience';
 
+  static SkillTagCoverageGuardService? fromEnv([Map<String, String>? env]) {
+    final e = env ?? Platform.environment;
+    final modeStr = e['COVERAGE_MODE'];
+    final uniqueStr = e['COVERAGE_MIN_UNIQUE_TAGS'];
+    final pctStr = e['COVERAGE_MIN_PCT'];
+    if (modeStr == null && uniqueStr == null && pctStr == null) {
+      return null;
+    }
+    final mode = modeStr == 'strict'
+        ? CoverageGuardMode.strict
+        : CoverageGuardMode.soft;
+    int? minUnique;
+    double? minPct;
+    if (uniqueStr != null) {
+      minUnique = int.tryParse(uniqueStr);
+      if (minUnique == null) {
+        AppLogger.warn('Invalid COVERAGE_MIN_UNIQUE_TAGS: $uniqueStr');
+      }
+    }
+    if (pctStr != null) {
+      minPct = double.tryParse(pctStr);
+      if (minPct == null) {
+        AppLogger.warn('Invalid COVERAGE_MIN_PCT: $pctStr');
+      }
+    }
+    final effectiveUnique = minUnique ?? _defaultMinUniqueTags;
+    final effectivePct = minPct ?? _defaultMinCoveragePct;
+    AppLogger.info(
+      'coverage_guard_env: mode=$mode unique=$effectiveUnique pct=${effectivePct.toStringAsFixed(2)}',
+    );
+    return SkillTagCoverageGuardService(
+      mode: mode,
+      minUniqueTagsOverride: minUnique,
+      minCoveragePctOverride: minPct,
+    );
+  }
+
   static Future<void> setThresholds({
     int? minUniqueTags,
     double? minCoveragePct,
     String? audience,
   }) async {
     final prefs = await PreferencesService.getInstance();
-    final keyUnique =
-        audience == null ? _uniqueKey : _audKey(_uniqueKey, audience);
+    final keyUnique = audience == null
+        ? _uniqueKey
+        : _audKey(_uniqueKey, audience);
     final keyPct = audience == null ? _pctKey : _audKey(_pctKey, audience);
     if (minUniqueTags != null) {
       await prefs.setInt(keyUnique, minUniqueTags);
@@ -89,12 +141,14 @@ class SkillTagCoverageGuardService {
 
   static Future<_Thresholds> getThresholds({String? audience}) async {
     final prefs = await PreferencesService.getInstance();
-    final unique = prefs.getInt(
+    final unique =
+        prefs.getInt(
           audience == null ? _uniqueKey : _audKey(_uniqueKey, audience),
         ) ??
         prefs.getInt(_uniqueKey) ??
         _defaultMinUniqueTags;
-    final pct = prefs.getDouble(
+    final pct =
+        prefs.getDouble(
           audience == null ? _pctKey : _audKey(_pctKey, audience),
         ) ??
         prefs.getDouble(_pctKey) ??


### PR DESCRIPTION
## Summary
- run flutter unit tests in CI with env-configurable coverage thresholds
- allow `SkillTagCoverageGuardService` to read coverage mode and thresholds from environment variables
- document coverage guard environment knobs

## Testing
- `flutter test --no-pub` *(fails: Can't find ')' to match '(' in saved_hand_manager_service.dart)*

------
https://chatgpt.com/codex/tasks/task_e_6896b88eaa44832aa37ab2bea62cf004