### PR TITLE
feat: cache theory badge matches

### DIFF
--- a/lib/screens/training_pack_spot_panel.dart
+++ b/lib/screens/training_pack_spot_panel.dart
@@ -23,6 +23,7 @@ class TrainingPackSpotPanel extends StatelessWidget {
         onRemove: controller.removeSpot,
         onChanged: controller.saveSpots,
         onReorder: controller.reorder,
+        packId: controller.pack.id,
       ),
     );
   }

--- a/lib/services/inline_theory_linker_cache.dart
+++ b/lib/services/inline_theory_linker_cache.dart
@@ -1,0 +1,41 @@
+import '../models/theory_mini_lesson_node.dart';
+import 'mini_lesson_library_service.dart';
+
+/// Caches theory lessons by tag to avoid repeated library loads.
+class InlineTheoryLinkerCache {
+  InlineTheoryLinkerCache({MiniLessonLibraryService? library})
+      : _library = library ?? MiniLessonLibraryService.instance;
+
+  final MiniLessonLibraryService _library;
+  bool _ready = false;
+  Future<void>? _loading;
+
+  /// Global singleton instance.
+  static final InlineTheoryLinkerCache instance = InlineTheoryLinkerCache();
+
+  /// Ensures the underlying library is loaded. Subsequent calls are no-ops.
+  Future<void> ensureReady() {
+    if (_ready) return Future.value();
+    return _loading ??= _load();
+  }
+
+  Future<void> _load() async {
+    await _library.loadAll();
+    _ready = true;
+  }
+
+  /// Returns all lessons matching any of [tags]. Returns an empty list if the
+  /// cache is not ready or no matches are found.
+  List<TheoryMiniLessonNode> getMatchesForTags(List<String> tags) {
+    if (!_ready) return const [];
+    final normalized = tags.map((e) => e.toLowerCase()).toList();
+    return _library.findByTags(normalized);
+  }
+
+  /// Returns the first lesson matching [tags] or `null` if none found.
+  TheoryMiniLessonNode? getFirstMatchForTags(List<String> tags) {
+    final matches = getMatchesForTags(tags);
+    return matches.isEmpty ? null : matches.first;
+  }
+}
+

--- a/lib/widgets/common/inline_theory_badge.dart
+++ b/lib/widgets/common/inline_theory_badge.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 
 import '../../models/theory_mini_lesson_node.dart';
-import '../../services/mini_lesson_library_service.dart';
 import '../../screens/theory_lesson_viewer_screen.dart';
 import '../../services/analytics_service.dart';
+import '../../services/inline_theory_linker_cache.dart';
 
 /// Displays a small badge linking to a relevant theory lesson for given tags.
 ///
