### PR TITLE
refactor: migrate color opacity API and restore chip theming

### DIFF
--- a/lib/main_demo.dart
+++ b/lib/main_demo.dart
@@ -200,13 +200,13 @@ class _PokerAnalyzerDemoAppState extends State<PokerAnalyzerDemoApp>
                                 vertical: 4,
                               ),
                               decoration: BoxDecoration(
-                                color: Colors.white.withOpacity(0.2),
+                                color: Colors.white.withValues(alpha: 0.2),
                                 borderRadius: BorderRadius.circular(8),
                               ),
                               child: Text(
                                 'Demo Mode Active',
                                 style: TextStyle(
-                                  color: Colors.white.withOpacity(0.8),
+                                  color: Colors.white.withValues(alpha: 0.8),
                                   fontSize: 12,
                                 ),
                               ),

--- a/lib/screens/achievements_catalog_screen.dart
+++ b/lib/screens/achievements_catalog_screen.dart
@@ -75,7 +75,7 @@ class AchievementsCatalogScreen extends StatelessWidget {
                   boxShadow: highlight
                       ? [
                           BoxShadow(
-                            color: accent.withOpacity(0.6),
+                            color: accent.withValues(alpha: 0.6),
                             blurRadius: 12,
                             spreadRadius: 1,
                           ),

--- a/lib/screens/autogen_metrics_dashboard_screen.dart
+++ b/lib/screens/autogen_metrics_dashboard_screen.dart
@@ -316,12 +316,12 @@ class _AutogenMetricsDashboardScreenState
                   HorizontalRangeAnnotation(
                     y1: 0,
                     y2: 60,
-                    color: Colors.red.withOpacity(0.2),
+                    color: Colors.red.withValues(alpha: 0.2),
                   ),
                   HorizontalRangeAnnotation(
                     y1: 60,
                     y2: 70,
-                    color: Colors.red.withOpacity(0.1),
+                    color: Colors.red.withValues(alpha: 0.1),
                   ),
                 ],
               ),

--- a/lib/screens/booster_bulk_stats_dashboard.dart
+++ b/lib/screens/booster_bulk_stats_dashboard.dart
@@ -61,7 +61,7 @@ class _BoosterBulkStatsDashboardState extends State<BoosterBulkStatsDashboard> {
             color: q.$2 == 'fail'
                 ? WidgetStateProperty.all(AppColors.errorBg)
                 : q.$2 == 'warning'
-                    ? WidgetStateProperty.all(Colors.orange.withOpacity(.2))
+                    ? WidgetStateProperty.all(Colors.orange.withValues(alpha: .2))
                     : null,
             cells: [DataCell(Text(q.$1)), DataCell(Text(q.$2))],
           ),

