### PR TITLE
chore: bootstrap flutter for ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,6 +28,9 @@ jobs:
       - name: Check Flutter version
         run: flutter --version
 
+      - name: Bootstrap Flutter local.properties
+        run: bash scripts/setup_flutter_localprops.sh
+
       - name: Install dependencies
         run: flutter pub get
 
@@ -35,6 +38,5 @@ jobs:
       # - name: Analyze
       #   run: flutter analyze
 
-      # Временно отключаем тесты, если они падают
-      # - name: Run tests
-      #   run: flutter test
+      - name: Run tests
+        run: flutter test

--- a/.github/workflows/unit-tests-nightly.yml
+++ b/.github/workflows/unit-tests-nightly.yml
@@ -32,5 +32,6 @@ jobs:
           key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
           restore-keys: |
             ${{ runner.os }}-pub-
+      - run: bash scripts/setup_flutter_localprops.sh
       - run: flutter pub get
       - run: flutter test --coverage --concurrency=6

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -97,6 +97,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pub-
 
+      - name: Bootstrap Flutter local.properties
+        if: ${{ steps.compute.outputs.fast_path != 'true' }}
+        run: bash scripts/setup_flutter_localprops.sh
+
       - name: Install deps
         if: ${{ steps.compute.outputs.fast_path != 'true' }}
         run: flutter pub get

--- a/docs/build_android.md
+++ b/docs/build_android.md
@@ -1,0 +1,19 @@
+# Android build notes
+
+Gradle looks for the Flutter SDK in two ways:
+
+1. `FLUTTER_SDK` environment variable (also honors `FLUTTER_HOME`).
+2. `android/local.properties` with a `flutter.sdk=/path/to/flutter` entry.
+
+The repository provides `scripts/setup_flutter_localprops.sh` which detects the
+SDK path and writes `android/local.properties` accordingly. Run it before
+invoking Gradle on fresh machines.
+
+Locally you can set `FLUTTER_SDK` in your shell or create `android/local.properties`
+manually:
+
+```properties
+flutter.sdk=/absolute/path/to/flutter
+```
+
+This keeps Gradle stable on clean runners and ensures plugin resolution works.

--- a/scripts/setup_flutter_localprops.sh
+++ b/scripts/setup_flutter_localprops.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Ensure android/local.properties has flutter.sdk path for Gradle builds.
+# Detects Flutter SDK via FLUTTER_SDK, FLUTTER_HOME or `which flutter`.
+# Idempotent and exits 0 even if SDK not found.
+
+set -u
+set -o pipefail
+
+# Determine SDK path
+sdk="${FLUTTER_SDK:-${FLUTTER_HOME:-}}"
+if [ -z "$sdk" ]; then
+  if command -v flutter >/dev/null 2>&1; then
+    # flutter binary path -> remove /bin/flutter
+    binpath="$(command -v flutter)"
+    sdk="$(dirname "$(dirname "$binpath")")"
+  fi
+fi
+
+if [ -n "$sdk" ]; then
+  propfile="android/local.properties"
+  mkdir -p "$(dirname "$propfile")"
+  if [ -f "$propfile" ] && grep -q '^flutter\.sdk=' "$propfile"; then
+    # replace existing value if different
+    current="$(grep '^flutter\.sdk=' "$propfile" | head -n1 | cut -d'=' -f2-)"
+    if [ "$current" != "$sdk" ]; then
+      sed -i.bak "s|^flutter\.sdk=.*|flutter.sdk=$sdk|" "$propfile" && rm -f "$propfile.bak"
+    fi
+  else
+    echo "flutter.sdk=$sdk" >> "$propfile"
+  fi
+fi
+
+exit 0


### PR DESCRIPTION
## Summary
- add helper script to populate android/local.properties with Flutter SDK
- document Flutter SDK lookup
- call helper in CI to fix Gradle plugin resolution before running tests

## Testing
- `bash scripts/setup_flutter_localprops.sh`
- `flutter pub get`
- `flutter test` *(fails: many compile errors)*

------
https://chatgpt.com/codex/tasks/task_e_689967b18438832ab644600195ffb625