### PR TITLE
refactor: update remedial pack generator signature

### DIFF
--- a/lib/models/pack_spec.dart
+++ b/lib/models/pack_spec.dart
@@ -1,0 +1,6 @@
+abstract class PackSpec {
+  List<String> get topTags;
+  Map<String, int> get textureCounts;
+  int get streetBias;
+  double get minAccuracyTarget;
+}

--- a/lib/models/remedial_spec.dart
+++ b/lib/models/remedial_spec.dart
@@ -1,7 +1,13 @@
-class RemedialSpec {
+import 'pack_spec.dart';
+
+class RemedialSpec implements PackSpec {
+  @override
   final List<String> topTags;
+  @override
   final Map<String, int> textureCounts;
+  @override
   final int streetBias;
+  @override
   final double minAccuracyTarget;
 
   const RemedialSpec({

--- a/lib/services/remedial_pack_generator.dart
+++ b/lib/services/remedial_pack_generator.dart
@@ -1,13 +1,13 @@
 import '../models/autogen_preset.dart';
 import '../models/texture_filter_config.dart';
 import '../models/theory_injector_config.dart';
-import '../models/remedial_spec.dart';
+import '../models/pack_spec.dart';
 import 'learning_path_telemetry.dart';
 
 class RemedialPackGenerator {
-  AutogenPreset build(String pathId, String stageId, RemedialSpec spec,
-      {int spotsPerPack = 6}) {
-    final bounded = spotsPerPack.clamp(6, 12);
+  AutogenPreset build(String pathId, String stageId, PackSpec spec,
+      {int? spotsPerPack}) {
+    final bounded = (spotsPerPack ?? 6).clamp(6, 12);
     final total = spec.textureCounts.values.fold<int>(0, (a, b) => a + b);
     final mix = <String, double>{};
     if (total > 0) {


### PR DESCRIPTION
## Summary
- introduce `PackSpec` abstraction for training pack specs
- implement `PackSpec` in `RemedialSpec`
- update `RemedialPackGenerator` to take `PackSpec` and optional `spotsPerPack`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a58f9b51c832a8241b3f8f9c71158