### PR TITLE
feat: suggest theory after mistakes

### DIFF
--- a/lib/widgets/mistake_inline_theory_prompt.dart
+++ b/lib/widgets/mistake_inline_theory_prompt.dart
@@ -1,0 +1,143 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/theory_mini_lesson_node.dart';
+import '../services/inline_theory_linker_cache.dart';
+import '../services/analytics_service.dart';
+import '../screens/theory_lesson_viewer_screen.dart';
+
+typedef LessonMatchProvider = Future<List<TheoryMiniLessonNode>> Function(
+    List<String> tags);
+typedef AnalyticsLogger = Future<void> Function(
+    String event, Map<String, dynamic> params);
+
+Future<List<TheoryMiniLessonNode>> _defaultMatchProvider(List<String> tags) async {
+  final cache = InlineTheoryLinkerCache.instance;
+  await cache.ensureReady();
+  return cache.getMatchesForTags(tags);
+}
+
+Future<void> _defaultLog(String event, Map<String, dynamic> params) {
+  return AnalyticsService.instance.logEvent(event, params);
+}
+
+class MistakeInlineTheoryPrompt extends StatefulWidget {
+  final List<String> tags;
+  final String packId;
+  final String spotId;
+  final LessonMatchProvider matchProvider;
+  final AnalyticsLogger log;
+
+  const MistakeInlineTheoryPrompt({
+    super.key,
+    required this.tags,
+    required this.packId,
+    required this.spotId,
+    LessonMatchProvider? matchProvider,
+    AnalyticsLogger? log,
+  })  : matchProvider = matchProvider ?? _defaultMatchProvider,
+        log = log ?? _defaultLog;
+
+  @override
+  State<MistakeInlineTheoryPrompt> createState() =>
+      _MistakeInlineTheoryPromptState();
+}
+
+class _MistakeInlineTheoryPromptState extends State<MistakeInlineTheoryPrompt> {
+  List<TheoryMiniLessonNode>? _lessons;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final hide = prefs.getBool('hide_theory_prompt_${widget.packId}') ?? false;
+    if (hide) return;
+    final matches = await widget.matchProvider(widget.tags);
+    if (matches.isEmpty) return;
+    await widget.log('theory_suggested_after_mistake', {
+      'packId': widget.packId,
+      'spotId': widget.spotId,
+      'count': matches.length,
+    });
+    setState(() => _lessons = matches);
+  }
+
+  Future<void> _openLesson(TheoryMiniLessonNode lesson, int total) async {
+    await Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => TheoryLessonViewerScreen(
+          lesson: lesson,
+          currentIndex: 1,
+          totalCount: total,
+        ),
+        fullscreenDialog: true,
+      ),
+    );
+  }
+
+  Future<void> _open() async {
+    final lessons = _lessons!;
+    if (lessons.length == 1) {
+      await widget.log('theory_link_opened', {
+        'packId': widget.packId,
+        'spotId': widget.spotId,
+      });
+      await _openLesson(lessons.first, lessons.length);
+      return;
+    }
+    await widget.log('theory_list_opened', {
+      'packId': widget.packId,
+      'spotId': widget.spotId,
+      'count': lessons.length,
+    });
+    final selected = await showModalBottomSheet<TheoryMiniLessonNode>(
+      context: context,
+      builder: (_) => ListView(
+        children: [
+          for (final l in lessons)
+            ListTile(
+              title: Text(l.resolvedTitle),
+              subtitle: Text(l.tags.join(', ')),
+              onTap: () => Navigator.pop(context, l),
+            ),
+        ],
+      ),
+    );
+    if (selected != null) {
+      await widget.log('theory_link_opened', {
+        'packId': widget.packId,
+        'spotId': widget.spotId,
+      });
+      await _openLesson(selected, lessons.length);
+    }
+  }
+
+  Future<void> _disable() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool('hide_theory_prompt_${widget.packId}', true);
+    setState(() => _lessons = null);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final lessons = _lessons;
+    if (lessons == null) return const SizedBox.shrink();
+    return Row(
+      children: [
+        ActionChip(
+          avatar: const Icon(Icons.school, size: 16),
+          label: Text('Learn now (Theory • ${lessons.length})'),
+          onPressed: _open,
+        ),
+        TextButton(
+          onPressed: _disable,
+          child: const Text("Don't show for this pack"),
+        ),
+      ],
+    );
+  }
+}

