### PR TITLE
feat: add theory recall cooldown and snippet rotation

### DIFF
--- a/lib/controllers/pack_run_controller.dart
+++ b/lib/controllers/pack_run_controller.dart
@@ -1,33 +1,83 @@
+import '../models/pack_run_session_state.dart';
+import '../models/recall_snippet_result.dart';
 import '../models/theory_snippet.dart';
 import '../services/theory_index_service.dart';
 
 class PackRunController {
+  static const int _tagCooldown = 10;
+  static const int _globalCooldown = 3;
+
   final TheoryIndexService _theoryIndex;
-  final Map<String, bool> _recallShown = {};
-  final Map<String, int> _attempts = {};
-  final Set<String> _shownTheory = {};
-  int _handCounter = 0;
-  int _lastShownAt = -3;
+  final PackRunSessionState _state;
 
-  PackRunController({TheoryIndexService? theoryIndex})
-      : _theoryIndex = theoryIndex ?? TheoryIndexService();
+  PackRunController({TheoryIndexService? theoryIndex, PackRunSessionState? state})
+      : _theoryIndex = theoryIndex ?? TheoryIndexService(),
+        _state = state ?? PackRunSessionState();
 
-  Future<TheorySnippet?> onResult(
+  Future<RecallSnippetResult?> onResult(
       String spotId, bool correct, List<String> tags) async {
-    _handCounter++;
-    if (correct) return null;
-    final attempt = (_attempts[spotId] ?? 0) + 1;
-    _attempts[spotId] = attempt;
-    if (attempt > 1) return null;
-    if (_recallShown[spotId] == true) return null;
-    if (_handCounter - _lastShownAt < 3) return null;
-    if (tags.isEmpty) return null;
-    final snippet =
-        await _theoryIndex.matchSnippet(tags, exclude: _shownTheory) ??
-            const TheorySnippet.generic();
-    _recallShown[spotId] = true;
-    _shownTheory.add(snippet.id);
-    _lastShownAt = _handCounter;
-    return snippet;
+    _state.handCounter++;
+    if (correct) {
+      await _state.save();
+      return null;
+    }
+    final attempt = (_state.attemptsBySpot[spotId] ?? 0) + 1;
+    _state.attemptsBySpot[spotId] = attempt;
+    if (attempt > 1) {
+      await _state.save();
+      return null;
+    }
+    if (_state.recallShownBySpot[spotId] == true) {
+      await _state.save();
+      return null;
+    }
+    if (_state.handCounter - _state.lastShownAt < _globalCooldown) {
+      await _state.save();
+      return null;
+    }
+    if (tags.isEmpty) {
+      await _state.save();
+      return null;
+    }
+
+    for (final tag in tags) {
+      final last = _state.tagLastShown[tag];
+      if (last != null && _state.handCounter - last < _tagCooldown) {
+        _logTelemetry(tag, '', true);
+        continue;
+      }
+      final snippets = await _theoryIndex.snippetsForTag(tag);
+      if (snippets.isEmpty) continue;
+      final history = _state.recallHistory[tag] ?? <String>[];
+      TheorySnippet snippet;
+      try {
+        snippet = snippets.firstWhere((s) => !history.contains(s.id));
+      } catch (_) {
+        snippet = snippets.first; // fallback
+        history.clear();
+      }
+      history.add(snippet.id);
+      _state.recallHistory[tag] = history;
+      _state.recallShownBySpot[spotId] = true;
+      _state.tagLastShown[tag] = _state.handCounter;
+      _state.lastShownAt = _state.handCounter;
+      await _state.save();
+      _logTelemetry(tag, snippet.id, false);
+      return RecallSnippetResult(
+        tagId: tag,
+        snippet: snippet,
+        allSnippets: snippets,
+      );
+    }
+    await _state.save();
+    return null;
+  }
+
+  void _logTelemetry(String tagId, String snippetId, bool cooldownSkipped) {
+    // Placeholder for analytics integration.
+    // ignore: avoid_print
+    print(
+        'recall:{tag:$tagId,snippet:$snippetId,cooldownSkipped:$cooldownSkipped}');
   }
 }
+

--- a/lib/models/pack_run_session_state.dart
+++ b/lib/models/pack_run_session_state.dart
@@ -1,0 +1,73 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Persists per-tag cooldowns and recall history for a training session.
+class PackRunSessionState {
+  PackRunSessionState({
+    this.handCounter = 0,
+    this.lastShownAt = -3,
+    Map<String, int>? tagLastShown,
+    Map<String, List<String>>? recallHistory,
+    Map<String, bool>? recallShownBySpot,
+    Map<String, int>? attemptsBySpot,
+  })  : tagLastShown = tagLastShown ?? <String, int>{},
+        recallHistory = recallHistory ?? <String, List<String>>{},
+        recallShownBySpot = recallShownBySpot ?? <String, bool>{},
+        attemptsBySpot = attemptsBySpot ?? <String, int>{};
+
+  int handCounter;
+  int lastShownAt;
+  final Map<String, int> tagLastShown;
+  final Map<String, List<String>> recallHistory;
+  final Map<String, bool> recallShownBySpot;
+  final Map<String, int> attemptsBySpot;
+
+  static const _prefsKey = 'packRunSessionState';
+
+  Map<String, dynamic> toJson() => {
+        'handCounter': handCounter,
+        'tagLastShown': tagLastShown,
+        'recallHistory': recallHistory,
+        'recallShownBySpot': recallShownBySpot,
+        'attemptsBySpot': attemptsBySpot,
+        'lastShownAt': lastShownAt,
+      };
+
+  factory PackRunSessionState.fromJson(Map<String, dynamic> json) {
+    return PackRunSessionState(
+      handCounter: json['handCounter'] as int? ?? 0,
+      tagLastShown: (json['tagLastShown'] as Map?)?.map((key, value) =>
+              MapEntry(key as String, value as int)) ??
+          <String, int>{},
+      recallHistory: (json['recallHistory'] as Map?)?.map((key, value) =>
+              MapEntry(key as String, (value as List).cast<String>())) ??
+          <String, List<String>>{},
+      recallShownBySpot: (json['recallShownBySpot'] as Map?)?.map(
+              (key, value) => MapEntry(key as String, value as bool)) ??
+          <String, bool>{},
+      attemptsBySpot: (json['attemptsBySpot'] as Map?)?.map(
+              (key, value) => MapEntry(key as String, value as int)) ??
+          <String, int>{},
+      lastShownAt: json['lastShownAt'] as int? ?? -3,
+    );
+  }
+
+  static Future<PackRunSessionState> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_prefsKey);
+    if (raw == null) return PackRunSessionState();
+    try {
+      final map = jsonDecode(raw) as Map<String, dynamic>;
+      return PackRunSessionState.fromJson(map);
+    } catch (_) {
+      return PackRunSessionState();
+    }
+  }
+
+  Future<void> save() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_prefsKey, jsonEncode(toJson()));
+  }
+}
+

