### PR TITLE
feat: add remedial pack generation controller

### DIFF
--- a/lib/models/stage_remedial_meta.dart
+++ b/lib/models/stage_remedial_meta.dart
@@ -6,6 +6,7 @@ class StageRemedialMeta {
   final Map<String, int> missTags;
   final Map<String, int> missTextures;
   final DateTime createdAt;
+  final double accuracyAfter;
   final bool completed;
 
   StageRemedialMeta({
@@ -14,6 +15,7 @@ class StageRemedialMeta {
     Map<String, int>? missTags,
     Map<String, int>? missTextures,
     DateTime? createdAt,
+    this.accuracyAfter = 0.0,
     this.completed = false,
   })  : missTags = missTags ?? const {},
         missTextures = missTextures ?? const {},
@@ -34,6 +36,7 @@ class StageRemedialMeta {
       createdAt: json['createdAt'] != null
           ? DateTime.tryParse(json['createdAt'].toString()) ?? DateTime.now()
           : DateTime.now(),
+      accuracyAfter: (json['accuracyAfter'] as num?)?.toDouble() ?? 0.0,
       completed: json['completed'] as bool? ?? false,
     );
   }
@@ -44,16 +47,18 @@ class StageRemedialMeta {
         if (missTags.isNotEmpty) 'missTags': missTags,
         if (missTextures.isNotEmpty) 'missTextures': missTextures,
         'createdAt': createdAt.toIso8601String(),
+        if (accuracyAfter > 0) 'accuracyAfter': accuracyAfter,
         if (completed) 'completed': true,
       };
 
-  StageRemedialMeta copyWith({bool? completed}) {
+  StageRemedialMeta copyWith({bool? completed, double? accuracyAfter}) {
     return StageRemedialMeta(
       remedialPackId: remedialPackId,
       sourceAttempts: sourceAttempts,
       missTags: missTags,
       missTextures: missTextures,
       createdAt: createdAt,
+      accuracyAfter: accuracyAfter ?? this.accuracyAfter,
       completed: completed ?? this.completed,
     );
   }
@@ -63,7 +68,7 @@ class StageRemedialMeta {
       'remedialPackId': remedialPackId,
       'accuracyAfter': accuracyAfter,
     });
-    return copyWith(completed: true);
+    return copyWith(completed: true, accuracyAfter: accuracyAfter);
   }
 }
 

--- a/lib/services/pack_registry_service.dart
+++ b/lib/services/pack_registry_service.dart
@@ -1,4 +1,6 @@
 import '../models/v2/training_pack_template_v2.dart';
+import '../models/training_pack_model.dart';
+import '../models/game_type.dart';
 import '../core/training/library/training_pack_library_v2.dart';
 import 'training_pack_template_storage_service.dart';
 
