### PR TITLE
Add smoke tests for win overlays and weekly summary card

### DIFF
--- a/test/smoke/weekly_summary_card_smoke_test.dart
+++ b/test/smoke/weekly_summary_card_smoke_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:provider/provider.dart';
+
+import 'package:poker_analyzer/widgets/weekly_summary_card.dart';
+import 'package:poker_analyzer/services/session_log_service.dart';
+import 'package:poker_analyzer/services/tag_mastery_service.dart';
+import 'package:poker_analyzer/models/session_log.dart';
+
+class _MockSessionLogService extends Mock implements SessionLogService {}
+class _MockTagMasteryService extends Mock implements TagMasteryService {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(
+      DateTimeRange(start: DateTime.now(), end: DateTime.now()),
+    );
+  });
+  testWidgets('WeeklySummaryCard builds with fake services', (tester) async {
+    final logs = _MockSessionLogService();
+    final mastery = _MockTagMasteryService();
+
+    when(() => logs.load()).thenAnswer((_) async {});
+    when(() => logs.filter(range: any(named: 'range'))).thenReturn([
+      SessionLog(
+        sessionId: 's1',
+        templateId: 't1',
+        startedAt: DateTime.now(),
+        completedAt: DateTime.now(),
+        correctCount: 1,
+        mistakeCount: 0,
+      ),
+    ]);
+
+    when(() => mastery.computeDelta(fromLastWeek: any(named: 'fromLastWeek')))
+        .thenAnswer((_) async => {'tag': 0.1});
+
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          Provider<SessionLogService>.value(value: logs),
+          Provider<TagMasteryService>.value(value: mastery),
+        ],
+        child: const MaterialApp(
+          home: Scaffold(
+            body: WeeklySummaryCard(),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.byType(WeeklySummaryCard), findsOneWidget);
+  });
+}

--- a/test/smoke/win_overlays_smoke_test.dart
+++ b/test/smoke/win_overlays_smoke_test.dart
@@ -1,0 +1,134 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:poker_analyzer/widgets/win_pot_animation.dart';
+import 'package:poker_analyzer/widgets/win_chips_animation.dart';
+import 'package:poker_analyzer/widgets/win_text_widget.dart';
+import 'package:poker_analyzer/widgets/winner_glow_widget.dart';
+import 'package:poker_analyzer/widgets/winner_zone_highlight.dart';
+
+void main() {
+  testWidgets('win overlays render and complete animations', (tester) async {
+    bool potDone = false;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Stack(
+            children: [
+              WinPotAnimation(
+                start: Offset.zero,
+                end: const Offset(10, 10),
+                amount: 100,
+                onCompleted: () => potDone = true,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 1000));
+    await tester.pump();
+    expect(potDone, isTrue);
+
+    bool chipsDone = false;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Stack(
+            children: [
+              WinChipsAnimation(
+                start: Offset.zero,
+                end: const Offset(10, 10),
+                amount: 100,
+                onCompleted: () => chipsDone = true,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 400));
+    await tester.pump();
+    expect(chipsDone, isTrue);
+
+    bool chipsColoredDone = false;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Stack(
+            children: [
+              WinChipsAnimation(
+                start: Offset.zero,
+                end: const Offset(10, 10),
+                amount: 100,
+                color: Colors.purple,
+                onCompleted: () => chipsColoredDone = true,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 400));
+    await tester.pump();
+    expect(chipsColoredDone, isTrue);
+
+    bool textDone = false;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Stack(
+            children: [
+              WinTextWidget(
+                position: Offset.zero,
+                text: 'Winner',
+                onCompleted: () => textDone = true,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 2000));
+    await tester.pump();
+    expect(textDone, isTrue);
+
+    bool glowDone = false;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Stack(
+            children: [
+              WinnerGlowWidget(
+                position: Offset.zero,
+                onCompleted: () => glowDone = true,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 1500));
+    await tester.pump();
+    expect(glowDone, isTrue);
+
+    bool zoneDone = false;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Stack(
+            children: [
+              WinnerZoneHighlight(
+                rect: const Rect.fromLTWH(0, 0, 10, 10),
+                onCompleted: () => zoneDone = true,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 2000));
+    await tester.pump();
+    expect(zoneDone, isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- add widget smoke tests exercising win overlays and animation completion
- cover weekly summary card rendering with fake services

## Testing
- `flutter test test/smoke/win_overlays_smoke_test.dart` *(fails: No tests ran)*
- `flutter test test/smoke` *(fails: compile errors in unrelated library code)*

------
https://chatgpt.com/codex/tasks/task_e_689a99aafe54832aa82fb9ee01e42597