### PR TITLE
feat: add skill tag coverage dashboard

### DIFF
--- a/lib/models/skill_tag_stats.dart
+++ b/lib/models/skill_tag_stats.dart
@@ -6,6 +6,8 @@ class SkillTagStats {
   final Map<String, List<String>> spotTags;
   final Map<String, int> categoryCounts;
   final Map<String, double> categoryCoverage;
+  final Map<String, int> packsPerTag;
+  final Map<String, DateTime> tagLastUpdated;
 
   const SkillTagStats({
     required this.tagCounts,
@@ -15,5 +17,7 @@ class SkillTagStats {
     this.spotTags = const {},
     this.categoryCounts = const {},
     this.categoryCoverage = const {},
+    this.packsPerTag = const {},
+    this.tagLastUpdated = const {},
   });
 }

--- a/lib/services/skill_tag_coverage_tracker.dart
+++ b/lib/services/skill_tag_coverage_tracker.dart
@@ -19,6 +19,8 @@ class SkillTagCoverageTracker {
       <String, Set<String>>{};
   final Map<String, Set<String>> _allTagsByCategory =
       <String, Set<String>>{};
+  final Map<String, Set<String>> _tagPacks = <String, Set<String>>{};
+  final Map<String, DateTime> _tagLastUpdated = <String, DateTime>{};
   int _totalTags = 0;
 
   SkillTagCoverageTracker({
@@ -54,10 +56,11 @@ class SkillTagCoverageTracker {
   }
 
   /// Analyzes [pack] and updates global coverage counts.
-  SkillTagStats analyzePack(TrainingPackModel pack) => analyze(pack.spots);
+  SkillTagStats analyzePack(TrainingPackModel pack) =>
+      analyze(pack.spots, packId: pack.id);
 
   /// Computes tag coverage statistics for [spots].
-  SkillTagStats analyze(List<TrainingPackSpot> spots) {
+  SkillTagStats analyze(List<TrainingPackSpot> spots, {String? packId}) {
     final counts = <String, int>{};
     final perSpot = <String, List<String>>{};
     final localCategoryCounts = <String, int>{};
@@ -75,6 +78,10 @@ class SkillTagCoverageTracker {
         localCategoryCounts[cat] = (localCategoryCounts[cat] ?? 0) + 1;
         (_seenTagsByCategory[cat] ??= <String>{}).add(tag);
         (localSeenByCategory[cat] ??= <String>{}).add(tag);
+        if (packId != null) {
+          (_tagPacks[tag] ??= <String>{}).add(packId);
+        }
+        _tagLastUpdated[tag] = DateTime.now();
       }
     }
     _totalTags += total;
@@ -148,6 +155,8 @@ class SkillTagCoverageTracker {
       overloadedTags: overloaded,
       categoryCounts: Map<String, int>.from(categoryCounts),
       categoryCoverage: coverage,
+      packsPerTag: _tagPacks.map((k, v) => MapEntry(k, v.length)),
+      tagLastUpdated: Map<String, DateTime>.from(_tagLastUpdated),
     );
   }
 
@@ -236,6 +245,8 @@ class SkillTagCoverageTracker {
     skillTagCounts.clear();
     categoryCounts.clear();
     _seenTagsByCategory.clear();
+    _tagPacks.clear();
+    _tagLastUpdated.clear();
     _totalTags = 0;
   }
 

--- a/lib/services/skill_tag_coverage_tracker_service.dart
+++ b/lib/services/skill_tag_coverage_tracker_service.dart
@@ -1,4 +1,5 @@
 import '../models/skill_tag_coverage_report.dart';
+import '../models/skill_tag_stats.dart';
 import 'training_pack_library_service.dart';
 import 'skill_tag_coverage_tracker.dart';
 
@@ -25,6 +26,13 @@ class SkillTagCoverageTrackerService {
   /// Returns current tag usage statistics.
   Map<String, int> getTagStats() =>
       Map<String, int>.from(_tracker.skillTagCounts);
+
+  /// Returns the aggregated coverage statistics including per-category data.
+  SkillTagStats getCoverageStats() => _tracker.aggregateReport;
+
+  /// Exposes the tag-to-category mapping.
+  Map<String, String> get tagCategoryMap =>
+      Map<String, String>.from(_tracker.tagCategoryMap);
 
   /// Resets the underlying tracker.
   void reset() => _tracker.reset();

--- a/lib/utils/skill_tag_coverage_utils.dart
+++ b/lib/utils/skill_tag_coverage_utils.dart
@@ -1,0 +1,44 @@
+import '../models/skill_tag_stats.dart';
+
+/// Summary statistics for a single category.
+class CategorySummary {
+  final int total;
+  final int covered;
+  final int uncovered;
+  final double avg;
+
+  const CategorySummary(
+    this.total,
+    this.covered,
+    this.uncovered,
+    this.avg,
+  );
+}
+
+/// Computes coverage summary per category given the global stats.
+Map<String, CategorySummary> computeCategorySummary(
+  SkillTagStats stats,
+  Set<String> allTags,
+  Map<String, String> tagCategoryMap,
+) {
+  final totals = <String, int>{};
+  final covered = <String, Set<String>>{};
+  for (final tag in allTags) {
+    final norm = tag.toLowerCase();
+    final cat = tagCategoryMap[norm] ?? 'uncategorized';
+    totals[cat] = (totals[cat] ?? 0) + 1;
+    if ((stats.tagCounts[norm] ?? 0) > 0) {
+      (covered[cat] ??= <String>{}).add(norm);
+    }
+  }
+
+  final result = <String, CategorySummary>{};
+  totals.forEach((cat, total) {
+    final coveredCount = covered[cat]?.length ?? 0;
+    final uncovered = total - coveredCount;
+    final avg = total == 0 ? 0 : coveredCount / total * 100;
+    result[cat] = CategorySummary(total, coveredCount, uncovered, avg);
+  });
+  return result;
+}
+

--- a/lib/widgets/skill_tag_coverage_dashboard.dart
+++ b/lib/widgets/skill_tag_coverage_dashboard.dart
@@ -1,0 +1,261 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import '../models/skill_tag_stats.dart';
+import '../services/skill_tag_coverage_tracker_service.dart';
+import '../utils/skill_tag_coverage_utils.dart';
+
+class SkillTagCoverageDashboard extends StatefulWidget {
+  final Stream<SkillTagStats>? statsStream;
+  final Map<String, String>? tagCategoryMap;
+  final Set<String>? allTags;
+
+  const SkillTagCoverageDashboard({
+    super.key,
+    this.statsStream,
+    this.tagCategoryMap,
+    this.allTags,
+  });
+
+  @override
+  State<SkillTagCoverageDashboard> createState() =>
+      _SkillTagCoverageDashboardState();
+}
+
+class _TagRow {
+  final String tag;
+  final String category;
+  final int packs;
+  final int spots;
+  final double coverage;
+  final DateTime? lastUpdated;
+
+  _TagRow(
+    this.tag,
+    this.category,
+    this.packs,
+    this.spots,
+    this.coverage,
+    this.lastUpdated,
+  );
+}
+
+class _SkillTagCoverageDashboardState extends State<SkillTagCoverageDashboard> {
+  bool _showUncoveredOnly = false;
+  int? _sortColumnIndex;
+  bool _sortAscending = true;
+  List<_TagRow> _rows = <_TagRow>[];
+
+  @override
+  Widget build(BuildContext context) {
+    final stream = widget.statsStream ??
+        Stream.periodic(
+          const Duration(seconds: 1),
+          (_) => SkillTagCoverageTrackerService.instance.getCoverageStats(),
+        );
+    final tagCategoryMap =
+        widget.tagCategoryMap ??
+            SkillTagCoverageTrackerService.instance.tagCategoryMap;
+    final allTags = widget.allTags ??
+        SkillTagCoverageTrackerService.instance.allSkillTags;
+
+    return StreamBuilder<SkillTagStats>(
+      stream: stream,
+      builder: (context, snapshot) {
+        final stats = snapshot.data;
+        if (stats == null) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        _rows = _buildRows(stats, allTags, tagCategoryMap);
+        _applySort();
+        final categorySummary =
+            computeCategorySummary(stats, allTags, tagCategoryMap);
+        return Column(
+          children: [
+            SwitchListTile(
+              title: const Text('Show only uncovered'),
+              value: _showUncoveredOnly,
+              onChanged: (v) => setState(() => _showUncoveredOnly = v),
+            ),
+            _buildCategoryTable(categorySummary),
+            Expanded(
+              child: SingleChildScrollView(
+                scrollDirection: Axis.vertical,
+                child: SingleChildScrollView(
+                  scrollDirection: Axis.horizontal,
+                  child: DataTable(
+                    sortColumnIndex: _sortColumnIndex,
+                    sortAscending: _sortAscending,
+                    columns: [
+                      DataColumn(label: const Text('Tag'), onSort: _onSort),
+                      DataColumn(
+                          label: const Text('Category'), onSort: _onSort),
+                      DataColumn(
+                          label: const Text('Packs Covered'),
+                          numeric: true,
+                          onSort: _onSort),
+                      DataColumn(
+                          label: const Text('Spots Covered'),
+                          numeric: true,
+                          onSort: _onSort),
+                      DataColumn(
+                          label: const Text('Coverage %'),
+                          numeric: true,
+                          onSort: _onSort),
+                      DataColumn(
+                          label: const Text('Last Updated'), onSort: _onSort),
+                    ],
+                    rows: [
+                      for (final r in _filteredRows())
+                        DataRow(
+                          cells: [
+                            DataCell(Text(r.tag),
+                                onTap: () => Navigator.of(context)
+                                    .pushNamed('/trainingPacks',
+                                        arguments: r.tag)),
+                            DataCell(Text(r.category)),
+                            DataCell(Text('${r.packs}')),
+                            DataCell(Text('${r.spots}')),
+                            DataCell(Text(r.coverage.toStringAsFixed(1))),
+                            DataCell(Text(
+                                r.lastUpdated?.toIso8601String() ?? '')),
+                          ],
+                          color: MaterialStateProperty.resolveWith<Color?>((_) {
+                            final index =
+                                r.category.hashCode % Colors.primaries.length;
+                            return Colors.primaries[index].withOpacity(0.1);
+                          }),
+                        ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  List<_TagRow> _buildRows(
+    SkillTagStats stats,
+    Set<String> allTags,
+    Map<String, String> catMap,
+  ) {
+    final total = stats.totalTags == 0 ? 1 : stats.totalTags;
+    final rows = <_TagRow>[];
+    for (final tag in allTags) {
+      final norm = tag.toLowerCase();
+      final spots = stats.tagCounts[norm] ?? 0;
+      final packs = stats.packsPerTag[norm] ?? 0;
+      final coverage = spots / total * 100;
+      final last = stats.tagLastUpdated[norm];
+      final cat = catMap[norm] ?? 'uncategorized';
+      rows.add(_TagRow(tag, cat, packs, spots, coverage, last));
+    }
+    return rows;
+  }
+
+  List<_TagRow> _filteredRows() {
+    if (!_showUncoveredOnly) return _rows;
+    return _rows.where((r) => r.spots == 0).toList();
+  }
+
+  void _onSort(int columnIndex, bool ascending) {
+    setState(() {
+      _sortColumnIndex = columnIndex;
+      _sortAscending = ascending;
+      _rows.sort((a, b) {
+        int cmp;
+        switch (columnIndex) {
+          case 0:
+            cmp = a.tag.compareTo(b.tag);
+            break;
+          case 1:
+            cmp = a.category.compareTo(b.category);
+            break;
+          case 2:
+            cmp = a.packs.compareTo(b.packs);
+            break;
+          case 3:
+            cmp = a.spots.compareTo(b.spots);
+            break;
+          case 4:
+            cmp = a.coverage.compareTo(b.coverage);
+            break;
+          case 5:
+            final at = a.lastUpdated?.millisecondsSinceEpoch ?? 0;
+            final bt = b.lastUpdated?.millisecondsSinceEpoch ?? 0;
+            cmp = at.compareTo(bt);
+            break;
+          default:
+            cmp = 0;
+        }
+        return ascending ? cmp : -cmp;
+      });
+    });
+  }
+
+  void _applySort() {
+    if (_sortColumnIndex == null) return;
+    _rows.sort((a, b) {
+      int cmp;
+      switch (_sortColumnIndex) {
+        case 0:
+          cmp = a.tag.compareTo(b.tag);
+          break;
+        case 1:
+          cmp = a.category.compareTo(b.category);
+          break;
+        case 2:
+          cmp = a.packs.compareTo(b.packs);
+          break;
+        case 3:
+          cmp = a.spots.compareTo(b.spots);
+          break;
+        case 4:
+          cmp = a.coverage.compareTo(b.coverage);
+          break;
+        case 5:
+          final at = a.lastUpdated?.millisecondsSinceEpoch ?? 0;
+          final bt = b.lastUpdated?.millisecondsSinceEpoch ?? 0;
+          cmp = at.compareTo(bt);
+          break;
+        default:
+          cmp = 0;
+      }
+      return _sortAscending ? cmp : -cmp;
+    });
+  }
+
+  Widget _buildCategoryTable(Map<String, CategorySummary> summary) {
+    final rows = summary.entries
+        .map(
+          (e) => DataRow(
+            cells: [
+              DataCell(Text(e.key)),
+              DataCell(Text('${e.value.total}')),
+              DataCell(Text('${e.value.covered}')),
+              DataCell(Text('${e.value.uncovered}')),
+              DataCell(Text(e.value.avg.toStringAsFixed(1))),
+            ],
+          ),
+        )
+        .toList();
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      child: DataTable(
+        columns: const [
+          DataColumn(label: Text('Category')),
+          DataColumn(label: Text('Total Tags'), numeric: true),
+          DataColumn(label: Text('Covered'), numeric: true),
+          DataColumn(label: Text('Uncovered'), numeric: true),
+          DataColumn(label: Text('Avg %'), numeric: true),
+        ],
+        rows: rows,
+      ),
+    );
+  }
+}
+

--- a/test/widgets/skill_tag_coverage_dashboard_test.dart
+++ b/test/widgets/skill_tag_coverage_dashboard_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/skill_tag_stats.dart';
+import 'package:poker_analyzer/utils/skill_tag_coverage_utils.dart';
+import 'package:poker_analyzer/widgets/skill_tag_coverage_dashboard.dart';
+
+void main() {
+  final stats = SkillTagStats(
+    tagCounts: {'a': 5, 'b': 1, 'c': 0},
+    totalTags: 6,
+    unusedTags: const [],
+    overloadedTags: const [],
+    packsPerTag: const {'a': 3, 'b': 1, 'c': 0},
+    tagLastUpdated: const {},
+  );
+  final allTags = {'a', 'b', 'c'};
+  final tagCategoryMap = {'a': 'cat1', 'b': 'cat1', 'c': 'cat2'};
+
+  testWidgets('sorts by spots covered', (tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: SkillTagCoverageDashboard(
+        statsStream: Stream.value(stats),
+        allTags: allTags,
+        tagCategoryMap: tagCategoryMap,
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Spots Covered'));
+    await tester.pump();
+
+    final cPos = tester.getTopLeft(find.text('c')).dy;
+    final bPos = tester.getTopLeft(find.text('b')).dy;
+    final aPos = tester.getTopLeft(find.text('a')).dy;
+
+    expect(cPos < bPos, true);
+    expect(bPos < aPos, true);
+  });
+
+  testWidgets('filters uncovered tags', (tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: SkillTagCoverageDashboard(
+        statsStream: Stream.value(stats),
+        allTags: allTags,
+        tagCategoryMap: tagCategoryMap,
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(Switch));
+    await tester.pump();
+
+    expect(find.text('c'), findsOneWidget);
+    expect(find.text('a'), findsNothing);
+  });
+
+  test('computeCategorySummary aggregates', () {
+    final summary = computeCategorySummary(stats, allTags, tagCategoryMap);
+    final cat1 = summary['cat1']!;
+    final cat2 = summary['cat2']!;
+
+    expect(cat1.total, 2);
+    expect(cat1.covered, 2);
+    expect(cat1.uncovered, 0);
+    expect(cat1.avg, 100);
+
+    expect(cat2.total, 1);
+    expect(cat2.covered, 0);
+    expect(cat2.uncovered, 1);
+    expect(cat2.avg, 0);
+  });
+}
+


### PR DESCRIPTION
## Summary
- expand `SkillTagStats` and tracker to record packs-per-tag and last updated timestamps
- expose aggregated coverage stats and categories through the tracker service
- introduce `SkillTagCoverageDashboard` widget with sorting, filtering, and category summaries

## Testing
- `dart test` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_689a1cd08ef0832aae57fd816c7f3ff2