--- a/lib/screens/decay_adaptation_insight_screen.dart
+++ b/lib/screens/decay_adaptation_insight_screen.dart
@@ -141,9 +141,9 @@ class _DecayAdaptationInsightScreenState extends State<DecayAdaptationInsightScr
   Color? _colorFor(BoosterAdaptation a) {
     switch (a) {
       case BoosterAdaptation.increase:
-        return Colors.red.withOpacity(.2);
+        return Colors.red.withValues(alpha: .2);
       case BoosterAdaptation.reduce:
-        return Colors.green.withOpacity(.2);
+        return Colors.green.withValues(alpha: .2);
       default:
         return null;
     }

--- a/lib/screens/drill_history_screen.dart
+++ b/lib/screens/drill_history_screen.dart
@@ -243,7 +243,7 @@ class _DrillHistoryScreenState extends State<DrillHistoryScreen> {
               borderRadius: BorderRadius.circular(8),
               boxShadow: [
                 BoxShadow(
-                  color: Colors.black.withOpacity(0.3),
+                  color: Colors.black.withValues(alpha: 0.3),
                   blurRadius: 4,
                   offset: const Offset(0, 2),
                 ),

--- a/lib/screens/goals_screen.dart
+++ b/lib/screens/goals_screen.dart
@@ -63,7 +63,7 @@ class _GoalCardState extends State<GoalCard>
             boxShadow: widget.goal.completed
                 ? [
                     BoxShadow(
-                      color: Colors.green.withOpacity(glow),
+                      color: Colors.green.withValues(alpha: glow),
                       blurRadius: 20 * glow,
                       spreadRadius: 2 * glow,
                     )

--- a/lib/screens/hand_analysis_history_screen.dart
+++ b/lib/screens/hand_analysis_history_screen.dart
@@ -112,7 +112,7 @@ class _HandAnalysisHistoryScreenState extends State<HandAnalysisHistoryScreen> {
               borderRadius: BorderRadius.circular(8),
               boxShadow: [
                 BoxShadow(
-                  color: Colors.black.withOpacity(0.3),
+                  color: Colors.black.withValues(alpha: 0.3),
                   blurRadius: 4,
                   offset: const Offset(0, 2),
                 ),

--- a/lib/screens/hand_editor_screen.dart
+++ b/lib/screens/hand_editor_screen.dart
@@ -490,7 +490,7 @@ class _HandEditorScreenState extends State<HandEditorScreen>
       context: context,
       builder: (context) => StatefulBuilder(
         builder: (context, setState) => AlertDialog(
-          backgroundColor: Colors.black.withOpacity(0.3),
+          backgroundColor: Colors.black.withValues(alpha: 0.3),
           title: const Text('Reveal', style: TextStyle(color: Colors.white)),
           content: Column(
             mainAxisSize: MainAxisSize.min,
@@ -552,7 +552,7 @@ class _HandEditorScreenState extends State<HandEditorScreen>
     final result = await showDialog<List<double>>(
       context: context,
       builder: (context) => AlertDialog(
-        backgroundColor: Colors.black.withOpacity(0.3),
+        backgroundColor: Colors.black.withValues(alpha: 0.3),
         title: const Text('Distribute', style: TextStyle(color: Colors.white)),
         content: Column(
           mainAxisSize: MainAxisSize.min,
@@ -678,11 +678,11 @@ class _HandEditorScreenState extends State<HandEditorScreen>
             width: 36,
             height: 52,
             decoration: BoxDecoration(
-              color: Colors.white.withOpacity(c == null ? 0.3 : 1),
+              color: Colors.white.withValues(alpha: c == null ? 0.3 : 1),
               borderRadius: BorderRadius.circular(6),
               boxShadow: [
                 BoxShadow(
-                  color: Colors.black.withOpacity(0.25),
+                  color: Colors.black.withValues(alpha: 0.25),
                   blurRadius: 3,
                   offset: const Offset(1, 2),
                 )

--- a/lib/screens/hand_history_review_screen.dart
+++ b/lib/screens/hand_history_review_screen.dart
@@ -223,7 +223,7 @@ class _HandHistoryReviewScreenState extends State<HandHistoryReviewScreen> {
     return Container(
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
-        color: Colors.redAccent.withOpacity(0.2),
+        color: Colors.redAccent.withValues(alpha: 0.2),
         borderRadius: BorderRadius.circular(8),
       ),
       child: Row(

--- a/lib/screens/learning_path_screen_v2.dart
+++ b/lib/screens/learning_path_screen_v2.dart
@@ -615,7 +615,7 @@ class _LearningPathScreenState extends State<LearningPathScreen> {
           vertical: AppConstants.defaultPadding / 2 - 2),
       shape: border,
       color: highlight
-          ? Colors.amber.withOpacity(0.2)
+          ? Colors.amber.withValues(alpha: 0.2)
           : state == LearningStageUIState.locked
           ? Colors.grey.shade800
           : null,

--- a/lib/screens/mistake_insight_screen.dart
+++ b/lib/screens/mistake_insight_screen.dart
@@ -99,7 +99,7 @@ class _MistakeInsightScreenState extends State<MistakeInsightScreen> {
               width: 14,
               borderRadius: BorderRadius.circular(4),
               gradient: LinearGradient(
-                colors: [color.withOpacity(0.7), color],
+                colors: [color.withValues(alpha: 0.7), color],
                 begin: Alignment.bottomCenter,
                 end: Alignment.topCenter,
               ),

--- a/lib/screens/pack_library_diff_screen.dart
+++ b/lib/screens/pack_library_diff_screen.dart
@@ -196,11 +196,11 @@ class _PackLibraryDiffScreenState extends State<PackLibraryDiffScreen> {
   Color _color(_DiffType type) {
     switch (type) {
       case _DiffType.added:
-        return Colors.green.withOpacity(.2);
+        return Colors.green.withValues(alpha: .2);
       case _DiffType.removed:
-        return Colors.red.withOpacity(.2);
+        return Colors.red.withValues(alpha: .2);
       case _DiffType.changed:
-        return Colors.amber.withOpacity(.2);
+        return Colors.amber.withValues(alpha: .2);
     }
   }
 }

--- a/lib/screens/pack_merge_explorer_screen.dart
+++ b/lib/screens/pack_merge_explorer_screen.dart
@@ -64,7 +64,7 @@ class _PackMergeExplorerScreenState extends State<PackMergeExplorerScreen> {
                       for (final c in g.pairs)
                         ListTile(
                           tileColor: c.overlap > 0.5
-                              ? Colors.green.withOpacity(.2)
+                              ? Colors.green.withValues(alpha: .2)
                               : null,
                           title: Text('${c.a.name} ↔ ${c.b.name}'),
                           subtitle: Text(

--- a/lib/screens/poker_analyzer_overlay.dart
+++ b/lib/screens/poker_analyzer_overlay.dart
@@ -60,7 +60,7 @@ class _HudHeader extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       padding: const EdgeInsets.all(16),
-      color: Colors.black.withOpacity(0.5),
+      color: Colors.black.withValues(alpha: 0.5),
       child: Row(
         children: [
           Text(

--- a/lib/screens/progress_screen.dart
+++ b/lib/screens/progress_screen.dart
@@ -598,7 +598,7 @@ class _ProgressScreenState extends State<ProgressScreen>
               width: 14,
               borderRadius: BorderRadius.circular(4),
               gradient: LinearGradient(
-                colors: [color.withOpacity(0.7), color],
+                colors: [color.withValues(alpha: 0.7), color],
                 begin: Alignment.bottomCenter,
                 end: Alignment.topCenter,
               ),

--- a/lib/screens/room_hand_history_import_screen.dart
+++ b/lib/screens/room_hand_history_import_screen.dart
@@ -470,7 +470,7 @@ class _RoomHandHistoryImportScreenState
                         selected: _tagFilter == tag,
                         backgroundColor: Colors
                             .primaries[tag.hashCode % Colors.primaries.length]
-                            .withOpacity(0.3),
+                            .withValues(alpha: 0.3),
                         selectedColor:
                             Colors.primaries[tag.hashCode % Colors.primaries.length],
                         onSelected: (_) => setState(() => _tagFilter = tag),
@@ -613,7 +613,7 @@ class _RoomHandHistoryImportScreenState
                           if (_undoActive)
                             Positioned.fill(
                               child: Container(
-                                  color: Colors.black.withOpacity(0.05)),
+                                  color: Colors.black.withValues(alpha: 0.05)),
                             ),
                         ],
                       );

--- a/lib/screens/session_result_screen.dart
+++ b/lib/screens/session_result_screen.dart
@@ -109,7 +109,7 @@ class _SessionResultScreenState extends State<SessionResultScreen> {
     final res = await showDialog<String>(
       context: context,
       builder: (ctx) => AlertDialog(
-        backgroundColor: Colors.black.withOpacity(0.8),
+        backgroundColor: Colors.black.withValues(alpha: 0.8),
         title: const Text('Note', style: TextStyle(color: Colors.white)),
         content: TextField(
           controller: c,

--- a/lib/screens/session_stats_screen.dart
+++ b/lib/screens/session_stats_screen.dart
@@ -774,7 +774,7 @@ class _SessionStatsScreenState extends State<SessionStatsScreen> {
             Container(
               padding: EdgeInsets.all(12 * scale),
               decoration: BoxDecoration(
-                color: Colors.redAccent.withOpacity(0.2),
+                color: Colors.redAccent.withValues(alpha: 0.2),
                 borderRadius: BorderRadius.circular(8),
               ),
               child: Row(

--- a/lib/screens/smart_path_preview_screen.dart
+++ b/lib/screens/smart_path_preview_screen.dart
@@ -74,7 +74,7 @@ class SmartPathPreviewScreen extends StatelessWidget {
             subtitle: Text(stage.packId),
             trailing: _buildPreviewButton(context, stage),
             tileColor:
-                stage.type == StageType.theory ? color.withOpacity(0.1) : null,
+                stage.type == StageType.theory ? color.withValues(alpha: 0.1) : null,
           ),
         const SizedBox(height: 12),
       ],

--- a/lib/screens/streak_history_screen.dart
+++ b/lib/screens/streak_history_screen.dart
@@ -40,7 +40,7 @@ class StreakHistoryScreen extends StatelessWidget {
               width: 14,
               borderRadius: BorderRadius.circular(4),
               gradient: LinearGradient(
-                colors: [color.withOpacity(0.7), color],
+                colors: [color.withValues(alpha: 0.7), color],
                 begin: Alignment.bottomCenter,
                 end: Alignment.topCenter,
               ),

--- a/lib/screens/tag_mistake_overview_screen.dart
+++ b/lib/screens/tag_mistake_overview_screen.dart
@@ -626,7 +626,7 @@ class _TagMistakeOverviewScreenState extends State<TagMistakeOverviewScreen> {
           ? {
               for (final t in _activeTags)
                 t: colorFromHex(context.read<TagService>().colorOf(t))
-                    .withOpacity(0.5)
+                    .withValues(alpha: 0.5)
             }
           : {'Предыдущий': Colors.blueAccent};
     }

--- a/lib/screens/template_hands_editor_screen.dart
+++ b/lib/screens/template_hands_editor_screen.dart
@@ -253,7 +253,7 @@ class _TemplateHandsEditorScreenState extends State<TemplateHandsEditorScreen> {
                 final title = hand.name.isEmpty ? 'Без названия' : hand.name;
                 return ListTile(
                   key: ValueKey(id),
-                  tileColor: selected ? Colors.blue.withOpacity(0.3) : null,
+                  tileColor: selected ? Colors.blue.withValues(alpha: 0.3) : null,
                   onLongPress: () => setState(() => _selectedIds.add(id)),
                   onTap: _isSelecting
                       ? () {

--- a/lib/screens/theory_lesson_viewer_screen.dart
+++ b/lib/screens/theory_lesson_viewer_screen.dart
@@ -29,7 +29,7 @@ class _HighlightBuilder extends MarkdownElementBuilder {
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 2, vertical: 1),
       decoration: BoxDecoration(
-        color: Colors.yellow.withOpacity(0.3),
+        color: Colors.yellow.withValues(alpha: 0.3),
         borderRadius: BorderRadius.circular(4),
       ),
       child: Text(

--- a/lib/screens/top_mistakes_overview_screen.dart
+++ b/lib/screens/top_mistakes_overview_screen.dart
@@ -45,7 +45,7 @@ class TopMistakesOverviewScreen extends StatelessWidget {
             width: 14,
             borderRadius: BorderRadius.circular(4),
             gradient: LinearGradient(
-              colors: [color.withOpacity(0.7), color],
+              colors: [color.withValues(alpha: 0.7), color],
               begin: Alignment.bottomCenter,
               end: Alignment.topCenter,
             ),

--- a/lib/screens/track_recap_screen.dart
+++ b/lib/screens/track_recap_screen.dart
@@ -81,7 +81,7 @@ class _TrackRecapScreenState extends State<TrackRecapScreen> {
             width: 14,
             borderRadius: BorderRadius.circular(4),
             gradient: LinearGradient(
-              colors: [accent.withOpacity(0.7), accent],
+              colors: [accent.withValues(alpha: 0.7), accent],
               begin: Alignment.bottomCenter,
               end: Alignment.topCenter,
             ),

--- a/lib/screens/training_activity_by_weekday_screen.dart
+++ b/lib/screens/training_activity_by_weekday_screen.dart
@@ -57,7 +57,7 @@ class TrainingActivityByWeekdayScreen extends StatelessWidget {
               width: 14,
               borderRadius: BorderRadius.circular(4),
               gradient: LinearGradient(
-                colors: [color.withOpacity(0.7), color],
+                colors: [color.withValues(alpha: 0.7), color],
                 begin: Alignment.bottomCenter,
                 end: Alignment.topCenter,
               ),

--- a/lib/screens/training_session_screen.dart
+++ b/lib/screens/training_session_screen.dart
@@ -707,7 +707,7 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
                               horizontal: 8,
                             ),
                             decoration: BoxDecoration(
-                              color: Colors.orange.withOpacity(0.2),
+                              color: Colors.orange.withValues(alpha: 0.2),
                               borderRadius: BorderRadius.circular(4),
                             ),
                             child: const Text(
@@ -797,7 +797,7 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
                                               : 0,
                                           color: Colors.purpleAccent,
                                           backgroundColor: Colors.purpleAccent
-                                              .withOpacity(0.3),
+                                              .withValues(alpha: 0.3),
                                         ),
                                       ),
                                       const SizedBox(width: 8),

--- a/lib/screens/v2/training_pack_play_screen.dart
+++ b/lib/screens/v2/training_pack_play_screen.dart
@@ -871,7 +871,7 @@ class _TrainingPackPlayScreenState
                                           _handTotals[g.label]!
                                       : 0,
                                   color: Colors.purpleAccent,
-                                  backgroundColor: Colors.purpleAccent.withOpacity(0.3),
+                                  backgroundColor: Colors.purpleAccent.withValues(alpha: 0.3),
                                   minHeight: 6 * scale,
                                 ),
                                 SizedBox(height: 4 * scale),
@@ -891,7 +891,7 @@ class _TrainingPackPlayScreenState
                                           _handTotals[g.label]!
                                       : 0,
                                   color: Colors.purpleAccent,
-                                  backgroundColor: Colors.purpleAccent.withOpacity(0.3),
+                                  backgroundColor: Colors.purpleAccent.withValues(alpha: 0.3),
                                   minHeight: 6 * scale,
                                 ),
                               ),

--- a/lib/screens/v2/training_pack_result_screen.dart
+++ b/lib/screens/v2/training_pack_result_screen.dart
@@ -348,9 +348,9 @@ class _TrainingPackResultScreenState extends State<TrainingPackResultScreen> {
                 spacing: 8,
                 children: [
                   Text(l.spotsLabel('$_total'), style: const TextStyle(color: Colors.white)),
-                  Text('•', style: TextStyle(color: Colors.white.withOpacity(0.5))),
+                  Text('•', style: TextStyle(color: Colors.white.withValues(alpha: 0.5))),
                   Text(l.accuracyLabel(_rate.toStringAsFixed(0)), style: const TextStyle(color: Colors.white)),
-                  Text('•', style: TextStyle(color: Colors.white.withOpacity(0.5))),
+                  Text('•', style: TextStyle(color: Colors.white.withValues(alpha: 0.5))),
                   Text(
                     l.evBb("${_evSum >= 0 ? '+' : ''}${_evSum.toStringAsFixed(1)}"),
                     style: TextStyle(
@@ -360,7 +360,7 @@ class _TrainingPackResultScreenState extends State<TrainingPackResultScreen> {
                     ),
                   ),
                   if (_icmEvs.isNotEmpty) ...[
-                    Text('•', style: TextStyle(color: Colors.white.withOpacity(0.5))),
+                    Text('•', style: TextStyle(color: Colors.white.withValues(alpha: 0.5))),
                     Text(
                       l.icmLabel("${_icmSum >= 0 ? '+' : ''}${_icmSum.toStringAsFixed(1)}"),
                       style: TextStyle(

--- a/lib/screens/v2/training_pack_result_screen_v2.dart
+++ b/lib/screens/v2/training_pack_result_screen_v2.dart
@@ -436,7 +436,7 @@ class _EvDiffChart extends StatelessWidget {
             width: 14,
             borderRadius: BorderRadius.circular(4),
             gradient: LinearGradient(
-              colors: [color.withOpacity(0.7), color],
+              colors: [color.withValues(alpha: 0.7), color],
               begin: Alignment.bottomCenter,
               end: Alignment.topCenter,
             ),
@@ -531,7 +531,7 @@ class _IcmDiffChart extends StatelessWidget {
             width: 14,
             borderRadius: BorderRadius.circular(4),
             gradient: LinearGradient(
-              colors: [color.withOpacity(0.7), color],
+              colors: [color.withValues(alpha: 0.7), color],
               begin: Alignment.bottomCenter,
               end: Alignment.topCenter,
             ),

--- a/lib/screens/v2/training_pack_template_filter_panel.dart
+++ b/lib/screens/v2/training_pack_template_filter_panel.dart
@@ -120,7 +120,7 @@ mixin TrainingPackTemplateFilterPanel on State<TrainingPackTemplateListScreen> {
     items.add(LinearProgressIndicator(
       value: progVal,
       color: progColor,
-      backgroundColor: progColor.withOpacity(0.3),
+      backgroundColor: progColor.withValues(alpha: 0.3),
     ));
     items.add(const SizedBox(height: 4));
     if (t.targetStreet != null && t.streetGoal > 0) {
@@ -149,7 +149,7 @@ mixin TrainingPackTemplateFilterPanel on State<TrainingPackTemplateListScreen> {
                 child: LinearProgressIndicator(
                   value: val,
                   color: Colors.purpleAccent,
-                  backgroundColor: Colors.purpleAccent.withOpacity(0.3),
+                  backgroundColor: Colors.purpleAccent.withValues(alpha: 0.3),
                 ),
               ),
               const SizedBox(width: 8),

--- a/lib/screens/yaml_pack_diff_screen.dart
+++ b/lib/screens/yaml_pack_diff_screen.dart
@@ -22,7 +22,7 @@ class YamlPackDiffScreen extends StatelessWidget {
     final tagsB = {...packB.tags};
     final tagsDiff = tagsA.difference(tagsB).length + tagsB.difference(tagsA).length;
     final spotCountDiff = (packA.spotCount - packB.spotCount).abs();
-    final diffColor = Colors.amber.withOpacity(.2);
+    final diffColor = Colors.amber.withValues(alpha: .2);
     return Scaffold(
       appBar: AppBar(
         title: const Text('Yaml Diff'),

--- a/lib/services/png_exporter.dart
+++ b/lib/services/png_exporter.dart
@@ -52,7 +52,7 @@ class PngExporter {
             right: 0,
             bottom: 0,
             child: Container(
-              color: Colors.black.withOpacity(0.5),
+              color: Colors.black.withValues(alpha: 0.5),
               padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 8),
               alignment: Alignment.center,
               child: Text(

--- a/lib/services/stage_auto_highlight_service.dart
+++ b/lib/services/stage_auto_highlight_service.dart
@@ -80,7 +80,7 @@ class _StageHighlightState extends State<_StageHighlight>
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(8),
           border: Border.all(color: Colors.orangeAccent, width: 4),
-          color: Colors.orangeAccent.withOpacity(0.3),
+          color: Colors.orangeAccent.withValues(alpha: 0.3),
         ),
       ),
     );

--- a/lib/theme/app_colors.dart
+++ b/lib/theme/app_colors.dart
@@ -9,7 +9,7 @@ class AppColors {
   static const cardBackground = darkCard;
   static const button = Color(0xFFB73239);
   static Color accent = const Color(0xFFD8B243);
-  static final errorBg = Colors.red.withOpacity(.2);
+  static final errorBg = Colors.red.withValues(alpha: .2);
   static const evPre = Color(0xFF009733);
   static const evPost = Color(0xFFC9A559);
   static const icmPre = Color(0xFF404B1E);

--- a/lib/ui/tools/path_map_visualizer.dart
+++ b/lib/ui/tools/path_map_visualizer.dart
@@ -92,7 +92,7 @@ class PathMapVisualizer extends StatelessWidget {
       child: Container(
         padding: const EdgeInsets.all(8),
         decoration: BoxDecoration(
-          color: color.withOpacity(0.2),
+          color: color.withValues(alpha: 0.2),
           borderRadius: BorderRadius.circular(4),
           border: border,
         ),

--- a/lib/widgets/action_history_overlay.dart
+++ b/lib/widgets/action_history_overlay.dart
@@ -47,7 +47,7 @@ class ActionHistoryOverlay extends StatelessWidget {
         padding: EdgeInsets.symmetric(horizontal: 6 * scale, vertical: 3 * scale),
         margin: const EdgeInsets.only(right: 4, bottom: 4),
         decoration: BoxDecoration(
-          color: ActionFormattingHelper.actionColor(a.action).withOpacity(0.8),
+          color: ActionFormattingHelper.actionColor(a.action).withValues(alpha: 0.8),
           borderRadius: BorderRadius.circular(12),
         ),
         child: Row(

--- a/lib/widgets/action_list_widget.dart
+++ b/lib/widgets/action_list_widget.dart
@@ -412,14 +412,14 @@ class _ActionListWidgetState extends State<ActionListWidget> {
             final isBlind = index < 2 && a.action == 'post';
             final heroBg = (a.playerIndex == widget.heroIndex && a.ev != null)
                 ? (a.ev! >= 0
-                      ? Colors.green.withOpacity(0.1)
-                      : Colors.red.withOpacity(0.1))
+                      ? Colors.green.withValues(alpha: 0.1)
+                      : Colors.red.withValues(alpha: 0.1))
                 : null;
             final bg =
                 heroBg ??
                 (_errors[index] == null
                     ? Colors.transparent
-                    : Colors.red.withOpacity(0.15));
+                    : Colors.red.withValues(alpha: 0.15));
             return Container(
               key: ValueKey(a),
               color: bg,

--- a/lib/widgets/active_tag_goal_banner.dart
+++ b/lib/widgets/active_tag_goal_banner.dart
@@ -48,7 +48,7 @@ class _ActiveTagGoalBannerState extends State<ActiveTagGoalBanner> {
           margin: const EdgeInsets.fromLTRB(16, 8, 16, 8),
           padding: const EdgeInsets.all(12),
           decoration: BoxDecoration(
-            color: color.withOpacity(0.2),
+            color: color.withValues(alpha: 0.2),
             borderRadius: BorderRadius.circular(8),
           ),
           child: Column(

--- a/lib/widgets/badge_icon.dart
+++ b/lib/widgets/badge_icon.dart
@@ -11,7 +11,7 @@ class BadgeIcon extends StatelessWidget {
     return Container(
       decoration: BoxDecoration(boxShadow: [
         BoxShadow(
-          color: AppColors.accent.withOpacity(0.6),
+          color: AppColors.accent.withValues(alpha: 0.6),
           blurRadius: 12,
           spreadRadius: 2,
         )

--- a/lib/widgets/bet_stack_chips.dart
+++ b/lib/widgets/bet_stack_chips.dart
@@ -49,7 +49,7 @@ class BetStackChips extends StatelessWidget {
                     ),
                     boxShadow: [
                       BoxShadow(
-                        color: Colors.black.withOpacity(0.6),
+                        color: Colors.black.withValues(alpha: 0.6),
                         blurRadius: 3,
                         offset: const Offset(1, 2),
                       )

--- a/lib/widgets/board_cards_widget.dart
+++ b/lib/widgets/board_cards_widget.dart
@@ -89,11 +89,11 @@ class BoardCardsWidget extends StatelessWidget {
                     width: 36 * scale,
                     height: 52 * scale,
                     decoration: BoxDecoration(
-                      color: Colors.white.withOpacity(card == null ? 0.3 : 1),
+                      color: Colors.white.withValues(alpha: card == null ? 0.3 : 1),
                       borderRadius: BorderRadius.circular(6),
                       boxShadow: [
                         BoxShadow(
-                          color: Colors.black.withOpacity(0.25),
+                          color: Colors.black.withValues(alpha: 0.25),
                           blurRadius: 3,
                           offset: const Offset(1, 2),
                         )

--- a/lib/widgets/booster_theory_widget.dart
+++ b/lib/widgets/booster_theory_widget.dart
@@ -82,7 +82,7 @@ class BoosterTheoryWidget extends StatelessWidget {
         : AppColors.lightCard;
     switch (slot) {
       case BoosterSlot.recap:
-        return Colors.amber.withOpacity(0.15);
+        return Colors.amber.withValues(alpha: 0.15);
       default:
         return base;
     }

--- a/lib/widgets/card_picker_widget.dart
+++ b/lib/widgets/card_picker_widget.dart
@@ -39,11 +39,11 @@ class CardPickerWidget extends StatelessWidget {
             width: 36 * scale,
             height: 52 * scale,
             decoration: BoxDecoration(
-              color: Colors.white.withOpacity(card == null ? 0.3 : 1),
+              color: Colors.white.withValues(alpha: card == null ? 0.3 : 1),
               borderRadius: BorderRadius.circular(6),
               boxShadow: [
                 BoxShadow(
-                  color: Colors.black.withOpacity(0.25),
+                  color: Colors.black.withValues(alpha: 0.25),
                   blurRadius: 3,
                   offset: const Offset(1, 2),
                 )

--- a/lib/widgets/card_selector.dart
+++ b/lib/widgets/card_selector.dart
@@ -40,7 +40,7 @@ Future<CardModel?> showCardSelector(BuildContext context,
                         borderRadius: BorderRadius.circular(6),
                         boxShadow: [
                           BoxShadow(
-                            color: Colors.black.withOpacity(0.25),
+                            color: Colors.black.withValues(alpha: 0.25),
                             blurRadius: 3,
                             offset: const Offset(1, 2),
                           )

--- a/lib/widgets/chip_amount_widget.dart
+++ b/lib/widgets/chip_amount_widget.dart
@@ -38,7 +38,7 @@ class ChipAmountWidget extends StatelessWidget {
         key: ValueKey(text),
         padding: EdgeInsets.symmetric(horizontal: 8 * scale, vertical: 4 * scale),
         decoration: BoxDecoration(
-          color: color.withOpacity(0.9),
+          color: color.withValues(alpha: 0.9),
           borderRadius: BorderRadius.circular(12 * scale),
         ),
         child: Text(

--- a/lib/widgets/chip_stack_moving_widget.dart
+++ b/lib/widgets/chip_stack_moving_widget.dart
@@ -176,7 +176,7 @@ class _ChipStackMovingWidgetState extends State<ChipStackMovingWidget>
         decoration: BoxDecoration(
           boxShadow: [
             BoxShadow(
-              color: widget.glowColor!.withOpacity(0.8),
+              color: widget.glowColor!.withValues(alpha: 0.8),
               blurRadius: 12 * widget.scale,
               spreadRadius: 2 * widget.scale,
             ),

--- a/lib/widgets/chip_trail.dart
+++ b/lib/widgets/chip_trail.dart
@@ -19,7 +19,7 @@ class MiniChip extends StatelessWidget {
         ),
         boxShadow: [
           BoxShadow(
-            color: Colors.black.withOpacity(0.6),
+            color: Colors.black.withValues(alpha: 0.6),
             blurRadius: 4,
           ),
         ],

--- a/lib/widgets/chip_widget.dart
+++ b/lib/widgets/chip_widget.dart
@@ -55,7 +55,7 @@ class ChipWidget extends StatelessWidget {
                     ),
                     boxShadow: [
                       BoxShadow(
-                        color: Colors.black.withOpacity(0.6),
+                        color: Colors.black.withValues(alpha: 0.6),
                         blurRadius: 3 * scale,
                         offset: const Offset(1, 2),
                       )

--- a/lib/widgets/collapsible_street_section.dart
+++ b/lib/widgets/collapsible_street_section.dart
@@ -83,7 +83,7 @@ class _CollapsibleStreetSectionState extends State<CollapsibleStreetSection> {
     return Container(
       margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
       decoration: BoxDecoration(
-        color: _open ? Colors.black54 : Colors.black.withOpacity(0.4),
+        color: _open ? Colors.black54 : Colors.black.withValues(alpha: 0.4),
         borderRadius: BorderRadius.circular(12),
       ),
       child: Column(

--- a/lib/widgets/collapsible_street_summary.dart
+++ b/lib/widgets/collapsible_street_summary.dart
@@ -88,7 +88,7 @@ class _CollapsibleStreetSummaryState extends State<CollapsibleStreetSummary> {
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
           child: Container(
             decoration: BoxDecoration(
-              color: Colors.black.withOpacity(0.4),
+              color: Colors.black.withValues(alpha: 0.4),
               borderRadius: BorderRadius.circular(12),
             ),
             child: Column(

--- a/lib/widgets/combined_progress_bar.dart
+++ b/lib/widgets/combined_progress_bar.dart
@@ -36,7 +36,7 @@ class _CombinedProgressBarState extends State<CombinedProgressBar> {
           child: AnimatedContainer(
             duration: const Duration(milliseconds: 300),
             height: 6,
-            color: _highlight ? Colors.green.withOpacity(0.3) : Colors.white24,
+            color: _highlight ? Colors.green.withValues(alpha: 0.3) : Colors.white24,
             child: Stack(
               children: [
                 AnimatedContainer(
@@ -47,7 +47,7 @@ class _CombinedProgressBarState extends State<CombinedProgressBar> {
                 AnimatedContainer(
                   duration: const Duration(milliseconds: 300),
                   width: icmWidth,
-                  color: Colors.blue.withOpacity(.5),
+                  color: Colors.blue.withValues(alpha: .5),
                 ),
               ],
             ),

--- a/lib/widgets/common/ev_distribution_chart.dart
+++ b/lib/widgets/common/ev_distribution_chart.dart
@@ -63,7 +63,7 @@ class EvDistributionChart extends StatelessWidget {
               width: 14,
               borderRadius: BorderRadius.circular(4),
               gradient: LinearGradient(
-                colors: [color.withOpacity(0.7), color],
+                colors: [color.withValues(alpha: 0.7), color],
                 begin: Alignment.bottomCenter,
                 end: Alignment.topCenter,
               ),

--- a/lib/widgets/common/mistake_by_street_chart.dart
+++ b/lib/widgets/common/mistake_by_street_chart.dart
@@ -33,7 +33,7 @@ class MistakeByStreetChart extends StatelessWidget {
               width: 14,
               borderRadius: BorderRadius.circular(4),
               gradient: LinearGradient(
-                colors: [color.withOpacity(0.7), color],
+                colors: [color.withValues(alpha: 0.7), color],
                 begin: Alignment.bottomCenter,
                 end: Alignment.topCenter,
               ),

--- a/lib/widgets/common/session_accuracy_distribution_chart.dart
+++ b/lib/widgets/common/session_accuracy_distribution_chart.dart
@@ -46,7 +46,7 @@ class SessionAccuracyDistributionChart extends StatelessWidget {
               width: 14,
               borderRadius: BorderRadius.circular(4),
               gradient: LinearGradient(
-                colors: [color.withOpacity(0.7), color],
+                colors: [color.withValues(alpha: 0.7), color],
                 begin: Alignment.bottomCenter,
                 end: Alignment.topCenter,
               ),

--- a/lib/widgets/daily_challenge_streak_banner_widget.dart
+++ b/lib/widgets/daily_challenge_streak_banner_widget.dart
@@ -52,7 +52,7 @@ class _DailyChallengeStreakBannerWidgetState extends State<DailyChallengeStreakB
         margin: const EdgeInsets.only(bottom: 16),
         padding: const EdgeInsets.all(12),
         decoration: BoxDecoration(
-          color: Colors.deepOrangeAccent.withOpacity(0.2),
+          color: Colors.deepOrangeAccent.withValues(alpha: 0.2),
           borderRadius: BorderRadius.circular(8),
         ),
         child: Text(

--- a/lib/widgets/daily_spotlight_card.dart
+++ b/lib/widgets/daily_spotlight_card.dart
@@ -39,7 +39,7 @@ class _DailySpotlightCardState extends State<DailySpotlightCard> {
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
         gradient: LinearGradient(
-          colors: [accent.withOpacity(0.4), accent],
+          colors: [accent.withValues(alpha: 0.4), accent],
           begin: Alignment.topLeft,
           end: Alignment.bottomRight,
         ),

--- a/lib/widgets/deal_card_animation.dart
+++ b/lib/widgets/deal_card_animation.dart
@@ -103,7 +103,7 @@ class _DealCardAnimationState extends State<DealCardAnimation>
           borderRadius: BorderRadius.circular(4),
           boxShadow: [
             BoxShadow(
-              color: Colors.black.withOpacity(0.25),
+              color: Colors.black.withValues(alpha: 0.25),
               blurRadius: 3,
               offset: const Offset(1, 2),
             )

--- a/lib/widgets/decay_recall_insight_panel.dart
+++ b/lib/widgets/decay_recall_insight_panel.dart
@@ -91,7 +91,7 @@ class _DecayRecallInsightPanelState extends State<DecayRecallInsightPanel> {
                   width: 3,
                   borderRadius: BorderRadius.circular(2),
                   gradient: LinearGradient(
-                    colors: [accent.withOpacity(0.7), accent],
+                    colors: [accent.withValues(alpha: 0.7), accent],
                     begin: Alignment.bottomCenter,
                     end: Alignment.topCenter,
                   ),

--- a/lib/widgets/ev_loss_bar.dart
+++ b/lib/widgets/ev_loss_bar.dart
@@ -77,7 +77,7 @@ class EvLossBar extends StatelessWidget {
                         'Street: ${streetName(acts[i].street)} • EV loss: ${deltas[i].toStringAsFixed(1)} bb',
                     child: Container(
                       color: (deltas[i] > 0 ? Colors.red : Colors.green)
-                          .withOpacity(i < playbackIndex ? 1 : 0.3),
+                          .withValues(alpha: i < playbackIndex ? 1 : 0.3),
                     ),
                   ),
                 ),

--- a/lib/widgets/folded_stage_widget.dart
+++ b/lib/widgets/folded_stage_widget.dart
@@ -20,7 +20,7 @@ class FoldedStageWidget extends StatelessWidget {
       child: Container(
         padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 16),
         decoration: BoxDecoration(
-          color: Colors.green.withOpacity(0.1),
+          color: Colors.green.withValues(alpha: 0.1),
           borderRadius: BorderRadius.circular(8),
         ),
         child: Row(

--- a/lib/widgets/gain_amount_widget.dart
+++ b/lib/widgets/gain_amount_widget.dart
@@ -75,7 +75,7 @@ class _GainAmountWidgetState extends State<GainAmountWidget>
             fontSize: 16 * widget.scale,
             shadows: [
               Shadow(
-                color: Colors.black.withOpacity(0.6),
+                color: Colors.black.withValues(alpha: 0.6),
                 blurRadius: 4 * widget.scale,
               ),
             ],

--- a/lib/widgets/hero_range_grid_widget.dart
+++ b/lib/widgets/hero_range_grid_widget.dart
@@ -39,7 +39,7 @@ class HeroRangeGridWidget extends StatelessWidget {
     if (clamped >= 0.2) {
       return Colors.red.shade900;
     }
-    return Colors.grey.withOpacity(0.3);
+    return Colors.grey.withValues(alpha: 0.3);
   }
 
   @override

--- a/lib/widgets/history/accuracy_distribution_chart.dart
+++ b/lib/widgets/history/accuracy_distribution_chart.dart
@@ -46,7 +46,7 @@ class AccuracyDistributionChart extends StatelessWidget {
               width: 14,
               borderRadius: BorderRadius.circular(4),
               gradient: LinearGradient(
-                colors: [color.withOpacity(0.7), color],
+                colors: [color.withValues(alpha: 0.7), color],
                 begin: Alignment.bottomCenter,
                 end: Alignment.topCenter,
               ),

--- a/lib/widgets/history/session_accuracy_bar_chart.dart
+++ b/lib/widgets/history/session_accuracy_bar_chart.dart
@@ -34,7 +34,7 @@ class SessionAccuracyBarChart extends StatelessWidget {
             BarChartRodData(
               toY: r.accuracy,
               gradient: LinearGradient(
-                colors: [color.withOpacity(0.7), color],
+                colors: [color.withValues(alpha: 0.7), color],
                 begin: Alignment.bottomCenter,
                 end: Alignment.topCenter,
               ),

--- a/lib/widgets/inline_theory_recall_banner.dart
+++ b/lib/widgets/inline_theory_recall_banner.dart
@@ -30,7 +30,7 @@ class InlineTheoryRecallBanner extends StatelessWidget {
             margin: const EdgeInsets.symmetric(vertical: 8),
             padding: const EdgeInsets.all(12),
             decoration: BoxDecoration(
-              color: Colors.amber.withOpacity(0.2),
+              color: Colors.amber.withValues(alpha: 0.2),
               borderRadius: BorderRadius.circular(8),
             ),
             child: Text(

--- a/lib/widgets/learning_stage_tile.dart
+++ b/lib/widgets/learning_stage_tile.dart
@@ -169,7 +169,7 @@ class _LearningStageTileState extends State<LearningStageTile> {
       );
     }
     return ListTile(
-      tileColor: highlight ? Colors.blue.withOpacity(0.1) : null,
+      tileColor: highlight ? Colors.blue.withValues(alpha: 0.1) : null,
       title: Text(sub.title, style: TextStyle(color: grey)),
       subtitle:
           sub.description.isNotEmpty ? Text(sub.description, style: TextStyle(color: grey)) : null,

--- a/lib/widgets/lesson_onboarding_overlay.dart
+++ b/lib/widgets/lesson_onboarding_overlay.dart
@@ -36,7 +36,7 @@ class _LessonOnboardingOverlayState extends State<LessonOnboardingOverlay>
   Widget build(BuildContext context) {
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final bgColor =
-        isDark ? Colors.black.withOpacity(0.8) : Colors.white.withOpacity(0.8);
+        isDark ? Colors.black.withValues(alpha: 0.8) : Colors.white.withValues(alpha: 0.8);
     final cardColor = isDark ? Colors.black54 : Colors.white;
     final textColor = isDark ? Colors.white : Colors.black;
     final secondary = isDark ? Colors.white70 : Colors.black54;

--- a/lib/widgets/loss_amount_widget.dart
+++ b/lib/widgets/loss_amount_widget.dart
@@ -75,7 +75,7 @@ class _LossAmountWidgetState extends State<LossAmountWidget>
             fontSize: 16 * widget.scale,
             shadows: [
               Shadow(
-                color: Colors.black.withOpacity(0.6),
+                color: Colors.black.withValues(alpha: 0.6),
                 blurRadius: 4 * widget.scale,
               ),
             ],

--- a/lib/widgets/loss_fade_widget.dart
+++ b/lib/widgets/loss_fade_widget.dart
@@ -67,7 +67,7 @@ class _LossFadeWidgetState extends State<LossFadeWidget>
         borderRadius: BorderRadius.circular(6 * widget.scale),
         boxShadow: [
           BoxShadow(
-            color: Colors.black.withOpacity(0.25),
+            color: Colors.black.withValues(alpha: 0.25),
             blurRadius: 3 * widget.scale,
             offset: const Offset(1, 2),
           )

--- a/lib/widgets/mistake_empty_state.dart
+++ b/lib/widgets/mistake_empty_state.dart
@@ -46,7 +46,7 @@ class _MistakeEmptyStateState extends State<MistakeEmptyState>
               borderRadius: BorderRadius.circular(12),
               boxShadow: [
                 BoxShadow(
-                  color: Colors.black.withOpacity(0.3),
+                  color: Colors.black.withValues(alpha: 0.3),
                   blurRadius: 6,
                   offset: const Offset(0, 3),
                 ),

--- a/lib/widgets/path_node_unlock_hint_overlay.dart
+++ b/lib/widgets/path_node_unlock_hint_overlay.dart
@@ -36,7 +36,7 @@ class PathNodeUnlockHintOverlay {
                     constraints: const BoxConstraints(maxWidth: 200),
                     padding: const EdgeInsets.all(8),
                     decoration: BoxDecoration(
-                      color: Colors.black.withOpacity(0.8),
+                      color: Colors.black.withValues(alpha: 0.8),
                       borderRadius: BorderRadius.circular(8),
                     ),
                     child: Text(

--- a/lib/widgets/player_info_widget.dart
+++ b/lib/widgets/player_info_widget.dart
@@ -140,7 +140,7 @@ class PlayerInfoWidget extends StatelessWidget {
     final Widget box = Container(
       padding: const EdgeInsets.all(6),
       decoration: BoxDecoration(
-        color: Colors.black.withOpacity(0.3),
+        color: Colors.black.withValues(alpha: 0.3),
         borderRadius: BorderRadius.circular(8),
         border: Border.all(
             color: borderColor ?? Colors.white24, width: borderColor != null ? 2 : 1),
@@ -252,7 +252,7 @@ class PlayerInfoWidget extends StatelessWidget {
                     width: 22,
                     height: 30,
                     decoration: BoxDecoration(
-                      color: Colors.white.withOpacity(card == null ? 0.3 : 1),
+                      color: Colors.white.withValues(alpha: card == null ? 0.3 : 1),
                       borderRadius: BorderRadius.circular(4),
                     ),
                     alignment: Alignment.center,
@@ -288,7 +288,7 @@ class PlayerInfoWidget extends StatelessWidget {
                 padding:
                     const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
                 decoration: BoxDecoration(
-                  color: Colors.greenAccent.withOpacity(0.8),
+                  color: Colors.greenAccent.withValues(alpha: 0.8),
                   borderRadius: BorderRadius.circular(6),
                 ),
                 child: Text(
@@ -307,13 +307,13 @@ class PlayerInfoWidget extends StatelessWidget {
                   Icon(
                     Icons.circle,
                     size: 12,
-                    color: AppColors.accent.withOpacity(0.8),
+                    color: AppColors.accent.withValues(alpha: 0.8),
                   ),
                   const SizedBox(width: 2),
                   Text(
                     '$streetInvestment',
                     style: TextStyle(
-                      color: AppColors.accent.withOpacity(0.8),
+                      color: AppColors.accent.withValues(alpha: 0.8),
                       fontSize: 12,
                     ),
                   ),
@@ -331,7 +331,7 @@ class PlayerInfoWidget extends StatelessWidget {
                 builder: (context) => StatefulBuilder(
                   builder: (context, setState) {
                     return AlertDialog(
-                      backgroundColor: Colors.black.withOpacity(0.3),
+                      backgroundColor: Colors.black.withValues(alpha: 0.3),
                       title: const Text(
                         'Edit Stack',
                         style: TextStyle(color: Colors.white),
@@ -567,7 +567,7 @@ class _ActivePlayerGlowState extends State<_ActivePlayerGlow>
           decoration: BoxDecoration(
             boxShadow: [
               BoxShadow(
-                color: Colors.orange.withOpacity(0.5 + (t * 0.3)),
+                color: Colors.orange.withValues(alpha: 0.5 + (t * 0.3)),
                 blurRadius: 8 + (8 * t),
                 spreadRadius: 1,
               ),

--- a/lib/widgets/player_stack_chips.dart
+++ b/lib/widgets/player_stack_chips.dart
@@ -56,7 +56,7 @@ class PlayerStackChips extends StatelessWidget {
                     ),
                     boxShadow: [
                       BoxShadow(
-                        color: Colors.black.withOpacity(0.6),
+                        color: Colors.black.withValues(alpha: 0.6),
                         blurRadius: 3,
                         offset: const Offset(1, 2),
                       )

--- a/lib/widgets/player_zone/action_tag_label.dart
+++ b/lib/widgets/player_zone/action_tag_label.dart
@@ -18,7 +18,7 @@ class ActionTagLabel extends StatelessWidget {
     return Container(
       padding: EdgeInsets.symmetric(horizontal: 6 * scale, vertical: 2 * scale),
       decoration: BoxDecoration(
-        color: color.withOpacity(0.6),
+        color: color.withValues(alpha: 0.6),
         borderRadius: BorderRadius.circular(6 * scale),
       ),
       child: Text(

--- a/lib/widgets/player_zone/bet_chip.dart
+++ b/lib/widgets/player_zone/bet_chip.dart
@@ -33,7 +33,7 @@ class BetChip extends StatelessWidget {
                 shape: BoxShape.circle,
                 boxShadow: [
                   BoxShadow(
-                    color: Colors.black.withOpacity(0.4),
+                    color: Colors.black.withValues(alpha: 0.4),
                     blurRadius: 3 * scale,
                     offset: const Offset(1, 2),
                   ),

--- a/lib/widgets/player_zone/bet_size_label.dart
+++ b/lib/widgets/player_zone/bet_size_label.dart
@@ -15,7 +15,7 @@ class BetSizeLabel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final bg = color.withOpacity(0.9);
+    final bg = color.withValues(alpha: 0.9);
     return Container(
       padding: EdgeInsets.symmetric(horizontal: 6 * scale, vertical: 2 * scale),
       decoration: BoxDecoration(
@@ -23,7 +23,7 @@ class BetSizeLabel extends StatelessWidget {
         borderRadius: BorderRadius.circular(12 * scale),
         boxShadow: [
           BoxShadow(
-            color: color.withOpacity(0.8),
+            color: color.withValues(alpha: 0.8),
             blurRadius: 8 * scale,
             spreadRadius: 1 * scale,
           ),

--- a/lib/widgets/player_zone/chip_moving_widget.dart
+++ b/lib/widgets/player_zone/chip_moving_widget.dart
@@ -117,7 +117,7 @@ class _ChipMovingWidgetState extends State<ChipMovingWidget>
           color: Colors.black,
           boxShadow: [
             BoxShadow(
-              color: Colors.black.withOpacity(0.5),
+              color: Colors.black.withValues(alpha: 0.5),
               blurRadius: 4 * widget.scale,
               offset: const Offset(1, 2),
             )

--- a/lib/widgets/player_zone/player_zone_action_panel.dart
+++ b/lib/widgets/player_zone/player_zone_action_panel.dart
@@ -96,7 +96,7 @@ class PlayerZoneActionPanel extends StatelessWidget {
                     borderRadius: BorderRadius.circular(8 * scale),
                     boxShadow: [
                       BoxShadow(
-                        color: AppColors.accent.withOpacity(0.6),
+                        color: AppColors.accent.withValues(alpha: 0.6),
                         blurRadius: 6 * scale,
                       ),
                     ],
@@ -229,7 +229,7 @@ class _ActionLabelOverlayState extends State<ActionLabelOverlay>
               vertical: 4 * widget.scale,
             ),
             decoration: BoxDecoration(
-              color: widget.color.withOpacity(0.9),
+              color: widget.color.withValues(alpha: 0.9),
               borderRadius: BorderRadius.circular(8 * widget.scale),
               boxShadow: const [BoxShadow(color: Colors.black45, blurRadius: 4)],
             ),
@@ -304,7 +304,7 @@ class _BetAmountOverlayState extends State<BetAmountOverlay>
           height: radius * 2,
           alignment: Alignment.center,
           decoration: BoxDecoration(
-            color: widget.color.withOpacity(0.9),
+            color: widget.color.withValues(alpha: 0.9),
             shape: BoxShape.circle,
             boxShadow: const [
               BoxShadow(color: Colors.black45, blurRadius: 4),
@@ -398,7 +398,7 @@ class _RefundMessageOverlayState extends State<RefundMessageOverlay>
             vertical: 4 * widget.scale,
           ),
           decoration: BoxDecoration(
-            color: Colors.lightGreenAccent.withOpacity(0.9),
+            color: Colors.lightGreenAccent.withValues(alpha: 0.9),
             borderRadius: BorderRadius.circular(8 * widget.scale),
             boxShadow: const [BoxShadow(color: Colors.black45, blurRadius: 4)],
           ),

--- a/lib/widgets/player_zone/player_zone_core.dart
+++ b/lib/widgets/player_zone/player_zone_core.dart
@@ -943,7 +943,7 @@ class _PlayerZoneWidgetState extends State<PlayerZoneWidget>
       context: context,
       builder: (context) => StatefulBuilder(
         builder: (context, setState) => AlertDialog(
-          backgroundColor: Colors.black.withOpacity(0.3),
+          backgroundColor: Colors.black.withValues(alpha: 0.3),
           title: const Text(
             'Edit Stack',
             style: TextStyle(color: Colors.white),
@@ -1111,7 +1111,7 @@ class _PlayerZoneWidgetState extends State<PlayerZoneWidget>
                         borderRadius: BorderRadius.circular(6 * widget.scale),
                         boxShadow: [
                           BoxShadow(
-                            color: AppColors.accent.withOpacity(0.6),
+                            color: AppColors.accent.withValues(alpha: 0.6),
                             blurRadius: 4 * widget.scale,
                           ),
                         ],
@@ -1273,11 +1273,11 @@ class _PlayerZoneWidgetState extends State<PlayerZoneWidget>
                     width: 36 * widget.scale,
                     height: 52 * widget.scale,
                     decoration: BoxDecoration(
-                      color: Colors.white.withOpacity(card == null ? 0.3 : 1),
+                      color: Colors.white.withValues(alpha: card == null ? 0.3 : 1),
                       borderRadius: BorderRadius.circular(6),
                       boxShadow: [
                         BoxShadow(
-                          color: Colors.black.withOpacity(0.25),
+                          color: Colors.black.withValues(alpha: 0.25),
                           blurRadius: 3,
                           offset: const Offset(1, 2),
                         )
@@ -1337,7 +1337,7 @@ class _PlayerZoneWidgetState extends State<PlayerZoneWidget>
                           borderRadius: BorderRadius.circular(8 * widget.scale),
                           boxShadow: [
                             BoxShadow(
-                              color: Colors.yellowAccent.withOpacity(glow),
+                              color: Colors.yellowAccent.withValues(alpha: glow),
                               blurRadius: 12 * glow * widget.scale,
                               spreadRadius: 2 * glow * widget.scale,
                             ),
@@ -1431,7 +1431,7 @@ class _PlayerZoneWidgetState extends State<PlayerZoneWidget>
                               boxShadow: [
                                 BoxShadow(
                                   color:
-                                      Colors.greenAccent.withOpacity(glow),
+                                      Colors.greenAccent.withValues(alpha: glow),
                                   blurRadius: 16 * glow * widget.scale,
                                   spreadRadius: 4 * glow * widget.scale,
                                 ),
@@ -1453,7 +1453,7 @@ class _PlayerZoneWidgetState extends State<PlayerZoneWidget>
                                 boxShadow: [
                                   BoxShadow(
                                     color: Colors.lightGreenAccent
-                                        .withOpacity(glow),
+                                        .withValues(alpha: glow),
                                     blurRadius: 16 * glow * widget.scale,
                                     spreadRadius: 4 * glow * widget.scale,
                                   ),
@@ -1610,7 +1610,7 @@ class _PlayerZoneWidgetState extends State<PlayerZoneWidget>
             child: Container(
               padding: EdgeInsets.symmetric(horizontal: 6 * widget.scale, vertical: 2 * widget.scale),
               decoration: BoxDecoration(
-                color: Colors.grey.withOpacity(0.6),
+                color: Colors.grey.withValues(alpha: 0.6),
                 borderRadius: BorderRadius.circular(10 * widget.scale),
               ),
               child: Text(
@@ -1727,7 +1727,7 @@ class _PlayerZoneWidgetState extends State<PlayerZoneWidget>
                   borderRadius: BorderRadius.circular(12 * widget.scale),
                   boxShadow: [
                     BoxShadow(
-                      color: Colors.blueAccent.withOpacity(0.6),
+                      color: Colors.blueAccent.withValues(alpha: 0.6),
                       blurRadius: blur,
                     )
                   ],
@@ -1746,7 +1746,7 @@ class _PlayerZoneWidgetState extends State<PlayerZoneWidget>
           border: Border.all(color: AppColors.accent, width: 2 * widget.scale),
           boxShadow: [
             BoxShadow(
-              color: AppColors.accent.withOpacity(0.7),
+              color: AppColors.accent.withValues(alpha: 0.7),
               blurRadius: 12 * widget.scale,
               spreadRadius: 2 * widget.scale,
             ),
@@ -1763,7 +1763,7 @@ class _PlayerZoneWidgetState extends State<PlayerZoneWidget>
               borderRadius: BorderRadius.circular(12 * widget.scale),
               boxShadow: [
                 BoxShadow(
-                  color: Colors.greenAccent.withOpacity(0.6),
+                  color: Colors.greenAccent.withValues(alpha: 0.6),
                   blurRadius: 16,
                   spreadRadius: 4,
                 ),
@@ -1780,7 +1780,7 @@ class _PlayerZoneWidgetState extends State<PlayerZoneWidget>
               borderRadius: BorderRadius.circular(12 * widget.scale),
               boxShadow: [
                 BoxShadow(
-                  color: _actionGlowColor.withOpacity(0.7),
+                  color: _actionGlowColor.withValues(alpha: 0.7),
                   blurRadius: 16,
                   spreadRadius: 4,
                 ),
@@ -1804,7 +1804,7 @@ class _PlayerZoneWidgetState extends State<PlayerZoneWidget>
                     borderRadius: BorderRadius.circular(12 * widget.scale),
                     boxShadow: [
                       BoxShadow(
-                        color: Colors.white.withOpacity(glow),
+                        color: Colors.white.withValues(alpha: glow),
                         blurRadius: 24 * glow * widget.scale,
                         spreadRadius: 4 * glow * widget.scale,
                       ),

--- a/lib/widgets/player_zone/player_zone_overlay.dart
+++ b/lib/widgets/player_zone/player_zone_overlay.dart
@@ -55,7 +55,7 @@ class FoldChipOverlay extends StatelessWidget {
                         color: AppColors.accent,
                         boxShadow: [
                           BoxShadow(
-                            color: Colors.black.withOpacity(0.5),
+                            color: Colors.black.withValues(alpha: 0.5),
                             blurRadius: 4 * scale,
                             offset: const Offset(1, 2),
                           ),
@@ -206,7 +206,7 @@ class _WinnerCelebrationState extends State<WinnerCelebration>
               vertical: 4 * widget.scale,
             ),
             decoration: BoxDecoration(
-              color: Colors.amberAccent.withOpacity(0.9),
+              color: Colors.amberAccent.withValues(alpha: 0.9),
               borderRadius: BorderRadius.circular(12 * widget.scale),
               boxShadow: const [
                 BoxShadow(color: Colors.black45, blurRadius: 6),
@@ -348,7 +348,7 @@ class ChipWinOverlay extends StatelessWidget {
                         color: AppColors.accent,
                         boxShadow: [
                           BoxShadow(
-                            color: Colors.black.withOpacity(0.5),
+                            color: Colors.black.withValues(alpha: 0.5),
                             blurRadius: 4 * scale,
                             offset: const Offset(1, 2),
                           ),

--- a/lib/widgets/player_zone/stack_bar_widget.dart
+++ b/lib/widgets/player_zone/stack_bar_widget.dart
@@ -57,7 +57,7 @@ class StackBarWidget extends StatelessWidget {
                 ? BoxDecoration(
                     boxShadow: [
                       BoxShadow(
-                        color: AppColors.accent.withOpacity(glow),
+                        color: AppColors.accent.withValues(alpha: glow),
                         blurRadius: 8 * glow * scale,
                         spreadRadius: 2 * glow * scale,
                       ),

--- a/lib/widgets/player_zone/winner_flying_chip.dart
+++ b/lib/widgets/player_zone/winner_flying_chip.dart
@@ -95,7 +95,7 @@ class _WinnerFlyingChipState extends State<WinnerFlyingChip>
           color: AppColors.accent,
           boxShadow: [
             BoxShadow(
-              color: Colors.black.withOpacity(0.5),
+              color: Colors.black.withValues(alpha: 0.5),
               blurRadius: 4 * widget.scale,
               offset: const Offset(1, 2),
             )

--- a/lib/widgets/playing_card_widget.dart
+++ b/lib/widgets/playing_card_widget.dart
@@ -22,7 +22,7 @@ class PlayingCardWidget extends StatelessWidget {
         borderRadius: BorderRadius.circular(4),
         boxShadow: [
           BoxShadow(
-            color: Colors.black.withOpacity(0.25),
+            color: Colors.black.withValues(alpha: 0.25),
             blurRadius: 3,
             offset: const Offset(1, 2),
           )

--- a/lib/widgets/poker_table_painter.dart
+++ b/lib/widgets/poker_table_painter.dart
@@ -11,14 +11,14 @@ class PokerTablePainter extends CustomPainter {
     final rect = Offset.zero & size;
     final path = Path()..addOval(rect);
 
-    canvas.drawShadow(path, Colors.black.withOpacity(0.5), 12.0, true);
+    canvas.drawShadow(path, Colors.black.withValues(alpha: 0.5), 12.0, true);
 
     final gradient = _gradientForTheme();
     final feltPaint = Paint()..shader = gradient.createShader(rect);
     canvas.drawOval(rect, feltPaint);
 
     final borderPaint = Paint()
-      ..color = _borderColor().withOpacity(0.3)
+      ..color = _borderColor().withValues(alpha: 0.3)
       ..style = PaintingStyle.stroke
       ..strokeWidth = size.shortestSide * 0.03;
     canvas.drawOval(rect.deflate(borderPaint.strokeWidth / 2), borderPaint);

--- a/lib/widgets/poker_table_view.dart
+++ b/lib/widgets/poker_table_view.dart
@@ -156,7 +156,7 @@ class _PokerTableViewState extends State<PokerTableView> {
                     final result = await showDialog<double>(
                       context: context,
                       builder: (context) => AlertDialog(
-                        backgroundColor: Colors.black.withOpacity(0.3),
+                        backgroundColor: Colors.black.withValues(alpha: 0.3),
                         title: const Text('Edit Pot',
                             style: TextStyle(color: Colors.white)),
                         content: TextField(
@@ -282,7 +282,7 @@ class _PokerTableViewState extends State<PokerTableView> {
                 final result = await showDialog<double>(
                   context: context,
                   builder: (context) => AlertDialog(
-                    backgroundColor: Colors.black.withOpacity(0.3),
+                    backgroundColor: Colors.black.withValues(alpha: 0.3),
                     title: Text(next.name.toUpperCase(),
                         style: const TextStyle(color: Colors.white)),
                     content: TextField(
@@ -339,7 +339,7 @@ class _PokerTableViewState extends State<PokerTableView> {
               final result = await showDialog<String>(
                 context: context,
                 builder: (context) => AlertDialog(
-                  backgroundColor: Colors.black.withOpacity(0.3),
+                  backgroundColor: Colors.black.withValues(alpha: 0.3),
                   title: const Text('Rename Player',
                       style: TextStyle(color: Colors.white)),
                   content: TextField(
@@ -404,7 +404,7 @@ class _PokerTableViewState extends State<PokerTableView> {
               padding: EdgeInsets.symmetric(
                   horizontal: 2 * widget.scale, vertical: 1 * widget.scale),
               decoration: BoxDecoration(
-                color: Colors.black.withOpacity(0.6),
+                color: Colors.black.withValues(alpha: 0.6),
                 borderRadius: BorderRadius.circular(4),
               ),
               child: Text(
@@ -505,7 +505,7 @@ class _PokerTableViewState extends State<PokerTableView> {
               final result = await showDialog<double>(
                 context: context,
                 builder: (context) => AlertDialog(
-                  backgroundColor: Colors.black.withOpacity(0.3),
+                  backgroundColor: Colors.black.withValues(alpha: 0.3),
                   title: const Text('Edit Stack',
                       style: TextStyle(color: Colors.white)),
                   content: TextField(
@@ -722,10 +722,10 @@ class _ActionSpotHighlightState extends State<_ActionSpotHighlight>
         height: radius * 2,
         decoration: BoxDecoration(
           shape: BoxShape.circle,
-          border: Border.all(color: Colors.yellow.withOpacity(0.6), width: 3),
+          border: Border.all(color: Colors.yellow.withValues(alpha: 0.6), width: 3),
           boxShadow: [
             BoxShadow(
-              color: Colors.yellow.withOpacity(0.4),
+              color: Colors.yellow.withValues(alpha: 0.4),
               blurRadius: 6 * widget.scale,
               spreadRadius: 2 * widget.scale,
             ),

--- a/lib/widgets/pot_chip_stack_painter.dart
+++ b/lib/widgets/pot_chip_stack_painter.dart
@@ -22,7 +22,7 @@ class PotChipStackPainter extends CustomPainter {
           end: Alignment.bottomCenter,
         ).createShader(rect);
       final shadow = Paint()
-        ..color = Colors.black.withOpacity(0.6)
+        ..color = Colors.black.withValues(alpha: 0.6)
         ..maskFilter = MaskFilter.blur(BlurStyle.normal, radius / 2);
       canvas.drawCircle(center.translate(1, 2), radius, shadow);
       canvas.drawCircle(center, radius, paint);

--- a/lib/widgets/pot_win_animation.dart
+++ b/lib/widgets/pot_win_animation.dart
@@ -103,7 +103,7 @@ class _PotWinAnimationState extends State<PotWinAnimation>
                   shape: BoxShape.circle,
                   gradient: RadialGradient(
                     colors: [
-                      Colors.yellow.withOpacity(0.8),
+                      Colors.yellow.withValues(alpha: 0.8),
                       Colors.transparent,
                     ],
                   ),

--- a/lib/widgets/progress_chip.dart
+++ b/lib/widgets/progress_chip.dart
@@ -7,10 +7,10 @@ class ProgressChip extends StatelessWidget {
   Widget build(BuildContext ctx) {
     final tint = Theme.of(ctx).colorScheme.surfaceTint;
     final color = pct >= 1
-        ? tint.withOpacity(.9)
+        ? tint.withValues(alpha: .9)
         : pct >= .5
-            ? tint.withOpacity(.7)
-            : tint.withOpacity(.5);
+            ? tint.withValues(alpha: .7)
+            : tint.withValues(alpha: .5);
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
       decoration: BoxDecoration(

--- a/lib/widgets/range_matrix_picker.dart
+++ b/lib/widgets/range_matrix_picker.dart
@@ -93,7 +93,7 @@ class _Cell extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final bg = selected ? color : color.withOpacity(0.4);
+    final bg = selected ? color : color.withValues(alpha: 0.4);
     return GestureDetector(
       onTap: readOnly ? null : onTap,
       onLongPress: readOnly ? null : onTap,
@@ -124,7 +124,7 @@ class _Cell extends StatelessWidget {
                 height: 24,
                 margin: const EdgeInsets.all(1),
                 decoration: BoxDecoration(
-                  color: Colors.lightGreen.withOpacity(0.3),
+                  color: Colors.lightGreen.withValues(alpha: 0.3),
                   border: Border.all(color: Colors.transparent),
                 ),
               ),

--- a/lib/widgets/refund_amount_widget.dart
+++ b/lib/widgets/refund_amount_widget.dart
@@ -73,7 +73,7 @@ class _RefundAmountWidgetState extends State<RefundAmountWidget>
             vertical: 4 * widget.scale,
           ),
           decoration: BoxDecoration(
-            color: Colors.lightGreenAccent.withOpacity(0.9),
+            color: Colors.lightGreenAccent.withValues(alpha: 0.9),
             borderRadius: BorderRadius.circular(8 * widget.scale),
             boxShadow: const [BoxShadow(color: Colors.black45, blurRadius: 4)],
           ),

--- a/lib/widgets/replay_spot_widget.dart
+++ b/lib/widgets/replay_spot_widget.dart
@@ -127,7 +127,7 @@ class _ReplaySpotWidgetState extends State<ReplaySpotWidget> {
       margin: const EdgeInsets.only(bottom: 12),
       padding: kCardPadding,
       decoration: BoxDecoration(
-        color: highlight ? Colors.redAccent.withOpacity(0.2) : Colors.white10,
+        color: highlight ? Colors.redAccent.withValues(alpha: 0.2) : Colors.white10,
         borderRadius: BorderRadius.circular(8),
       ),
       child: Row(

--- a/lib/widgets/reward_banner_widget.dart
+++ b/lib/widgets/reward_banner_widget.dart
@@ -19,7 +19,7 @@ class RewardBannerWidget extends StatelessWidget {
           margin: const EdgeInsets.only(bottom: 16),
           padding: const EdgeInsets.all(12),
           decoration: BoxDecoration(
-            color: Colors.blueAccent.withOpacity(0.2),
+            color: Colors.blueAccent.withValues(alpha: 0.2),
             borderRadius: BorderRadius.circular(8),
           ),
           child: Column(

--- a/lib/widgets/session_label_overlay.dart
+++ b/lib/widgets/session_label_overlay.dart
@@ -74,7 +74,7 @@ class _SessionLabelOverlayState extends State<SessionLabelOverlay>
             child: Container(
               padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
               decoration: BoxDecoration(
-                color: Colors.black.withOpacity(0.8),
+                color: Colors.black.withValues(alpha: 0.8),
                 borderRadius: BorderRadius.circular(12),
               ),
               child: Text(

--- a/lib/widgets/skill_loss_overlay_prompt.dart
+++ b/lib/widgets/skill_loss_overlay_prompt.dart
@@ -88,7 +88,7 @@ class _SkillLossOverlayPromptState extends State<SkillLossOverlayPrompt>
                       shape: BoxShape.circle,
                       border: Border.all(
                         color:
-                            accent.withOpacity(0.5 + 0.5 * _controller.value),
+                            accent.withValues(alpha: 0.5 + 0.5 * _controller.value),
                         width: 8,
                       ),
                     ),

--- a/lib/widgets/skill_tag_coverage_dashboard.dart
+++ b/lib/widgets/skill_tag_coverage_dashboard.dart
@@ -143,7 +143,7 @@ class _SkillTagCoverageDashboardState extends State<SkillTagCoverageDashboard> {
                             Color.alphaBlend(
                               Colors.primaries[r.category.hashCode %
                                       Colors.primaries.length]
-                                  .withOpacity(0.08),
+                                  .withValues(alpha: 0.08),
                               baseColor,
                             ),
                           ),

--- a/lib/widgets/skill_tree_node_card.dart
+++ b/lib/widgets/skill_tree_node_card.dart
@@ -65,7 +65,7 @@ class SkillTreeNodeCard extends StatelessWidget {
           decoration: BoxDecoration(
             boxShadow: [
               BoxShadow(
-                color: Colors.greenAccent.withOpacity(value),
+                color: Colors.greenAccent.withValues(alpha: value),
                 blurRadius: 12 * value,
                 spreadRadius: 2 * value,
               ),

--- a/lib/widgets/spot_viewer_dialog.dart
+++ b/lib/widgets/spot_viewer_dialog.dart
@@ -104,7 +104,7 @@ class _SpotViewerDialogState extends State<SpotViewerDialog> {
     final result = await showDialog<String>(
       context: context,
       builder: (context) => AlertDialog(
-        backgroundColor: Colors.black.withOpacity(0.8),
+        backgroundColor: Colors.black.withValues(alpha: 0.8),
         title: const Text('Note', style: TextStyle(color: Colors.white)),
         content: TextField(
           controller: controller,
@@ -140,7 +140,7 @@ class _SpotViewerDialogState extends State<SpotViewerDialog> {
       context: context,
       builder: (context) => StatefulBuilder(
         builder: (context, setStateDialog) => AlertDialog(
-          backgroundColor: Colors.black.withOpacity(0.8),
+          backgroundColor: Colors.black.withValues(alpha: 0.8),
           title: const Text('Tags', style: TextStyle(color: Colors.white)),
           content: SizedBox(
             width: 300,

--- a/lib/widgets/streak_badge_widget.dart
+++ b/lib/widgets/streak_badge_widget.dart
@@ -28,7 +28,7 @@ class StreakBadgeWidget extends StatelessWidget {
             borderRadius: BorderRadius.circular(12),
             boxShadow: [
               BoxShadow(
-                color: Colors.deepOrange.withOpacity(0.6),
+                color: Colors.deepOrange.withValues(alpha: 0.6),
                 blurRadius: 8,
                 offset: const Offset(0, 2),
               ),

--- a/lib/widgets/streak_chart.dart
+++ b/lib/widgets/streak_chart.dart
@@ -46,7 +46,7 @@ class StreakChart extends StatelessWidget {
               width: 4,
               borderRadius: BorderRadius.circular(2),
               gradient: LinearGradient(
-                colors: [color.withOpacity(0.7), color],
+                colors: [color.withValues(alpha: 0.7), color],
                 begin: Alignment.bottomCenter,
                 end: Alignment.topCenter,
               ),

--- a/lib/widgets/street_action_list_simple.dart
+++ b/lib/widgets/street_action_list_simple.dart
@@ -135,7 +135,7 @@ class _StreetActionListSimpleState extends State<StreetActionListSimple> {
               padding: const EdgeInsets.symmetric(vertical: 2),
               child: Text(
                 'No actions',
-                style: TextStyle(color: textColor().withOpacity(0.6)),
+                style: TextStyle(color: textColor().withValues(alpha: 0.6)),
               ),
             )
           else

--- a/lib/widgets/street_action_summary_bar.dart
+++ b/lib/widgets/street_action_summary_bar.dart
@@ -26,7 +26,7 @@ class StreetActionSummaryBar extends StatelessWidget {
 
     return Container(
       padding: const EdgeInsets.symmetric(vertical: 4.0, horizontal: 8.0),
-      color: Colors.black.withOpacity(0.3),
+      color: Colors.black.withValues(alpha: 0.3),
       child: SingleChildScrollView(
         scrollDirection: Axis.horizontal,
         child: Row(

--- a/lib/widgets/street_coverage_bar.dart
+++ b/lib/widgets/street_coverage_bar.dart
@@ -35,7 +35,7 @@ class StreetCoverageBar extends StatelessWidget {
                   Container(
                     width: segmentWidth(i),
                     height: 6,
-                    color: _color(i).withOpacity(totals[i] == 0 ? .3 : 1),
+                    color: _color(i).withValues(alpha: totals[i] == 0 ? .3 : 1),
                   ),
               ],
             ),

--- a/lib/widgets/tag_matrix_coverage_table.dart
+++ b/lib/widgets/tag_matrix_coverage_table.dart
@@ -17,7 +17,7 @@ class TagMatrixCoverageTable extends StatelessWidget {
 
   Color _color(int n) {
     if (n == 0) return Colors.black26;
-    if (n == 1) return Colors.orange.withOpacity(.4);
+    if (n == 1) return Colors.orange.withValues(alpha: .4);
     final t = n / max;
     return Color.lerp(Colors.blueGrey.shade300, Colors.greenAccent, t)!;
   }

--- a/lib/widgets/tag_progress_sparkline.dart
+++ b/lib/widgets/tag_progress_sparkline.dart
@@ -60,7 +60,7 @@ class TagProgressSparkline extends StatelessWidget {
                   width: 3,
                   borderRadius: BorderRadius.circular(2),
                   gradient: LinearGradient(
-                    colors: [accent.withOpacity(0.7), accent],
+                    colors: [accent.withValues(alpha: 0.7), accent],
                     begin: Alignment.bottomCenter,
                     end: Alignment.topCenter,
                   ),

--- a/lib/widgets/theory_auto_injection_analytics_panel.dart
+++ b/lib/widgets/theory_auto_injection_analytics_panel.dart
@@ -194,7 +194,7 @@ class _TheoryAutoInjectionAnalyticsPanelState
               borderRadius: BorderRadius.circular(4),
               gradient: LinearGradient(
                 colors: [
-                  Theme.of(context).colorScheme.secondary.withOpacity(0.7),
+                  Theme.of(context).colorScheme.secondary.withValues(alpha: 0.7),
                   Theme.of(context).colorScheme.secondary,
                 ],
                 begin: Alignment.bottomCenter,

--- a/lib/widgets/theory_lesson_feedback_bar.dart
+++ b/lib/widgets/theory_lesson_feedback_bar.dart
@@ -49,7 +49,7 @@ class _TheoryLessonFeedbackBarState extends State<TheoryLessonFeedbackBar> {
         style: OutlinedButton.styleFrom(
           foregroundColor: selected ? Colors.white : accent,
           side: BorderSide(color: accent),
-          backgroundColor: selected ? accent.withOpacity(0.2) : null,
+          backgroundColor: selected ? accent.withValues(alpha: 0.2) : null,
         ),
       ),
     );

--- a/lib/widgets/theory_quick_access_banner.dart
+++ b/lib/widgets/theory_quick_access_banner.dart
@@ -86,7 +86,7 @@ class _TheoryQuickAccessBannerWidgetState
       margin: const EdgeInsets.symmetric(vertical: 8),
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
-        color: Colors.lightBlueAccent.withOpacity(0.2),
+        color: Colors.lightBlueAccent.withValues(alpha: 0.2),
         borderRadius: BorderRadius.circular(8),
       ),
       child: Row(

--- a/lib/widgets/theory_streak_badge.dart
+++ b/lib/widgets/theory_streak_badge.dart
@@ -20,7 +20,7 @@ class StreakBadge extends StatelessWidget {
             final badge = Container(
               padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
               decoration: BoxDecoration(
-                color: Colors.deepOrangeAccent.withOpacity(0.8),
+                color: Colors.deepOrangeAccent.withValues(alpha: 0.8),
                 borderRadius: BorderRadius.circular(12),
               ),
               child: Row(

--- a/lib/widgets/training_action_log_dialog.dart
+++ b/lib/widgets/training_action_log_dialog.dart
@@ -60,7 +60,7 @@ class TrainingActionLogDialog extends StatelessWidget {
                               builder: (ctx) {
                                 final c = TextEditingController(text: spot!.note);
                                 return AlertDialog(
-                                  backgroundColor: Colors.black.withOpacity(0.8),
+                                  backgroundColor: Colors.black.withValues(alpha: 0.8),
                                   title: const Text('Note', style: TextStyle(color: Colors.white)),
                                   content: TextField(
                                     controller: c,

--- a/lib/widgets/training_pack_play_screen_v2_toolbar.dart
+++ b/lib/widgets/training_pack_play_screen_v2_toolbar.dart
@@ -45,7 +45,7 @@ class TrainingPackPlayScreenV2Toolbar extends StatelessWidget {
         color: Theme.of(context)
             .colorScheme
             .surface
-            .withOpacity(0.9),
+            .withValues(alpha: 0.9),
         padding: EdgeInsets.symmetric(
             horizontal: mini ? 8 : 16, vertical: mini ? 4 : 8),
         child: SafeArea(

--- a/lib/widgets/training_pack_template_card.dart
+++ b/lib/widgets/training_pack_template_card.dart
@@ -128,7 +128,7 @@ class _TrainingPackTemplateCardState extends State<TrainingPackTemplateCard> {
                 child: Container(
                   padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
                   decoration: BoxDecoration(
-                    color: Colors.orangeAccent.withOpacity(0.9),
+                    color: Colors.orangeAccent.withValues(alpha: 0.9),
                     borderRadius: BorderRadius.circular(4),
                   ),
                   child: const Text(

--- a/lib/widgets/training_spot_diagram.dart
+++ b/lib/widgets/training_spot_diagram.dart
@@ -128,7 +128,7 @@ class TrainingSpotDiagram extends StatelessWidget {
                       height: seatSize,
                       padding: const EdgeInsets.all(6),
                       decoration: BoxDecoration(
-                        color: Colors.black.withOpacity(0.6),
+                        color: Colors.black.withValues(alpha: 0.6),
                         borderRadius: BorderRadius.circular(8),
                         border: Border.all(
                           color: isHero ? highlightColor : Colors.white30,
@@ -137,7 +137,7 @@ class TrainingSpotDiagram extends StatelessWidget {
                         boxShadow: [
                           BoxShadow(
                             color: isHero
-                                ? highlightColor.withOpacity(0.7)
+                                ? highlightColor.withValues(alpha: 0.7)
                                 : Colors.black54,
                             blurRadius: isHero ? 10 : 2,
                             spreadRadius: isHero ? 3 : 0,

--- a/lib/widgets/win_chips_animation.dart
+++ b/lib/widgets/win_chips_animation.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'chip_stack_moving_widget.dart';
+import '../theme/app_colors.dart';
 
 /// Animation of chips flying from the pot to a player's stack.
 class WinChipsAnimation extends StatelessWidget {
@@ -25,7 +26,7 @@ class WinChipsAnimation extends StatelessWidget {
   final double fadeStart;
 
   /// Color of the chip stack.
-  final Color color;
+  final Color? color;
 
   const WinChipsAnimation({
     super.key,
@@ -36,16 +37,17 @@ class WinChipsAnimation extends StatelessWidget {
     this.control,
     this.onCompleted,
     this.fadeStart = 0.7,
-    this.color = const Color(0xFFD8B243),
+    this.color,
   });
 
   @override
   Widget build(BuildContext context) {
+    final chipColor = color ?? AppColors.accent;
     return ChipStackMovingWidget(
       start: start,
       end: end,
       amount: amount,
-      color: color,
+      color: chipColor,
       scale: scale,
       control: control,
       fadeStart: fadeStart,


### PR DESCRIPTION
## Summary
- restore themed default for WinChipsAnimation color and resolve at build time
- replace legacy `withOpacity` calls with `withValues`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a95957ad8832a896be97d03101703