@@ -12,69 +12,115 @@ import '../../services/analytics_service.dart';
 class InlineTheoryBadge extends StatefulWidget {
   final List<String> tags;
   final String spotId;
+  final String? packId;
+  final InlineTheoryLinkerCache cache;
 
   const InlineTheoryBadge({
     super.key,
     required this.tags,
     required this.spotId,
-  });
+    this.packId,
+    InlineTheoryLinkerCache? cache,
+  }) : cache = cache ?? InlineTheoryLinkerCache.instance;
 
   @override
   State<InlineTheoryBadge> createState() => _InlineTheoryBadgeState();
 }
 
 class _InlineTheoryBadgeState extends State<InlineTheoryBadge> {
-  late final Future<TheoryMiniLessonNode?> _lessonFuture;
+  List<TheoryMiniLessonNode> _lessons = const [];
+  bool _loaded = false;
 
   @override
   void initState() {
     super.initState();
-    _lessonFuture = _loadLesson();
+    _load();
   }
 
-  Future<TheoryMiniLessonNode?> _loadLesson() async {
-    final library = MiniLessonLibraryService.instance;
-    await library.loadAll();
-    final lessons = library.findByTags(widget.tags);
-    if (lessons.isEmpty) return null;
-    return lessons.first;
+  Future<void> _load() async {
+    try {
+      await widget.cache.ensureReady();
+      final matches = widget.cache.getMatchesForTags(widget.tags);
+      if (!mounted) return;
+      setState(() {
+        _lessons = matches;
+        _loaded = true;
+      });
+    } catch (_) {
+      if (mounted) setState(() => _loaded = true);
+    }
   }
 
-  void _openLesson(TheoryMiniLessonNode lesson) {
-    AnalyticsService.instance.logEvent('theory_link_opened', {
-      'lesson_id': lesson.id,
+  Future<void> _openLesson(TheoryMiniLessonNode lesson) async {
+    try {
+      await AnalyticsService.instance.logEvent('theory_link_opened', {
+        'lesson_id': lesson.id,
+        'spot_id': widget.spotId,
+        if (widget.packId != null) 'pack_id': widget.packId,
+      });
+      await showModalBottomSheet(
+        context: context,
+        isScrollControlled: true,
+        builder: (_) => SizedBox(
+          height: MediaQuery.of(context).size.height * 0.9,
+          child: TheoryLessonViewerScreen(
+            lesson: lesson,
+            currentIndex: 1,
+            totalCount: 1,
+          ),
+        ),
+      );
+    } catch (_) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Failed to open lesson')),
+        );
+      }
+    }
+  }
+
+  void _handleTap() {
+    final lessons = _lessons;
+    if (lessons.isEmpty) return;
+    if (lessons.length == 1) {
+      _openLesson(lessons.first);
+      return;
+    }
+    AnalyticsService.instance.logEvent('theory_list_opened', {
       'spot_id': widget.spotId,
+      if (widget.packId != null) 'pack_id': widget.packId,
+      'count': lessons.length,
     });
     showModalBottomSheet(
       context: context,
-      isScrollControlled: true,
-      builder: (_) => SizedBox(
-        height: MediaQuery.of(context).size.height * 0.9,
-        child: TheoryLessonViewerScreen(
-          lesson: lesson,
-          currentIndex: 1,
-          totalCount: 1,
-        ),
+      builder: (ctx) => ListView(
+        shrinkWrap: true,
+        children: [
+          for (final l in lessons)
+            ListTile(
+              title: Text(l.resolvedTitle),
+              subtitle: Text(l.tags.join(', ')),
+              onTap: () {
+                Navigator.pop(ctx);
+                Future.microtask(() => _openLesson(l));
+              },
+            ),
+        ],
       ),
     );
   }
 
   @override
   Widget build(BuildContext context) {
-    return FutureBuilder<TheoryMiniLessonNode?>(
-      future: _lessonFuture,
-      builder: (context, snapshot) {
-        final lesson = snapshot.data;
-        if (lesson == null) return const SizedBox.shrink();
-        return Padding(
-          padding: const EdgeInsets.only(right: 4.0),
-          child: ActionChip(
-            avatar: const Icon(Icons.school, size: 16),
-            label: const Text('Theory'),
-            onPressed: () => _openLesson(lesson),
-          ),
-        );
-      },
+    if (!_loaded || _lessons.isEmpty) return const SizedBox.shrink();
+    final count = _lessons.length;
+    return Padding(
+      padding: const EdgeInsets.only(right: 4.0),
+      child: ActionChip(
+        avatar: const Icon(Icons.school, size: 16),
+        label: Text('Theory • $count'),
+        onPressed: _handleTap,
+      ),
     );
   }
 }

--- a/lib/widgets/common/training_spot_list_core.dart
+++ b/lib/widgets/common/training_spot_list_core.dart
@@ -3,6 +3,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../models/training_spot.dart';
 import '../../utils/shared_prefs_keys.dart';
+import '../../services/inline_theory_linker_cache.dart';
 import 'training_spot_tile.dart';
 import 'training_spot_filter_panel.dart';
 import 'training_spot_overlay.dart';
@@ -13,6 +14,7 @@ class TrainingSpotList extends StatefulWidget {
   final ValueChanged<int>? onEdit;
   final VoidCallback? onChanged;
   final ReorderCallback? onReorder;
+  final String? packId;
 
   const TrainingSpotList({
     super.key,
@@ -21,6 +23,7 @@ class TrainingSpotList extends StatefulWidget {
     this.onEdit,
     this.onChanged,
     this.onReorder,
+    this.packId,
   });
 
   @override
@@ -36,6 +39,8 @@ class TrainingSpotListState extends State<TrainingSpotList> {
     super.initState();
     _filtered = [...widget.spots];
     _loadPrefs();
+    WidgetsBinding.instance
+        .addPostFrameCallback((_) => InlineTheoryLinkerCache.instance.ensureReady());
   }
 
   Future<void> _loadPrefs() async {
@@ -85,6 +90,7 @@ class TrainingSpotListState extends State<TrainingSpotList> {
                       ? () => widget.onRemove!(index)
                       : null,
                   onTap: widget.onChanged,
+                  packId: widget.packId,
                 );
               },
             ),

--- a/lib/widgets/common/training_spot_tile.dart
+++ b/lib/widgets/common/training_spot_tile.dart
@@ -8,6 +8,7 @@ class TrainingSpotTile extends StatelessWidget {
   final VoidCallback? onEdit;
   final VoidCallback? onRemove;
   final VoidCallback? onTap;
+  final String? packId;
 
   const TrainingSpotTile({
     super.key,
@@ -15,12 +16,22 @@ class TrainingSpotTile extends StatelessWidget {
     this.onEdit,
     this.onRemove,
     this.onTap,
+    this.packId,
   });
 
   @override
   Widget build(BuildContext context) {
     final pos = spot.positions.isNotEmpty ? spot.positions[spot.heroIndex] : '';
     final stack = spot.stacks.isNotEmpty ? spot.stacks[spot.heroIndex] : 0;
+    final spotId = (() {
+      try {
+        final dynamic s = spot;
+        final id = s.id;
+        if (id is String && id.isNotEmpty) return id;
+      } catch (_) {}
+      return spot.createdAt.toIso8601String();
+    })();
+
     return ListTile(
       title: Text('$pos ${stack}bb'),
       subtitle: spot.tags.isNotEmpty ? Text(spot.tags.join(', ')) : null,
@@ -30,7 +41,8 @@ class TrainingSpotTile extends StatelessWidget {
         children: [
           InlineTheoryBadge(
             tags: spot.tags,
-            spotId: spot.createdAt.toIso8601String(),
+            spotId: spotId,
+            packId: packId,
           ),
           if (onEdit != null)
             IconButton(icon: const Icon(Icons.edit), onPressed: onEdit),

--- a/lib/widgets/pack_spot_list.dart
+++ b/lib/widgets/pack_spot_list.dart
@@ -25,6 +25,7 @@ class PackSpotList extends StatelessWidget {
         onRemove: controller.removeSpot,
         onChanged: controller.saveSpots,
         onReorder: controller.reorder,
+        packId: controller.pack.id,
       ),
     );
   }

--- a/test/services/inline_theory_linker_cache_test.dart
+++ b/test/services/inline_theory_linker_cache_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/services/inline_theory_linker_cache.dart';
+import 'package:poker_analyzer/services/mini_lesson_library_service.dart';
+
+class _FakeLibrary implements MiniLessonLibraryService {
+  final List<TheoryMiniLessonNode> lessons;
+  int loadCount = 0;
+  _FakeLibrary(this.lessons);
+
+  @override
+  List<TheoryMiniLessonNode> get all => lessons;
+
+  @override
+  Future<void> loadAll() async {
+    loadCount++;
+  }
+
+  @override
+  Future<void> reload() async {}
+
+  @override
+  TheoryMiniLessonNode? getById(String id) =>
+      lessons.firstWhere((l) => l.id == id, orElse: () => null);
+
+  @override
+  List<TheoryMiniLessonNode> findByTags(List<String> tags) {
+    final set = tags.toSet();
+    final seen = <String>{};
+    final result = <TheoryMiniLessonNode>[];
+    for (final l in lessons) {
+      if (l.tags.any(set.contains)) {
+        if (seen.add(l.id)) result.add(l);
+      }
+    }
+    return result;
+  }
+
+  @override
+  List<TheoryMiniLessonNode> getByTags(Set<String> tags) =>
+      findByTags(tags.toList());
+
+  @override
+  List<String> linkedPacksFor(String lessonId) => const [];
+}
+
+void main() {
+  test('ensureReady loads library only once', () async {
+    final lib = _FakeLibrary(const [
+      TheoryMiniLessonNode(
+        id: 'l1',
+        title: 'A',
+        content: '',
+        tags: ['tag'],
+      ),
+    ]);
+    final cache = InlineTheoryLinkerCache(library: lib);
+    await cache.ensureReady();
+    await cache.ensureReady();
+    expect(lib.loadCount, 1);
+  });
+
+  test('getMatchesForTags returns lessons after ready', () async {
+    final lessons = const [
+      TheoryMiniLessonNode(id: 'l1', title: 'A', content: '', tags: ['x']),
+      TheoryMiniLessonNode(id: 'l2', title: 'B', content: '', tags: ['y']),
+    ];
+    final cache = InlineTheoryLinkerCache(library: _FakeLibrary(lessons));
+    await cache.ensureReady();
+    final matches = cache.getMatchesForTags(['y']);
+    expect(matches.length, 1);
+    expect(matches.first.id, 'l2');
+  });
+}
+

--- a/test/widgets/inline_theory_badge_test.dart
+++ b/test/widgets/inline_theory_badge_test.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/services/inline_theory_linker_cache.dart';
+import 'package:poker_analyzer/services/mini_lesson_library_service.dart';
+import 'package:poker_analyzer/services/user_action_logger.dart';
+import 'package:poker_analyzer/widgets/common/inline_theory_badge.dart';
+
+class _FakeLibrary implements MiniLessonLibraryService {
+  final List<TheoryMiniLessonNode> lessons;
+  _FakeLibrary(this.lessons);
+
+  @override
+  List<TheoryMiniLessonNode> get all => lessons;
+
+  @override
+  Future<void> loadAll() async {}
+
+  @override
+  Future<void> reload() async {}
+
+  @override
+  TheoryMiniLessonNode? getById(String id) =>
+      lessons.firstWhere((l) => l.id == id, orElse: () => null);
+
+  @override
+  List<TheoryMiniLessonNode> findByTags(List<String> tags) {
+    final set = tags.toSet();
+    final seen = <String>{};
+    final result = <TheoryMiniLessonNode>[];
+    for (final l in lessons) {
+      if (l.tags.any(set.contains)) {
+        if (seen.add(l.id)) result.add(l);
+      }
+    }
+    return result;
+  }
+
+  @override
+  List<TheoryMiniLessonNode> getByTags(Set<String> tags) =>
+      findByTags(tags.toList());
+
+  @override
+  List<String> linkedPacksFor(String lessonId) => const [];
+}
+
+void main() {
+  testWidgets('shows count and logs telemetry', (tester) async {
+    SharedPreferences.setMockInitialValues({});
+    await UserActionLogger.instance.load();
+
+    final lessons = const [
+      TheoryMiniLessonNode(id: 'l1', title: 'L1', content: '', tags: ['tag']),
+      TheoryMiniLessonNode(id: 'l2', title: 'L2', content: '', tags: ['tag']),
+    ];
+    final cache = InlineTheoryLinkerCache(library: _FakeLibrary(lessons));
+    await cache.ensureReady();
+
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: InlineTheoryBadge(
+          tags: const ['tag'],
+          spotId: 's1',
+          packId: 'p1',
+          cache: cache,
+        ),
+      ),
+    ));
+    await tester.pump();
+
+    expect(find.text('Theory • 2'), findsOneWidget);
+
+    await tester.tap(find.byType(ActionChip));
+    await tester.pumpAndSettle();
+    expect(find.text('L1'), findsOneWidget);
+
+    final events1 = UserActionLogger.instance.events;
+    expect(events1.last['event'], 'theory_list_opened');
+    expect(events1.last['pack_id'], 'p1');
+    expect(events1.last['spot_id'], 's1');
+
+    await tester.tap(find.text('L1'));
+    await tester.pumpAndSettle();
+
+    final events = UserActionLogger.instance.events;
+    final last = events.last;
+    expect(last['event'], 'theory_link_opened');
+    expect(last['pack_id'], 'p1');
+    expect(last['spot_id'], 's1');
+    expect(last['lesson_id'], 'l1');
+  });
+}
+


### PR DESCRIPTION
## Summary
- add InlineTheoryLinkerCache to preload theory lessons once
- show Theory • N badges and allow multi-lesson selection with telemetry
- prefetch cache for training spot lists and forward pack/spot IDs

## Testing
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689aa09bad98832aaa25ba16dbb3eeeb