### PR TITLE
feat: add board texture filters to autogen

### DIFF
--- a/lib/models/texture_filter_config.dart
+++ b/lib/models/texture_filter_config.dart
@@ -1,0 +1,17 @@
+class TextureFilterConfig {
+  final Set<String> include;
+  final Set<String> exclude;
+  final Map<String, double> targetMix;
+
+  const TextureFilterConfig({
+    this.include = const {},
+    this.exclude = const {},
+    this.targetMix = const {},
+  });
+
+  Map<String, dynamic> toJson() => {
+        if (include.isNotEmpty) 'include': include.toList(),
+        if (exclude.isNotEmpty) 'exclude': exclude.toList(),
+        if (targetMix.isNotEmpty) 'targetMix': targetMix,
+      };
+}

--- a/lib/screens/autogen_debug_screen.dart
+++ b/lib/screens/autogen_debug_screen.dart
@@ -24,6 +24,7 @@ import '../widgets/autogen_duplicate_table_widget.dart';
 import 'pack_fingerprint_comparer_report_ui.dart';
 import '../widgets/deduplication_policy_editor.dart';
 import '../widgets/theory_coverage_panel_widget.dart';
+import '../models/texture_filter_config.dart';
 
 class _DirExporter extends TrainingPackExporterV2 {
   final String outDir;
@@ -64,6 +65,16 @@ class _AutogenDebugScreenState extends State<AutogenDebugScreen> {
     text: 'packs/generated',
   );
   String? _sessionId;
+  final Set<String> _include = {};
+  final Set<String> _exclude = {};
+  final Map<String, double> _targetMix = {};
+  static const List<String> _textures = [
+    'low',
+    'paired',
+    'monotone',
+    'twoTone',
+    'rainbow'
+  ];
 
   @override
   void initState() {
@@ -103,6 +114,13 @@ class _AutogenDebugScreenState extends State<AutogenDebugScreen> {
       generator: generator,
       dashboard: dashboard,
       exporter: exporter,
+      textureFilters: TextureFilterConfig(
+        include: _include,
+        exclude: _exclude,
+        targetMix: Map.fromEntries(
+          _targetMix.entries.where((e) => e.value > 0),
+        ),
+      ),
     );
     await status.bindExecutor(executor);
     setState(() {
@@ -167,6 +185,81 @@ class _AutogenDebugScreenState extends State<AutogenDebugScreen> {
                   decoration: const InputDecoration(
                     labelText: 'Output Directory',
                   ),
+                ),
+                const SizedBox(height: 8),
+                const Text('Include Textures'),
+                Wrap(
+                  spacing: 8,
+                  children: [
+                    for (final t in _textures)
+                      FilterChip(
+                        label: Text(t),
+                        selected: _include.contains(t),
+                        onSelected: (v) {
+                          setState(() {
+                            if (v) {
+                              _include.add(t);
+                            } else {
+                              _include.remove(t);
+                            }
+                          });
+                        },
+                      ),
+                  ],
+                ),
+                const SizedBox(height: 8),
+                const Text('Exclude Textures'),
+                Wrap(
+                  spacing: 8,
+                  children: [
+                    for (final t in _textures)
+                      FilterChip(
+                        label: Text(t),
+                        selected: _exclude.contains(t),
+                        onSelected: (v) {
+                          setState(() {
+                            if (v) {
+                              _exclude.add(t);
+                            } else {
+                              _exclude.remove(t);
+                            }
+                          });
+                        },
+                      ),
+                  ],
+                ),
+                const SizedBox(height: 8),
+                const Text('Target Mix'),
+                Column(
+                  children: [
+                    for (final t in _textures)
+                      Row(
+                        children: [
+                          SizedBox(width: 80, child: Text(t)),
+                          Expanded(
+                            child: Slider(
+                              value: _targetMix[t] ?? 0,
+                              onChanged: (v) {
+                                setState(() {
+                                  _targetMix[t] = v;
+                                });
+                              },
+                            ),
+                          ),
+                          Text('${((_targetMix[t] ?? 0) * 100).toStringAsFixed(0)}%'),
+                        ],
+                      ),
+                  ],
+                ),
+                TextButton(
+                  onPressed: () {
+                    setState(() {
+                      _include.clear();
+                      _exclude.clear();
+                      _targetMix.clear();
+                    });
+                  },
+                  child: const Text('Reset Textures'),
                 ),
               ],
             ),

--- a/lib/services/autogen_stats_dashboard_service.dart
+++ b/lib/services/autogen_stats_dashboard_service.dart
@@ -24,6 +24,9 @@ class AutogenStatsDashboardService extends ChangeNotifier {
     unusedTags: [],
     overloadedTags: [],
   );
+  Map<String, int> textureCounts = {};
+  Map<String, int> textureRejects = {};
+  Map<String, double> targetTextureMix = {};
   DateTime? _start;
   int _yamlFiles = 0;
 
@@ -41,6 +44,9 @@ class AutogenStatsDashboardService extends ChangeNotifier {
       unusedTags: [],
       overloadedTags: [],
     );
+    textureCounts = {};
+    textureRejects = {};
+    targetTextureMix = {};
     _yamlFiles = 0;
     notifyListeners();
   }
@@ -63,6 +69,20 @@ class AutogenStatsDashboardService extends ChangeNotifier {
   void recordFingerprint(String _) {
     stats.fingerprintCount++;
     notifyListeners();
+  }
+
+  void setTargetTextureMix(Map<String, double> mix) {
+    targetTextureMix = Map.from(mix);
+    notifyListeners();
+  }
+
+  void recordTexture(String tex) {
+    textureCounts[tex] = (textureCounts[tex] ?? 0) + 1;
+    notifyListeners();
+  }
+
+  void recordRejectedTexture(String tex) {
+    textureRejects[tex] = (textureRejects[tex] ?? 0) + 1;
   }
 
   /// Updates coverage statistics for dashboard preview.
@@ -90,6 +110,12 @@ class AutogenStatsDashboardService extends ChangeNotifier {
       ..sort((a, b) => b.value.compareTo(a.value));
     for (final entry in sorted.take(10)) {
       buffer.writeln('  ${entry.key}: ${entry.value}');
+    }
+
+    if (targetTextureMix.isNotEmpty) {
+      buffer.writeln('Texture target: $targetTextureMix');
+      buffer.writeln('Texture achieved: $textureCounts');
+      buffer.writeln('Texture rejects: $textureRejects');
     }
 
     final report = buffer.toString();

--- a/lib/widgets/autogen_realtime_stats_panel.dart
+++ b/lib/widgets/autogen_realtime_stats_panel.dart
@@ -17,13 +17,32 @@ class AutogenRealtimeStatsPanel extends StatelessWidget {
           final stats = dashboard.stats;
           return Container(
             padding: const EdgeInsets.all(8),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            child: Column(
               children: [
-                Text('🧠 Packs: ${stats.totalPacks}'),
-                Text('🎯 Spots: ${stats.totalSpots}'),
-                Text('⚠️ Skipped: ${stats.skippedSpots}'),
-                Text('🔐 Fingerprints: ${stats.fingerprintCount}'),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                  children: [
+                    Text('🧠 Packs: ${stats.totalPacks}'),
+                    Text('🎯 Spots: ${stats.totalSpots}'),
+                    Text('⚠️ Skipped: ${stats.skippedSpots}'),
+                    Text('🔐 Fingerprints: ${stats.fingerprintCount}'),
+                  ],
+                ),
+                if (dashboard.targetTextureMix.isNotEmpty)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 8),
+                    child: Wrap(
+                      spacing: 8,
+                      children: [
+                        for (final entry in dashboard.targetTextureMix.entries)
+                          Text(
+                            '${entry.key}: '
+                            '${(dashboard.textureCounts[entry.key] ?? 0)}'
+                            '/${(entry.value * 100).toStringAsFixed(0)}%',
+                          ),
+                      ],
+                    ),
+                  ),
               ],
             ),
           );

--- a/test/services/training_pack_auto_generator_texture_filter_test.dart
+++ b/test/services/training_pack_auto_generator_texture_filter_test.dart
@@ -1,0 +1,45 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/services/training_pack_auto_generator.dart';
+import 'package:poker_analyzer/services/board_texture_classifier.dart';
+import 'package:poker_analyzer/models/texture_filter_config.dart';
+import 'package:poker_analyzer/models/training_pack_template_set.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/v2/hand_data.dart';
+import 'package:poker_analyzer/models/inline_theory_entry.dart';
+import 'package:poker_analyzer/services/training_pack_generator_engine_v2.dart';
+
+class _FakeEngine extends TrainingPackGeneratorEngineV2 {
+  final List<TrainingPackSpot> out;
+  _FakeEngine(this.out);
+  @override
+  List<TrainingPackSpot> generate(TrainingPackTemplateSet set,
+          {Map<String, InlineTheoryEntry> theoryIndex = const {}, int? seed}) =>
+      List.from(out);
+}
+
+TrainingPackSpot _spot(String id, String board) {
+  final cards = [board.substring(0, 2), board.substring(2, 4), board.substring(4, 6)];
+  return TrainingPackSpot(id: id, hand: HandData(board: cards), board: cards);
+}
+
+void main() {
+  test('texture filters include/exclude and mix', () async {
+    final engine = _FakeEngine([
+      _spot('m', 'KsQsJs'), // monotone
+      _spot('r', '2c3d5h'), // rainbow low
+      _spot('p', 'AhAd7s'), // paired twoTone
+    ]);
+    final gen = TrainingPackAutoGenerator(
+      engine: engine,
+      boardClassifier: const BoardTextureClassifier(),
+      textureFilters: const TextureFilterConfig(
+        include: {'monotone', 'rainbow'},
+        exclude: {'paired'},
+        targetMix: {'monotone': 0.5, 'rainbow': 0.5},
+      ),
+    );
+    final set = TrainingPackTemplateSet(baseSpot: TrainingPackSpot(id: 'base'));
+    final spots = await gen.generate(set, deduplicate: false);
+    expect(spots.map((s) => s.id).toList(), ['m', 'r']);
+  });
+}


### PR DESCRIPTION
## Summary
- support texture-based filtering/mix during pack generation
- expose include/exclude/mix controls in autogen debug UI
- track and display live texture distribution statistics

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899642449ec832a99387f5df6f59409