--- a/test/widgets/mistake_inline_theory_prompt_test.dart
+++ b/test/widgets/mistake_inline_theory_prompt_test.dart
@@ -1,0 +1,132 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/widgets/mistake_inline_theory_prompt.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+
+class _FakeProvider {
+  final List<TheoryMiniLessonNode> lessons;
+  _FakeProvider(this.lessons);
+  Future<List<TheoryMiniLessonNode>> call(List<String> tags) async => lessons;
+}
+
+class _EventLogger {
+  final events = <Map<String, dynamic>>[];
+  Future<void> call(String event, Map<String, dynamic> params) async {
+    events.add({'event': event, ...params});
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('MistakeInlineTheoryPrompt', () {
+    testWidgets('shows and opens single lesson', (tester) async {
+      SharedPreferences.setMockInitialValues({});
+      final lesson =
+          TheoryMiniLessonNode(id: 'l1', title: 'L1', content: 'c', tags: ['a']);
+      final provider = _FakeProvider([lesson]);
+      final logger = _EventLogger();
+
+      await tester.pumpWidget(MaterialApp(
+        home: MistakeInlineTheoryPrompt(
+          tags: const ['a'],
+          packId: 'p1',
+          spotId: 's1',
+          matchProvider: provider.call,
+          log: logger.call,
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Learn now (Theory • 1)'), findsOneWidget);
+      expect(
+          logger.events.any((e) =>
+              e['event'] == 'theory_suggested_after_mistake' && e['count'] == 1),
+          isTrue);
+
+      await tester.tap(find.text('Learn now (Theory • 1)'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('L1'), findsOneWidget);
+      expect(
+          logger.events.any((e) => e['event'] == 'theory_link_opened'), isTrue);
+    });
+
+    testWidgets('shows list when multiple lessons', (tester) async {
+      SharedPreferences.setMockInitialValues({});
+      final lessons = [
+        TheoryMiniLessonNode(id: 'l1', title: 'L1', content: 'c', tags: ['a']),
+        TheoryMiniLessonNode(id: 'l2', title: 'L2', content: 'c', tags: ['a']),
+      ];
+      final provider = _FakeProvider(lessons);
+      final logger = _EventLogger();
+
+      await tester.pumpWidget(MaterialApp(
+        home: MistakeInlineTheoryPrompt(
+          tags: const ['a'],
+          packId: 'p1',
+          spotId: 's1',
+          matchProvider: provider.call,
+          log: logger.call,
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Learn now (Theory • 2)'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('L1'), findsOneWidget);
+      expect(
+          logger.events.any((e) =>
+              e['event'] == 'theory_list_opened' && e['count'] == 2),
+          isTrue);
+
+      await tester.tap(find.text('L1'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('L1'), findsOneWidget);
+      expect(
+          logger.events.where((e) => e['event'] == 'theory_link_opened').length,
+          1);
+    });
+
+    testWidgets('preference disables prompt', (tester) async {
+      SharedPreferences.setMockInitialValues({});
+      final lesson =
+          TheoryMiniLessonNode(id: 'l1', title: 'L1', content: 'c', tags: ['a']);
+      final provider = _FakeProvider([lesson]);
+      final logger = _EventLogger();
+
+      await tester.pumpWidget(MaterialApp(
+        home: MistakeInlineTheoryPrompt(
+          tags: const ['a'],
+          packId: 'p1',
+          spotId: 's1',
+          matchProvider: provider.call,
+          log: logger.call,
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text("Don't show for this pack"));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Learn now (Theory • 1)'), findsNothing);
+
+      await tester.pumpWidget(MaterialApp(
+        home: MistakeInlineTheoryPrompt(
+          tags: const ['a'],
+          packId: 'p1',
+          spotId: 's1',
+          matchProvider: provider.call,
+          log: logger.call,
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Learn now (Theory • 1)'), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- show inline theory prompt after incorrect answers
- track suggestion/list/open analytics

## Testing
- `flutter test test/widgets/mistake_inline_theory_prompt_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689aa58079d8832a966a19315c05d2c5