### PR TITLE
refactor: make schema validator standalone

### DIFF
--- a/.github/workflows/theory-integrity.yml
+++ b/.github/workflows/theory-integrity.yml
@@ -34,7 +34,7 @@ jobs:
         run: flutter config --no-analytics
 
       - name: Install dependencies
-        run: flutter pub get
+        run: dart pub get
 
       # Быстрый список затронутых YAML (если есть helper-скрипт — используем; если нет — не падаем)
       - name: Collect changed YAML paths

--- a/test/tools/schema_check_unit_test.dart
+++ b/test/tools/schema_check_unit_test.dart
@@ -1,0 +1,30 @@
+import 'package:test/test.dart';
+import 'package:yaml/yaml.dart';
+
+import '../../tool/schema_check.dart' as schema_check;
+
+void main() {
+  test('valid yaml passes', () {
+    final map =
+        loadYaml('''
+baseSpot: {}
+outputVariants:
+  foo:
+    targetStreet: flop
+''')
+            as Map;
+    final err = schema_check.validateMap(map);
+    expect(err, isNull);
+  });
+
+  test('non-map outputVariants rejected', () {
+    final map =
+        loadYaml('''
+baseSpot: {}
+outputVariants: []
+''')
+            as Map;
+    final err = schema_check.validateMap(map);
+    expect(err, isNotNull);
+  });
+}

--- a/tool/schema_check.dart
+++ b/tool/schema_check.dart
@@ -1,7 +1,77 @@
 import 'dart:io';
 
 import 'package:args/args.dart';
-import 'package:poker_analyzer/models/training_pack_template_set.dart';
+import 'package:yaml/yaml.dart';
+
+String? validateMap(Map<dynamic, dynamic> root, {String? source}) {
+  if (root['baseSpot'] is! Map) {
+    return 'E_BASE_SPOT_REQUIRED baseSpot object required';
+  }
+
+  final outputVariants = root['outputVariants'];
+  if (outputVariants is! Map) {
+    return 'E_OUTPUT_VARIANTS_MAP_REQUIRED outputVariants must be a map';
+  }
+
+  for (final entry in outputVariants.entries) {
+    final key = entry.key;
+    final value = entry.value;
+    if (key is! String || key.trim().isEmpty) {
+      return 'E_OUTPUT_VARIANT_NAME_INVALID outputVariants keys must be non-empty strings';
+    }
+    if (value is! Map) {
+      return 'E_OUTPUT_VARIANT_NOT_MAP outputVariants[$key] must be a map';
+    }
+
+    for (final field in value.keys) {
+      if (field is! String ||
+          ![
+            'targetStreet',
+            'boardConstraints',
+            'requiredTags',
+            'excludedTags',
+            'seed',
+          ].contains(field)) {
+        return 'E_OUTPUT_VARIANT_FIELD_INVALID outputVariants[$key]: unexpected field $field';
+      }
+    }
+
+    if (value.containsKey('seed') && value['seed'] is! int) {
+      return 'E_SEED_INT_REQUIRED outputVariants[$key].seed must be int';
+    }
+
+    if (value.containsKey('targetStreet')) {
+      final ts = value['targetStreet'];
+      const allowed = ['preflop', 'flop', 'turn', 'river'];
+      if (ts is! String || !allowed.contains(ts)) {
+        return 'E_TARGET_STREET_INVALID outputVariants[$key].targetStreet must be one of ${allowed.join('|')}';
+      }
+    }
+
+    if (value.containsKey('requiredTags')) {
+      final list = value['requiredTags'];
+      if (list is! List || list.any((e) => e is! String)) {
+        return 'E_REQUIRED_TAGS_STRING_LIST outputVariants[$key].requiredTags must be a list of strings';
+      }
+    }
+
+    if (value.containsKey('excludedTags')) {
+      final list = value['excludedTags'];
+      if (list is! List || list.any((e) => e is! String)) {
+        return 'E_EXCLUDED_TAGS_STRING_LIST outputVariants[$key].excludedTags must be a list of strings';
+      }
+    }
+
+    if (value.containsKey('boardConstraints')) {
+      final list = value['boardConstraints'];
+      if (list is! List || list.any((e) => e is! Map)) {
+        return 'E_BOARD_CONSTRAINTS_MAP_LIST outputVariants[$key].boardConstraints must be a list of maps';
+      }
+    }
+  }
+
+  return null;
+}
 
 void main(List<String> args) {
   final parser = ArgParser()..addFlag('soft', negatable: false);
@@ -12,9 +82,9 @@ void main(List<String> args) {
       .listSync(recursive: true)
       .whereType<File>()
       .where((f) {
-    final l = f.path.toLowerCase();
-    return l.endsWith('.yaml') || l.endsWith('.yml');
-  });
+        final l = f.path.toLowerCase();
+        return l.endsWith('.yaml') || l.endsWith('.yml');
+      });
 
   final errors = <String>[];
   var checked = 0;
@@ -22,10 +92,19 @@ void main(List<String> args) {
     final content = file.readAsStringSync();
     if (!content.contains('baseSpot:')) continue;
     try {
-      TrainingPackTemplateSet.fromYaml(content, source: file.path);
-      checked++;
+      final doc = loadYaml(content);
+      if (doc is Map) {
+        final err = validateMap(doc, source: file.path);
+        if (err != null) {
+          errors.add('${file.path}: $err');
+        } else {
+          checked++;
+        }
+      } else {
+        errors.add('${file.path}: E_ROOT_MAP_REQUIRED root YAML must be a map');
+      }
     } catch (e) {
-      errors.add('${file.path}: $e');
+      errors.add('${file.path}: E_YAML_PARSE_ERROR $e');
     }
   }
 


### PR DESCRIPTION
## Summary
- decouple tool/schema_check.dart from app code using pure YAML validation
- run Dart-only schema checks in theory-integrity workflow
- add unit test for schema validator

## Testing
- `dart pub get` *(fails: Flutter SDK is not available)*
- `dart run tool/schema_check.dart --soft` *(fails: packages args,yaml not resolved)*
- `dart run tool/schema_check.dart` *(fails: packages args,yaml not resolved)*
- `dart test test/tools/schema_check_unit_test.dart` *(fails: Flutter SDK is not available)*

------
https://chatgpt.com/codex/tasks/task_e_6896bc3e412c832a9cb3175c421298a7