--- a/lib/models/recall_snippet_result.dart
+++ b/lib/models/recall_snippet_result.dart
@@ -1,0 +1,16 @@
+import 'package:meta/meta.dart';
+import 'theory_snippet.dart';
+
+/// Result returned when a recall snippet should be shown.
+@immutable
+class RecallSnippetResult {
+  final String tagId;
+  final TheorySnippet snippet;
+  final List<TheorySnippet> allSnippets;
+
+  const RecallSnippetResult({
+    required this.tagId,
+    required this.snippet,
+    required this.allSnippets,
+  });
+}

--- a/lib/screens/training_play_screen.dart
+++ b/lib/screens/training_play_screen.dart
@@ -14,7 +14,8 @@ import '../models/v2/training_pack_spot.dart';
 import '../app_bootstrap.dart';
 import '../services/training_session_fingerprint_service.dart';
 import '../controllers/pack_run_controller.dart';
-import '../models/theory_snippet.dart';
+import '../models/recall_snippet_result.dart';
+import '../models/pack_run_session_state.dart';
 import '../widgets/inline_theory_recall_card.dart';
 
 class TrainingPlayScreen extends StatefulWidget {
@@ -27,8 +28,8 @@ class TrainingPlayScreen extends StatefulWidget {
 class _TrainingPlayScreenState extends State<TrainingPlayScreen> {
   EvaluationResult? _result;
   InlineTheoryLink? _theoryLink;
-  final PackRunController _packController = PackRunController();
-  TheorySnippet? _recall;
+  PackRunController? _packController;
+  RecallSnippetResult? _recall;
 
   @override
   void initState() {
@@ -36,6 +37,11 @@ class _TrainingPlayScreenState extends State<TrainingPlayScreen> {
     AppBootstrap.registry
         .get<TrainingSessionFingerprintService>()
         .startSession();
+    PackRunSessionState.load().then((state) {
+      setState(() {
+        _packController = PackRunController(state: state);
+      });
+    });
   }
 
   Future<void> _choose(String action) async {
@@ -61,7 +67,7 @@ class _TrainingPlayScreenState extends State<TrainingPlayScreen> {
     await AppBootstrap.registry
         .get<TrainingSessionFingerprintService>()
         .logAttempt(attempt, shownTheoryTags: tags);
-    final snippet = await _packController.onResult(spot.id, res.correct, tags);
+    final snippet = await _packController?.onResult(spot.id, res.correct, tags);
     setState(() {
       _result = res;
       _theoryLink = link;
@@ -134,7 +140,8 @@ class _TrainingPlayScreenState extends State<TrainingPlayScreen> {
               const SizedBox(height: 8),
               if (_recall != null) ...[
                 InlineTheoryRecallCard(
-                  snippet: _recall!,
+                  snippet: _recall!.snippet,
+                  snippets: _recall!.allSnippets,
                   onDismiss: () => setState(() => _recall = null),
                 ),
                 const SizedBox(height: 8),

--- a/lib/services/theory_index_service.dart
+++ b/lib/services/theory_index_service.dart
@@ -6,6 +6,26 @@ class TheoryIndexService {
   TheoryIndexService({TheoryLibraryIndex? library})
       : _library = library ?? TheoryLibraryIndex();
 
+  /// Returns all snippets matching [tag].
+  Future<List<TheorySnippet>> snippetsForTag(String tag) async {
+    final resources = await _library.all();
+    final result = <TheorySnippet>[];
+    for (final res in resources) {
+      if (res.tags.contains(tag)) {
+        result.add(
+          TheorySnippet(
+            id: res.id,
+            title: res.title,
+            bullets: ['Key concept: ${res.title}'],
+            uri: res.uri,
+          ),
+        );
+      }
+    }
+    return result;
+  }
+
+  /// Retained for backwards compatibility; returns the first matching snippet.
   Future<TheorySnippet?> matchSnippet(List<String> tags,
       {Set<String>? exclude}) async {
     if (tags.isEmpty) return null;

--- a/lib/widgets/inline_theory_recall_card.dart
+++ b/lib/widgets/inline_theory_recall_card.dart
@@ -5,8 +5,14 @@ import '../models/theory_snippet.dart';
 
 class InlineTheoryRecallCard extends StatefulWidget {
   final TheorySnippet snippet;
+  final List<TheorySnippet> snippets;
   final VoidCallback onDismiss;
-  const InlineTheoryRecallCard({super.key, required this.snippet, required this.onDismiss});
+  const InlineTheoryRecallCard({
+    super.key,
+    required this.snippet,
+    this.snippets = const [],
+    required this.onDismiss,
+  });
 
   @override
   State<InlineTheoryRecallCard> createState() => _InlineTheoryRecallCardState();
@@ -35,6 +41,33 @@ class _InlineTheoryRecallCardState extends State<InlineTheoryRecallCard>
 
   void _handleDismiss() {
     if (mounted) widget.onDismiss();
+  }
+
+  void _showMore() {
+    showModalBottomSheet(
+      context: context,
+      builder: (_) => SizedBox(
+        height: 300,
+        child: PageView(
+          children: [
+            for (final s in widget.snippets)
+              Padding(
+                padding: const EdgeInsets.all(16),
+                child: ListView(
+                  children: [
+                    Text(s.title,
+                        style: const TextStyle(
+                            fontWeight: FontWeight.bold, fontSize: 18)),
+                    const SizedBox(height: 8),
+                    for (final b in s.bullets)
+                      Text('• $b', style: const TextStyle(fontSize: 14)),
+                  ],
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
   }
 
   @override
@@ -66,6 +99,11 @@ class _InlineTheoryRecallCardState extends State<InlineTheoryRecallCard>
                       }
                     },
                     child: const Text('Learn More'),
+                  ),
+                if (widget.snippets.length > 1)
+                  TextButton(
+                    onPressed: _showMore,
+                    child: const Text('More on this...'),
                   ),
               ],
             ),

--- a/test/pack_run_controller_test.dart
+++ b/test/pack_run_controller_test.dart
@@ -2,19 +2,22 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:poker_analyzer/controllers/pack_run_controller.dart';
 import 'package:poker_analyzer/models/theory_snippet.dart';
 import 'package:poker_analyzer/services/theory_index_service.dart';
+import 'package:poker_analyzer/models/recall_snippet_result.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class FakeTheoryIndexService extends TheoryIndexService {
   final TheorySnippet? snippet;
   FakeTheoryIndexService(this.snippet);
 
   @override
-  Future<TheorySnippet?> matchSnippet(List<String> tags,
-      {Set<String>? exclude}) async {
-    return snippet;
+  Future<List<TheorySnippet>> snippetsForTag(String tag) async {
+    if (snippet == null) return [];
+    return [snippet!];
   }
 }
 
 void main() {
+  SharedPreferences.setMockInitialValues({});
   test('spot with missing tags -> no card', () async {
     final controller =
         PackRunController(theoryIndex: FakeTheoryIndexService(null));
@@ -30,8 +33,9 @@ void main() {
     );
     final controller =
         PackRunController(theoryIndex: FakeTheoryIndexService(snippet));
-    final result = await controller.onResult('s1', false, ['push']);
-    expect(result?.id, snippet.id);
-    expect(result?.title, snippet.title);
+    final RecallSnippetResult? result =
+        await controller.onResult('s1', false, ['push']);
+    expect(result?.snippet.id, snippet.id);
+    expect(result?.snippet.title, snippet.title);
   });
 }


### PR DESCRIPTION
## Summary
- track hand-based cooldowns and recall history in `PackRunSessionState`
- rotate theory snippets per tag and respect per-tag cooldowns in `PackRunController`
- expose multiple snippets with "More on this" link in `InlineTheoryRecallCard`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a168e4908832a84bd432d6e3a3086