@@ -13,6 +15,28 @@ class PackRegistryService {
   /// Registers [pack] in memory for subsequent lookups.
   void register(TrainingPackTemplateV2 pack) {
     _cache[pack.id] = pack;
+  }
+
+  /// Registers a generated pack by [id] with optional [source] and [meta].
+  ///
+  /// Used for runtime-generated packs that are not part of the static
+  /// library. Only minimal template data is stored in memory.
+  void registerGenerated(String id,
+      {String source = '', Map<String, dynamic>? meta}) {
+    final tpl = TrainingPackTemplateV2(
+      id: id,
+      name: id,
+      trainingType: TrainingType.custom,
+      spots: [],
+      spotCount: 0,
+      tags: const [],
+      gameType: GameType.cash,
+      positions: const [],
+      bb: 0,
+      meta: {'source': source, if (meta != null) ...meta},
+      isGeneratedPack: true,
+    );
+    register(tpl);
   }
 
   /// Loads a pack by [id] checking memory cache, assets and disk cache.

--- a/lib/services/remedial_generation_controller.dart
+++ b/lib/services/remedial_generation_controller.dart
@@ -1,0 +1,123 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/remedial_spec.dart';
+import '../models/stage_remedial_meta.dart';
+import 'autogen_pipeline_executor.dart';
+import 'pack_registry_service.dart';
+import 'learning_path_telemetry.dart';
+
+class RemedialGenerationController {
+  final PackRegistryService _registry;
+  final Future<double> Function(String stageId) _accuracyFetcher;
+  final Future<String> Function({
+    required String presetId,
+    Map<String, dynamic>? extras,
+    int? spotsPerPack,
+  }) _autogenRunner;
+
+  RemedialGenerationController({
+    PackRegistryService? registry,
+    Future<double> Function(String stageId)? accuracyFetcher,
+    Future<String> Function({
+      required String presetId,
+      Map<String, dynamic>? extras,
+      int? spotsPerPack,
+    })?
+        autogenRunner,
+  })  : _registry = registry ?? PackRegistryService.instance,
+        _accuracyFetcher = accuracyFetcher ?? ((_) async => 0.0),
+        _autogenRunner = autogenRunner ?? ({
+          required String presetId,
+          Map<String, dynamic>? extras,
+          int? spotsPerPack,
+        }) async {
+          final exec = AutogenPipelineExecutor();
+          final dyn = exec as dynamic;
+          return await dyn.run(
+            presetId: presetId,
+            extras: extras,
+            spotsPerPack: spotsPerPack,
+          ) as String;
+        };
+
+  Future<Uri> createRemedialPack({
+    required String pathId,
+    required String stageId,
+    RemedialSpec? specOverride,
+    int? spotsPerPack,
+  }) async {
+    final prefs = await SharedPreferences.getInstance();
+    final key = 'learning.remedial.$pathId.$stageId';
+    StageRemedialMeta? meta;
+    final raw = prefs.getString(key);
+    if (raw != null) {
+      try {
+        meta = StageRemedialMeta.fromJson(jsonDecode(raw));
+      } catch (_) {}
+    }
+    final currentAccuracy = await _accuracyFetcher(stageId);
+    if (meta != null) {
+      final age = DateTime.now().difference(meta.createdAt);
+      final improved = currentAccuracy - meta.accuracyAfter >= 0.08;
+      if (age < const Duration(days: 7) && !improved) {
+        return Uri(
+          path: '/pathPlayer',
+          queryParameters: {
+            'pathId': pathId,
+            'stageId': stageId,
+            'sideQuestId': meta.remedialPackId,
+          },
+        );
+      }
+    }
+
+    final spec = specOverride ?? const RemedialSpec();
+    final extras = <String, dynamic>{
+      'pathId': pathId,
+      'stageId': stageId,
+      if (spec.topTags.isNotEmpty) 'boostTags': spec.topTags,
+    };
+    final packId = await _autogenRunner(
+      presetId: 'remedial_v1',
+      extras: extras,
+      spotsPerPack: (spotsPerPack ?? 6).clamp(6, 12),
+    );
+
+    _registry.registerGenerated(
+      packId,
+      source: 'remedial',
+      meta: {'pathId': pathId, 'stageId': stageId},
+    );
+
+    final metaToSave = StageRemedialMeta(
+      remedialPackId: packId,
+      sourceAttempts: 0,
+      missTags: {
+        for (final t in spec.topTags) t: 1,
+      },
+      missTextures: spec.textureCounts,
+      accuracyAfter: currentAccuracy,
+    );
+    await prefs.setString(key, jsonEncode(metaToSave.toJson()));
+
+    LearningPathTelemetry.instance.log('remedial_created', {
+      'pathId': pathId,
+      'stageId': stageId,
+      'remedialPackId': packId,
+      if (spec.topTags.isNotEmpty) 'missTags': spec.topTags,
+      if (spec.textureCounts.isNotEmpty) 'missTextures': spec.textureCounts,
+    });
+
+    return Uri(
+      path: '/pathPlayer',
+      queryParameters: {
+        'pathId': pathId,
+        'stageId': stageId,
+        'sideQuestId': packId,
+      },
+    );
+  }
+}

--- a/test/remedial_generation_controller_test.dart
+++ b/test/remedial_generation_controller_test.dart
@@ -1,0 +1,82 @@
+import 'dart:convert';
+
+import 'package:test/test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:Poker_Analyzer/models/stage_remedial_meta.dart';
+import 'package:Poker_Analyzer/services/remedial_generation_controller.dart';
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('dedupe logic respects age and accuracy improvement', () async {
+    var runCalls = 0;
+    Future<String> runAutogen({
+      required String presetId,
+      Map<String, dynamic>? extras,
+      int? spotsPerPack,
+    }) async {
+      runCalls++;
+      return 'gen$runCalls';
+    }
+
+    double currentAccuracy = 0.52;
+    Future<double> fetchAcc(String _) async => currentAccuracy;
+
+    final controller = RemedialGenerationController(
+      autogenRunner: runAutogen,
+      accuracyFetcher: fetchAcc,
+    );
+
+    final prefs = await SharedPreferences.getInstance();
+    final meta = StageRemedialMeta(
+      remedialPackId: 'existing',
+      accuracyAfter: 0.5,
+    );
+    await prefs.setString(
+        'learning.remedial.p.s', jsonEncode(meta.toJson()));
+
+    final uri1 = await controller.createRemedialPack(
+        pathId: 'p', stageId: 's');
+    expect(runCalls, 0);
+    expect(uri1.queryParameters['sideQuestId'], 'existing');
+
+    currentAccuracy = 0.59; // +9pp improvement
+    final uri2 = await controller.createRemedialPack(
+        pathId: 'p', stageId: 's');
+    expect(runCalls, 1);
+    expect(uri2.queryParameters['sideQuestId'], 'gen1');
+
+    final oldMeta = StageRemedialMeta(
+      remedialPackId: 'old',
+      accuracyAfter: 0.59,
+      createdAt: DateTime.now().subtract(const Duration(days: 8)),
+    );
+    await prefs.setString(
+        'learning.remedial.p.s', jsonEncode(oldMeta.toJson()));
+
+    currentAccuracy = 0.60; // <8pp but meta old
+    final uri3 = await controller.createRemedialPack(
+        pathId: 'p', stageId: 's');
+    expect(runCalls, 2);
+    expect(uri3.queryParameters['sideQuestId'], 'gen2');
+  });
+
+  test('returned uri contains all params', () async {
+    Future<String> runAutogen({
+      required String presetId,
+      Map<String, dynamic>? extras,
+      int? spotsPerPack,
+    }) async => 'pack123';
+
+    final controller = RemedialGenerationController(autogenRunner: runAutogen);
+    final uri = await controller.createRemedialPack(
+        pathId: 'path', stageId: 'stage');
+    expect(uri.path, '/pathPlayer');
+    expect(uri.queryParameters['pathId'], 'path');
+    expect(uri.queryParameters['stageId'], 'stage');
+    expect(uri.queryParameters['sideQuestId'], 'pack123');
+  });
+}


### PR DESCRIPTION
## Summary
- add RemedialGenerationController to generate, register, and launch remedial side quests
- extend StageRemedialMeta with accuracy tracking and completion updates
- allow PackRegistryService to register runtime-generated packs
- cover remedial dedupe logic and URI formation with tests

## Testing
- `dart test test/remedial_generation_controller_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a5dde7a24832a88cdcc3b91ac7837