### PR TITLE
chore: migrate remaining postflop templates

### DIFF
--- a/assets/packs/v2/manual_legacy/postflop/templates/flop_cbet_template.yaml
+++ b/assets/packs/v2/manual_legacy/postflop/templates/flop_cbet_template.yaml
@@ -23,3 +23,6 @@ variations:
       streets:
         preflop: [villainRaise, call]
         flop: [bet]
+outputVariants:
+  A:
+    targetStreet: flop

--- a/assets/packs/v2/manual_legacy/postflop/templates/river_decision_template.yaml
+++ b/assets/packs/v2/manual_legacy/postflop/templates/river_decision_template.yaml
@@ -24,3 +24,6 @@ variations:
         flop: [bet, villainCall]
         turn: [bet, villainCall]
         river: [bet]
+outputVariants:
+  A:
+    targetStreet: river

--- a/assets/packs/v2/manual_legacy/postflop/templates/turn_barrel_template.yaml
+++ b/assets/packs/v2/manual_legacy/postflop/templates/turn_barrel_template.yaml
@@ -23,3 +23,6 @@ variations:
       streets:
         flop: [bet, villainCall]
         turn: [bet]
+outputVariants:
+  A:
+    targetStreet: turn


### PR DESCRIPTION
## Summary
- convert legacy postflop templates to map-style `outputVariants`

## Testing
- `dart run tool/migrate_output_variants.dart --write`
- `dart run tool/schema_check.dart`


------
https://chatgpt.com/codex/tasks/task_e_6896be8c5848832a97bcb98d7f8ee736