### PR TITLE
feat: add inline theory badge in training pack viewer

### DIFF
--- a/lib/widgets/common/inline_theory_badge.dart
+++ b/lib/widgets/common/inline_theory_badge.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+
+import '../../models/theory_mini_lesson_node.dart';
+import '../../services/mini_lesson_library_service.dart';
+import '../../screens/theory_lesson_viewer_screen.dart';
+import '../../services/analytics_service.dart';
+
+/// Displays a small badge linking to a relevant theory lesson for given tags.
+///
+/// The badge is only shown if at least one lesson matches [tags]. Lessons are
+/// resolved lazily to avoid upfront loading costs.
+class InlineTheoryBadge extends StatefulWidget {
+  final List<String> tags;
+  final String spotId;
+
+  const InlineTheoryBadge({
+    super.key,
+    required this.tags,
+    required this.spotId,
+  });
+
+  @override
+  State<InlineTheoryBadge> createState() => _InlineTheoryBadgeState();
+}
+
+class _InlineTheoryBadgeState extends State<InlineTheoryBadge> {
+  late final Future<TheoryMiniLessonNode?> _lessonFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _lessonFuture = _loadLesson();
+  }
+
+  Future<TheoryMiniLessonNode?> _loadLesson() async {
+    final library = MiniLessonLibraryService.instance;
+    await library.loadAll();
+    final lessons = library.findByTags(widget.tags);
+    if (lessons.isEmpty) return null;
+    return lessons.first;
+  }
+
+  void _openLesson(TheoryMiniLessonNode lesson) {
+    AnalyticsService.instance.logEvent('theory_link_opened', {
+      'lesson_id': lesson.id,
+      'spot_id': widget.spotId,
+    });
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      builder: (_) => SizedBox(
+        height: MediaQuery.of(context).size.height * 0.9,
+        child: TheoryLessonViewerScreen(
+          lesson: lesson,
+          currentIndex: 1,
+          totalCount: 1,
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<TheoryMiniLessonNode?>(
+      future: _lessonFuture,
+      builder: (context, snapshot) {
+        final lesson = snapshot.data;
+        if (lesson == null) return const SizedBox.shrink();
+        return Padding(
+          padding: const EdgeInsets.only(right: 4.0),
+          child: ActionChip(
+            avatar: const Icon(Icons.school, size: 16),
+            label: const Text('Theory'),
+            onPressed: () => _openLesson(lesson),
+          ),
+        );
+      },
+    );
+  }
+}
+

--- a/lib/widgets/common/training_spot_tile.dart
+++ b/lib/widgets/common/training_spot_tile.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../../models/training_spot.dart';
+import 'inline_theory_badge.dart';
 
 class TrainingSpotTile extends StatelessWidget {
   final TrainingSpot spot;
@@ -27,6 +28,10 @@ class TrainingSpotTile extends StatelessWidget {
       trailing: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
+          InlineTheoryBadge(
+            tags: spot.tags,
+            spotId: spot.createdAt.toIso8601String(),
+          ),
           if (onEdit != null)
             IconButton(icon: const Icon(Icons.edit), onPressed: onEdit),
           if (onRemove != null)


### PR DESCRIPTION
## Summary
- add InlineTheoryBadge widget that lazily links spot tags to theory lessons and logs telemetry
- show a Theory badge on each training spot when matching lessons exist

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a9f1c4700832a9175a26fb1113cdd