### PR TITLE
feat: add inline theory recall cards

### DIFF
--- a/lib/controllers/pack_run_controller.dart
+++ b/lib/controllers/pack_run_controller.dart
@@ -1,0 +1,33 @@
+import '../models/theory_snippet.dart';
+import '../services/theory_index_service.dart';
+
+class PackRunController {
+  final TheoryIndexService _theoryIndex;
+  final Map<String, bool> _recallShown = {};
+  final Map<String, int> _attempts = {};
+  final Set<String> _shownTheory = {};
+  int _handCounter = 0;
+  int _lastShownAt = -3;
+
+  PackRunController({TheoryIndexService? theoryIndex})
+      : _theoryIndex = theoryIndex ?? TheoryIndexService();
+
+  Future<TheorySnippet?> onResult(
+      String spotId, bool correct, List<String> tags) async {
+    _handCounter++;
+    if (correct) return null;
+    final attempt = (_attempts[spotId] ?? 0) + 1;
+    _attempts[spotId] = attempt;
+    if (attempt > 1) return null;
+    if (_recallShown[spotId] == true) return null;
+    if (_handCounter - _lastShownAt < 3) return null;
+    if (tags.isEmpty) return null;
+    final snippet =
+        await _theoryIndex.matchSnippet(tags, exclude: _shownTheory) ??
+            const TheorySnippet.generic();
+    _recallShown[spotId] = true;
+    _shownTheory.add(snippet.id);
+    _lastShownAt = _handCounter;
+    return snippet;
+  }
+}

--- a/lib/models/theory_snippet.dart
+++ b/lib/models/theory_snippet.dart
@@ -1,0 +1,19 @@
+class TheorySnippet {
+  final String id;
+  final String title;
+  final List<String> bullets;
+  final String? uri;
+
+  const TheorySnippet({
+    required this.id,
+    required this.title,
+    required this.bullets,
+    this.uri,
+  });
+
+  const TheorySnippet.generic()
+      : id = 'generic',
+        title = 'Review key concepts before retrying',
+        bullets = const [],
+        uri = null;
+}

--- a/lib/screens/training_play_screen.dart
+++ b/lib/screens/training_play_screen.dart
@@ -13,6 +13,9 @@ import '../models/training_spot_attempt.dart';
 import '../models/v2/training_pack_spot.dart';
 import '../app_bootstrap.dart';
 import '../services/training_session_fingerprint_service.dart';
