### PR TITLE
Scope session state per pack and guard actions until ready

### DIFF
--- a/lib/screens/training_play_screen.dart
+++ b/lib/screens/training_play_screen.dart
@@ -34,14 +34,15 @@ class _TrainingPlayScreenState extends State<TrainingPlayScreen> {
   @override
   void initState() {
     super.initState();
+    final training = context.read<TrainingSessionController>();
     final fpService =
         AppBootstrap.registry.get<TrainingSessionFingerprintService>();
     fpService.startSession().then((sessionId) {
-      final key = PackRunSessionState.keyFor(
-        packId: 'default',
-        sessionId: sessionId,
-      );
+      final packId = training.template?.id ?? training.packId;
+      final key =
+          PackRunSessionState.keyFor(packId: packId, sessionId: sessionId);
       PackRunSessionState.load(key).then((state) {
+        if (!mounted) return;
         setState(() {
           _packController = PackRunController(state: state);
         });
@@ -90,6 +91,7 @@ class _TrainingPlayScreenState extends State<TrainingPlayScreen> {
     if (_result == null && _theoryLink == null) {
       _theoryLink = InlineTheoryLinker().getLink(spot.tags);
     }
+    final actionsEnabled = _packController != null && _result == null;
     return Scaffold(
       appBar: AppBar(
         title: const Text('Training'),
@@ -116,21 +118,25 @@ class _TrainingPlayScreenState extends State<TrainingPlayScreen> {
                 children: spot.actionType == SpotActionType.callPush
                     ? [
                         ElevatedButton(
-                          onPressed: () => _choose('CALL'),
+                          onPressed:
+                              actionsEnabled ? () => _choose('CALL') : null,
                           child: const Text('CALL'),
                         ),
                         ElevatedButton(
-                          onPressed: () => _choose('FOLD'),
+                          onPressed:
+                              actionsEnabled ? () => _choose('FOLD') : null,
                           child: const Text('FOLD'),
                         ),
                       ]
                     : [
                         ElevatedButton(
-                          onPressed: () => _choose('PUSH'),
+                          onPressed:
+                              actionsEnabled ? () => _choose('PUSH') : null,
                           child: const Text('PUSH'),
                         ),
                         ElevatedButton(
-                          onPressed: () => _choose('FOLD'),
+                          onPressed:
+                              actionsEnabled ? () => _choose('FOLD') : null,
                           child: const Text('FOLD'),
                         ),
                       ],

--- a/lib/services/training_session_controller.dart
+++ b/lib/services/training_session_controller.dart
@@ -2,16 +2,21 @@ import 'dart:async';
 import 'package:flutter/widgets.dart';
 import '../models/training_spot.dart';
 import '../models/evaluation_result.dart';
+import '../models/v2/training_pack_template.dart';
 import 'evaluation_executor_service.dart';
 import 'service_registry.dart';
 
 class TrainingSessionController {
   TrainingSessionController({
     required ServiceRegistry registry,
+    this.packId = 'default',
+    this.template,
     EvaluationExecutor? executor,
   }) : _executor = executor ?? registry.get<EvaluationExecutor>();
 
   final EvaluationExecutor _executor;
+  final String packId;
+  final TrainingPackTemplate? template;
   TrainingSpot? _currentSpot;
 
   TrainingSpot? get currentSpot => _currentSpot;

--- a/test/pack_run_session_state_test.dart
+++ b/test/pack_run_session_state_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/pack_run_session_state.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('scope key isolates cooldown state', () async {
+    SharedPreferences.setMockInitialValues({});
+    final k1 = PackRunSessionState.keyFor(packId: 'p1', sessionId: 's1');
+    final k2 = PackRunSessionState.keyFor(packId: 'p2', sessionId: 's1');
+
+    final s1 = await PackRunSessionState.load(k1);
+    s1.tagLastShown['t'] = 5;
+    await s1.save();
+
+    final reloaded1 = await PackRunSessionState.load(k1);
+    final reloaded2 = await PackRunSessionState.load(k2);
+
+    expect(reloaded1.tagLastShown['t'], 5);
+    expect(reloaded2.tagLastShown.containsKey('t'), false);
+  });
+}


### PR DESCRIPTION
## Summary
- derive pack run persistence key from current pack and session
- expose packId/template on TrainingSessionController
- disable play buttons until PackRunController is initialized
- add test covering session state scope isolation

## Testing
- `dart test test/pack_run_controller_test.dart test/pack_run_session_state_test.dart` *(fails: command not found: dart)*


------
https://chatgpt.com/codex/tasks/task_e_689a1b4e0a24832a9b0813058f74d1dd