### PR TITLE
feat: add telemetry sink and integrate recall

### DIFF
--- a/lib/controllers/pack_run_controller.dart
+++ b/lib/controllers/pack_run_controller.dart
@@ -2,6 +2,7 @@ import '../models/pack_run_session_state.dart';
 import '../models/recall_snippet_result.dart';
 import '../models/theory_snippet.dart';
 import '../services/theory_index_service.dart';
+import '../services/learning_path_telemetry.dart';
 
 class PackRunController {
   static const int _tagCooldown = 10;
@@ -9,10 +10,19 @@ class PackRunController {
 
   final TheoryIndexService _theoryIndex;
   final PackRunSessionState _state;
+  final LearningPathTelemetry _telemetry;
+  final String packId;
+  final String sessionId;
 
-  PackRunController({TheoryIndexService? theoryIndex, PackRunSessionState? state})
-      : _theoryIndex = theoryIndex ?? TheoryIndexService(),
-        _state = state ?? PackRunSessionState();
+  PackRunController({
+    required this.packId,
+    required this.sessionId,
+    TheoryIndexService? theoryIndex,
+    PackRunSessionState? state,
+    LearningPathTelemetry? telemetry,
+  })  : _theoryIndex = theoryIndex ?? TheoryIndexService(),
+        _state = state ?? PackRunSessionState(),
+        _telemetry = telemetry ?? LearningPathTelemetry.instance;
 
   Future<RecallSnippetResult?> onResult(
       String spotId, bool correct, List<String> tags) async {
@@ -32,7 +42,14 @@ class PackRunController {
         for (final tag in tags) {
           final last = _state.tagLastShown[tag];
           if (last != null && _state.handCounter - last < _tagCooldown) {
-            _logTelemetry(tag, '', true);
+            final remaining =
+                _tagCooldown - (_state.handCounter - last);
+            _telemetry.log('inline_theory_skipped_cooldown', {
+              'packId': packId,
+              'sessionId': sessionId,
+              'tagId': tag,
+              'cooldownRemaining': remaining,
+            });
             continue;
           }
           final snippets = await _theoryIndex.snippetsForTag(tag);
@@ -50,7 +67,13 @@ class PackRunController {
           _state.recallShownBySpot[spotId] = true;
           _state.tagLastShown[tag] = _state.handCounter;
           _state.lastShownAt = _state.handCounter;
-          _logTelemetry(tag, snippet.id, false);
+          _telemetry.log('inline_theory_shown', {
+            'packId': packId,
+            'sessionId': sessionId,
+            'spotIndex': _state.handCounter,
+            'tagId': tag,
+            'snippetId': snippet.id,
+          });
           result = RecallSnippetResult(
             tagId: tag,
             snippet: snippet,
@@ -65,11 +88,6 @@ class PackRunController {
     return result;
   }
 
-  void _logTelemetry(String tagId, String snippetId, bool cooldownSkipped) {
-    // Placeholder for analytics integration.
-    // ignore: avoid_print
-    print(
-        'recall:{tag:$tagId,snippet:$snippetId,cooldownSkipped:$cooldownSkipped}');
-  }
+  // Telemetry handled via [LearningPathTelemetry].
 }
 

--- a/lib/models/stage_remedial_meta.dart
+++ b/lib/models/stage_remedial_meta.dart
@@ -1,3 +1,5 @@
+import '../services/learning_path_telemetry.dart';
+
 class StageRemedialMeta {
   final String remedialPackId;
   final int sourceAttempts;
@@ -44,5 +46,24 @@ class StageRemedialMeta {
         'createdAt': createdAt.toIso8601String(),
         if (completed) 'completed': true,
       };
+
+  StageRemedialMeta copyWith({bool? completed}) {
+    return StageRemedialMeta(
+      remedialPackId: remedialPackId,
+      sourceAttempts: sourceAttempts,
+      missTags: missTags,
+      missTextures: missTextures,
+      createdAt: createdAt,
+      completed: completed ?? this.completed,
+    );
+  }
+
+  StageRemedialMeta markCompleted(double accuracyAfter) {
+    LearningPathTelemetry.instance.log('remedial_completed', {
+      'remedialPackId': remedialPackId,
+      'accuracyAfter': accuracyAfter,
+    });
+    return copyWith(completed: true);
+  }
 }
 

--- a/lib/screens/learning_path_stage_preview_screen.dart
+++ b/lib/screens/learning_path_stage_preview_screen.dart
@@ -169,11 +169,11 @@ class _LearningPathStagePreviewScreenState
           if (v) {
             await LearningPathProgressService.instance
                 .markTheoryViewed(widget.stage.id);
-            await const LearningPathTelemetry().logTheoryShown(
-              pathId: widget.path.id,
-              stageId: widget.stage.id,
-              snippetIds: _snippets.map((e) => e.id).toList(),
-            );
+            await LearningPathTelemetry.instance.log('theory_shown', {
+              'pathId': widget.path.id,
+              'stageId': widget.stage.id,
+              'snippetIds': _snippets.map((e) => e.id).toList(),
+            });
           }
         },
         children: [

--- a/lib/screens/training_play_screen.dart
+++ b/lib/screens/training_play_screen.dart
@@ -44,7 +44,11 @@ class _TrainingPlayScreenState extends State<TrainingPlayScreen> {
       PackRunSessionState.load(key).then((state) {
         if (!mounted) return;
         setState(() {
-          _packController = PackRunController(state: state);
+          _packController = PackRunController(
+            packId: packId,
+            sessionId: sessionId,
+            state: state,
+          );
         });
       });
     });

--- a/lib/services/analytics_adapter.dart
+++ b/lib/services/analytics_adapter.dart
@@ -1,0 +1,9 @@
+abstract class AnalyticsAdapter {
+  Future<void> send(String event, Map<String, Object?> data);
+}
+
+class NullAnalyticsAdapter implements AnalyticsAdapter {
+  const NullAnalyticsAdapter();
+  @override
+  Future<void> send(String event, Map<String, Object?> data) async {}
+}

--- a/lib/services/remedial_pack_generator.dart
+++ b/lib/services/remedial_pack_generator.dart
@@ -2,9 +2,10 @@ import '../models/autogen_preset.dart';
 import '../models/texture_filter_config.dart';
 import '../models/theory_injector_config.dart';
 import '../models/remedial_spec.dart';
+import 'learning_path_telemetry.dart';
 
 class RemedialPackGenerator {
-  AutogenPreset build(String stageId, RemedialSpec spec,
+  AutogenPreset build(String pathId, String stageId, RemedialSpec spec,
       {int spotsPerPack = 6}) {
     final bounded = spotsPerPack.clamp(6, 12);
     final total = spec.textureCounts.values.fold<int>(0, (a, b) => a + b);
@@ -21,7 +22,7 @@ class RemedialPackGenerator {
       minScore: 0.7,
       preferNovelty: false,
     );
-    return AutogenPreset(
+    final preset = AutogenPreset(
       id: 'remedial_v1',
       name: 'Remedial Pack',
       textures: textures,
@@ -32,5 +33,13 @@ class RemedialPackGenerator {
         'stageId': stageId,
       },
     );
+    LearningPathTelemetry.instance.log('remedial_created', {
+      'pathId': pathId,
+      'stageId': stageId,
+      'remedialPackId': preset.id,
+      'missTags': spec.topTags,
+      'missTextures': spec.textureCounts,
+    });
+    return preset;
   }
 }

--- a/test/remedial_pack_generator_test.dart
+++ b/test/remedial_pack_generator_test.dart
@@ -11,7 +11,7 @@ void main() {
       minAccuracyTarget: 0.7,
     );
     final gen = RemedialPackGenerator();
-    final preset = gen.build('stage1', spec, spotsPerPack: 20);
+    final preset = gen.build('path1', 'stage1', spec, spotsPerPack: 20);
     expect(preset.spotsPerPack, 12);
     expect(preset.textures.targetMix.values.every((v) => v <= 0.4), true);
     expect(preset.theory.enabled, true);

--- a/test/services/learning_path_telemetry_test.dart
+++ b/test/services/learning_path_telemetry_test.dart
@@ -1,0 +1,38 @@
+import 'dart:io';
+
+import 'package:poker_analyzer/services/learning_path_telemetry.dart';
+import 'package:poker_analyzer/services/analytics_adapter.dart';
+import 'package:test/test.dart';
+
+class _TestAdapter implements AnalyticsAdapter {
+  int calls = 0;
+  @override
+  Future<void> send(String event, Map<String, Object?> data) async {
+    calls++;
+  }
+}
+
+void main() {
+  test('log writes line and adapter called', () async {
+    final dir = await Directory.systemTemp.createTemp('telemetry');
+    final adapter = _TestAdapter();
+    final t = LearningPathTelemetry.test(dir: dir);
+    t.adapter = adapter;
+    await t.log('e1', {'a': 1});
+    await t.log('e2', {'a': 2});
+    final file = File('${dir.path}/autogen_report.log');
+    final lines = await file.readAsLines();
+    expect(lines.length, 2);
+    expect(adapter.calls, 2);
+  });
+
+  test('rotates when file exceeds limit', () async {
+    final dir = await Directory.systemTemp.createTemp('telemetry');
+    final t = LearningPathTelemetry.test(dir: dir, maxBytes: 200);
+    final big = 'x' * 150;
+    await t.log('e1', {'v': big});
+    await t.log('e2', {'v': big});
+    final f1 = File('${dir.path}/autogen_report.log.1');
+    expect(await f1.exists(), true);
+  });
+}

--- a/test/widgets/inline_theory_recall_smoke_test.dart
+++ b/test/widgets/inline_theory_recall_smoke_test.dart
@@ -1,0 +1,37 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/controllers/pack_run_controller.dart';
+import 'package:poker_analyzer/models/pack_run_session_state.dart';
+import 'package:poker_analyzer/models/theory_snippet.dart';
+import 'package:poker_analyzer/services/learning_path_telemetry.dart';
+import 'package:poker_analyzer/services/theory_index_service.dart';
+
+class _FakeTheoryIndexService extends TheoryIndexService {
+  @override
+  Future<List<TheorySnippet>> snippetsForTag(String tag) async {
+    return [const TheorySnippet(id: 's1', title: 't', bullets: [])];
+  }
+}
+
+void main() {
+  testWidgets('triggering recall logs without prints', (tester) async {
+    final dir = await Directory.systemTemp.createTemp('telemetry');
+    final telemetry = LearningPathTelemetry.test(dir: dir);
+    final controller = PackRunController(
+      packId: 'p1',
+      sessionId: 's1',
+      theoryIndex: _FakeTheoryIndexService(),
+      state: PackRunSessionState(),
+      telemetry: telemetry,
+    );
+    final prints = <String>[];
+    await runZoned(() async {
+      await controller.onResult('spot1', false, ['tag1']);
+    }, zoneSpecification: ZoneSpecification(print: (self, parent, zone, line) {
+      prints.add(line);
+    }));
+    expect(prints, isEmpty);
+  });
+}


### PR DESCRIPTION
## Summary
- add `LearningPathTelemetry` sink with JSON file output and pluggable adapter
- log inline theory recall events and remedial pack creation
- wire remedial completion logging helper and cover with tests

## Testing
- `flutter test test/services/learning_path_telemetry_test.dart test/widgets/inline_theory_recall_smoke_test.dart test/remedial_pack_generator_test.dart` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a4ea1e91c832aa00d40d445acfbf2