+import '../controllers/pack_run_controller.dart';
+import '../models/theory_snippet.dart';
+import '../widgets/inline_theory_recall_card.dart';
 
 class TrainingPlayScreen extends StatefulWidget {
   const TrainingPlayScreen({super.key});
@@ -24,6 +27,8 @@ class TrainingPlayScreen extends StatefulWidget {
 class _TrainingPlayScreenState extends State<TrainingPlayScreen> {
   EvaluationResult? _result;
   InlineTheoryLink? _theoryLink;
+  final PackRunController _packController = PackRunController();
+  TheorySnippet? _recall;
 
   @override
   void initState() {
@@ -56,9 +61,11 @@ class _TrainingPlayScreenState extends State<TrainingPlayScreen> {
     await AppBootstrap.registry
         .get<TrainingSessionFingerprintService>()
         .logAttempt(attempt, shownTheoryTags: tags);
+    final snippet = await _packController.onResult(spot.id, res.correct, tags);
     setState(() {
       _result = res;
       _theoryLink = link;
+      _recall = snippet;
     });
   }
 
@@ -125,10 +132,18 @@ class _TrainingPlayScreenState extends State<TrainingPlayScreen> {
                 ),
               ),
               const SizedBox(height: 8),
+              if (_recall != null) ...[
+                InlineTheoryRecallCard(
+                  snippet: _recall!,
+                  onDismiss: () => setState(() => _recall = null),
+                ),
+                const SizedBox(height: 8),
+              ],
               ElevatedButton(
                 onPressed: () => setState(() {
                   _result = null;
                   _theoryLink = null;
+                  _recall = null;
                 }),
                 child: const Text('Try Again'),
               ),

--- a/lib/services/theory_index_service.dart
+++ b/lib/services/theory_index_service.dart
@@ -1,0 +1,26 @@
+import 'theory_library_index.dart';
+import '../models/theory_snippet.dart';
+
+class TheoryIndexService {
+  final TheoryLibraryIndex _library;
+  TheoryIndexService({TheoryLibraryIndex? library})
+      : _library = library ?? TheoryLibraryIndex();
+
+  Future<TheorySnippet?> matchSnippet(List<String> tags,
+      {Set<String>? exclude}) async {
+    if (tags.isEmpty) return null;
+    final resources = await _library.all();
+    for (final res in resources) {
+      if (exclude?.contains(res.id) ?? false) continue;
+      if (res.tags.any(tags.contains)) {
+        return TheorySnippet(
+          id: res.id,
+          title: res.title,
+          bullets: ['Key concept: ${res.title}'],
+          uri: res.uri,
+        );
+      }
+    }
+    return null;
+  }
+}

--- a/lib/widgets/inline_theory_recall_card.dart
+++ b/lib/widgets/inline_theory_recall_card.dart
@@ -1,0 +1,77 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+import '../models/theory_snippet.dart';
+
+class InlineTheoryRecallCard extends StatefulWidget {
+  final TheorySnippet snippet;
+  final VoidCallback onDismiss;
+  const InlineTheoryRecallCard({super.key, required this.snippet, required this.onDismiss});
+
+  @override
+  State<InlineTheoryRecallCard> createState() => _InlineTheoryRecallCardState();
+}
+
+class _InlineTheoryRecallCardState extends State<InlineTheoryRecallCard>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  Timer? _timer;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller =
+        AnimationController(vsync: this, duration: const Duration(milliseconds: 300));
+    _controller.forward();
+    _timer = Timer(const Duration(seconds: 12), _handleDismiss);
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _handleDismiss() {
+    if (mounted) widget.onDismiss();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final snippet = widget.snippet;
+    return SlideTransition(
+      position: Tween<Offset>(begin: const Offset(0, 1), end: Offset.zero)
+          .animate(CurvedAnimation(parent: _controller, curve: Curves.easeOut)),
+      child: GestureDetector(
+        onTap: _handleDismiss,
+        child: Card(
+          color: Colors.blueGrey[800],
+          child: Padding(
+            padding: const EdgeInsets.all(12),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(snippet.title,
+                    style: const TextStyle(
+                        fontWeight: FontWeight.bold, color: Colors.white)),
+                for (final b in snippet.bullets)
+                  Text('• $b', style: const TextStyle(color: Colors.white70)),
+                if (snippet.uri != null)
+                  TextButton(
+                    onPressed: () async {
+                      final uri = Uri.parse(snippet.uri!);
+                      if (await canLaunchUrl(uri)) {
+                        await launchUrl(uri);
+                      }
+                    },
+                    child: const Text('Learn More'),
+                  ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/pack_run_controller_test.dart
+++ b/test/pack_run_controller_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/controllers/pack_run_controller.dart';
+import 'package:poker_analyzer/models/theory_snippet.dart';
+import 'package:poker_analyzer/services/theory_index_service.dart';
+
+class FakeTheoryIndexService extends TheoryIndexService {
+  final TheorySnippet? snippet;
+  FakeTheoryIndexService(this.snippet);
+
+  @override
+  Future<TheorySnippet?> matchSnippet(List<String> tags,
+      {Set<String>? exclude}) async {
+    return snippet;
+  }
+}
+
+void main() {
+  test('spot with missing tags -> no card', () async {
+    final controller =
+        PackRunController(theoryIndex: FakeTheoryIndexService(null));
+    final snippet = await controller.onResult('s1', false, []);
+    expect(snippet, isNull);
+  });
+
+  test('spot with valid tag -> card content matches theory snippet', () async {
+    const snippet = TheorySnippet(
+      id: 'th_push',
+      title: 'Push/Fold Basics',
+      bullets: ['Always push'],
+    );
+    final controller =
+        PackRunController(theoryIndex: FakeTheoryIndexService(snippet));
+    final result = await controller.onResult('s1', false, ['push']);
+    expect(result?.id, snippet.id);
+    expect(result?.title, snippet.title);
+  });
+}

--- a/test/widgets/inline_theory_recall_card_test.dart
+++ b/test/widgets/inline_theory_recall_card_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/widgets/inline_theory_recall_card.dart';
+import 'package:poker_analyzer/models/theory_snippet.dart';
+
+void main() {
+  testWidgets('recall card renders and dismisses on tap', (tester) async {
+    var dismissed = false;
+    await tester.pumpWidget(MaterialApp(
+      home: InlineTheoryRecallCard(
+        snippet: const TheorySnippet(id: '1', title: 'T', bullets: ['b']),
+        onDismiss: () => dismissed = true,
+      ),
+    ));
+    expect(find.text('T'), findsOneWidget);
+    await tester.tap(find.byType(InlineTheoryRecallCard));
+    await tester.pumpAndSettle();
+    expect(dismissed, isTrue);
+  });
+
+  testWidgets('recall card auto dismiss after 12s', (tester) async {
+    var dismissed = false;
+    await tester.pumpWidget(MaterialApp(
+      home: InlineTheoryRecallCard(
+        snippet: const TheorySnippet(id: '1', title: 'T', bullets: ['b']),
+        onDismiss: () => dismissed = true,
+      ),
+    ));
+    await tester.pump(const Duration(seconds: 12));
+    expect(dismissed, isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- add TheoryIndexService and PackRunController to surface theory snippets after mistakes
- introduce InlineTheoryRecallCard widget with slide-in animation and auto-dismiss
- integrate recall cards into training play screen and add unit/widget tests

## Testing
- `dart test test/pack_run_controller_test.dart test/widgets/inline_theory_recall_card_test.dart` *(failed: command not found)*
- `flutter test test/pack_run_controller_test.dart test/widgets/inline_theory_recall_card_test.dart` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a12b42924832a94d3a12cff1cf9e7