### PR TITLE
fix: resolve analyzer errors

### DIFF
--- a/lib/widgets/weekly_summary_card.dart
+++ b/lib/widgets/weekly_summary_card.dart
@@ -22,7 +22,7 @@ class WeeklySummaryCard extends StatelessWidget {
     final start = DateTime(now.year, now.month, now.day)
         .subtract(Duration(days: now.weekday - 1));
     final weekLogs = logsService.filter(
-      range: DateTimeRange(start, now),
+      range: DateTimeRange(start: start, end: now),
     );
     int hands = 0;
     int correct = 0;

--- a/lib/widgets/win_amount_widget.dart
+++ b/lib/widgets/win_amount_widget.dart
@@ -77,11 +77,11 @@ class _WinAmountWidgetState extends State<WinAmountWidget>
             fontSize: 16 * widget.scale,
             shadows: [
               Shadow(
-                color: Colors.black.withOpacity(0.6),
+                color: Colors.black.withValues(alpha: 0.6),
                 blurRadius: 4 * widget.scale,
               ),
               Shadow(
-                color: Colors.greenAccent.withOpacity(0.8),
+                color: Colors.greenAccent.withValues(alpha: 0.8),
                 blurRadius: 6 * widget.scale,
               ),
             ],

--- a/lib/widgets/win_chips_animation.dart
+++ b/lib/widgets/win_chips_animation.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import '../theme/app_colors.dart';
 import 'chip_stack_moving_widget.dart';
 
 /// Animation of chips flying from the pot to a player's stack.
@@ -29,7 +28,7 @@ class WinChipsAnimation extends StatelessWidget {
   final Color color;
 
   const WinChipsAnimation({
-    Key? key,
+    super.key,
     required this.start,
     required this.end,
     required this.amount,
@@ -37,8 +36,8 @@ class WinChipsAnimation extends StatelessWidget {
     this.control,
     this.onCompleted,
     this.fadeStart = 0.7,
-    this.color = AppColors.accent,
-  }) : super(key: key);
+    this.color = const Color(0xFFD8B243),
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widgets/win_pot_animation.dart
+++ b/lib/widgets/win_pot_animation.dart
@@ -19,13 +19,13 @@ class WinPotAnimation extends StatefulWidget {
   final VoidCallback? onCompleted;
 
   const WinPotAnimation({
-    Key? key,
+    super.key,
     required this.start,
     required this.end,
     required this.amount,
     this.scale = 1.0,
     this.onCompleted,
-  }) : super(key: key);
+  });
 
   @override
   State<WinPotAnimation> createState() => _WinPotAnimationState();

--- a/lib/widgets/win_text_widget.dart
+++ b/lib/widgets/win_text_widget.dart
@@ -79,7 +79,7 @@ class _WinTextWidgetState extends State<WinTextWidget>
               vertical: 4 * widget.scale,
             ),
           decoration: BoxDecoration(
-            color: Colors.black.withOpacity(0.8),
+            color: Colors.black.withValues(alpha: 0.8),
             borderRadius: BorderRadius.circular(8 * widget.scale),
           ),
           child: Text(

--- a/lib/widgets/winner_glow_widget.dart
+++ b/lib/widgets/winner_glow_widget.dart
@@ -80,7 +80,7 @@ class _WinnerGlowWidgetState extends State<WinnerGlowWidget>
             borderRadius: BorderRadius.circular(8 * widget.scale),
             boxShadow: [
               BoxShadow(
-                color: Colors.amberAccent.withOpacity(0.7),
+                color: Colors.amberAccent.withValues(alpha: 0.7),
                 blurRadius: 8 * widget.scale,
                 spreadRadius: 1 * widget.scale,
               ),

--- a/lib/widgets/winner_zone_highlight.dart
+++ b/lib/widgets/winner_zone_highlight.dart
@@ -90,7 +90,7 @@ class _WinnerZoneHighlightState extends State<WinnerZoneHighlight>
                 ),
                 boxShadow: [
                   BoxShadow(
-                    color: Colors.amberAccent.withOpacity(0.8),
+                    color: Colors.amberAccent.withValues(alpha: 0.8),
                     blurRadius: 20 * widget.scale,
                     spreadRadius: 4 * widget.scale,
                   ),

--- a/main.dart
+++ b/main.dart
@@ -206,13 +206,15 @@ class _PokerAnalyzerDemoAppState extends State<PokerAnalyzerDemoApp>
                             padding: const EdgeInsets.symmetric(
                                 horizontal: 8, vertical: 4),
                             decoration: BoxDecoration(
-                              color: AppColors.textPrimaryDark.withOpacity(0.2),
+                              color: AppColors.textPrimaryDark
+                                  .withValues(alpha: 0.2),
                               borderRadius: BorderRadius.circular(8),
                             ),
                             child: Text(
                               'Demo Mode Active',
                               style: TextStyle(
-                                color: AppColors.textPrimaryDark.withOpacity(0.8),
+                                color: AppColors.textPrimaryDark
+                                    .withValues(alpha: 0.8),
                                 fontSize: 12,
                               ),
                             ),

--- a/plugins/LocalEvPlugin.dart
+++ b/plugins/LocalEvPlugin.dart
@@ -4,6 +4,7 @@ import 'package:poker_analyzer/services/push_fold_ev_service.dart';
 import 'package:poker_analyzer/services/icm_push_ev_service.dart';
 import 'package:poker_analyzer/helpers/hand_utils.dart';
 import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/plugins/service_extension.dart';
 
 class LocalEvService {
   const LocalEvService();
@@ -78,6 +79,12 @@ class LocalEvPlugin implements Plugin {
   void register(ServiceRegistry registry) {
     registry.registerIfAbsent<LocalEvService>(const LocalEvService());
   }
+
+  @override
+  void unregister(ServiceRegistry registry) {}
+
+  @override
+  List<ServiceExtension<dynamic>> get extensions => const [];
 
   @override
   String get name => 'Local EV';


### PR DESCRIPTION
## Summary
- fix DateTimeRange usage in weekly summary card
- replace deprecated `withOpacity` calls and const-ify eligible constructors
- implement missing plugin hooks in `LocalEvPlugin`

## Testing
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_689a911372a0832a8a2da0f399345d7b