### PR TITLE
Surface remedial side quests in UI

### DIFF
--- a/lib/screens/training_session_summary_screen.dart
+++ b/lib/screens/training_session_summary_screen.dart
@@ -138,6 +138,7 @@ class _TrainingSessionSummaryScreenState
           MaterialPageRoute(
             builder: (_) => StageCompletedScreen(
               pathId: path.id,
+              stageId: stage.id,
               stageTitle: stage.title,
               accuracy: stats.accuracy,
               hands: stats.hands,

--- a/test/remedial_generation_controller_test.dart
+++ b/test/remedial_generation_controller_test.dart
@@ -3,8 +3,8 @@ import 'dart:convert';
 import 'package:test/test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-import 'package:Poker_Analyzer/models/stage_remedial_meta.dart';
-import 'package:Poker_Analyzer/services/remedial_generation_controller.dart';
+import 'package:poker_analyzer/models/stage_remedial_meta.dart';
+import 'package:poker_analyzer/services/remedial_generation_controller.dart';
 
 void main() {
   setUp(() {


### PR DESCRIPTION
## Summary
- Add "Fix My Mistakes" button on stage completion to generate remedial side-quests and navigate to the pack
- Show persistent side-quest chip on Learning Path screen with completion badge and launch flow
- Pass stage id to completion screen and fix package import casing in tests

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a673b2b14832aad5369fc24b2ce61