### PR TITLE
Add retry-after-theory flow with auto-retest option

### DIFF
--- a/lib/app_bootstrap.dart
+++ b/lib/app_bootstrap.dart
@@ -31,6 +31,9 @@ class AppBootstrap {
   static ServiceRegistry? _registry;
   static ServiceRegistry get registry => _registry!;
 
+  @visibleForTesting
+  static set testRegistry(ServiceRegistry registry) => _registry = registry;
+
   static Future<ServiceRegistry> init({
     CloudSyncService? cloud,
     required PluginRuntime runtime,
@@ -47,9 +50,11 @@ class AppBootstrap {
     }
     registry.registerIfAbsent<EvaluationExecutor>(EvaluationExecutorService());
     registry.registerIfAbsent<TrainingSessionFingerprintService>(
-        TrainingSessionFingerprintService());
+      TrainingSessionFingerprintService(),
+    );
     registry.registerIfAbsent<TrainingSessionContextService>(
-        TrainingSessionContextService());
+      TrainingSessionContextService(),
+    );
     XpGoalPanelBoosterInjector.instance.inject();
     _registry = registry;
     return registry;
@@ -63,9 +68,18 @@ class AppBootstrap {
 
   static Future<void> _loadAssets() async {
     try {
-      await _run('TrainingPackAssetLoader.loadAll', () => TrainingPackAssetLoader.instance.loadAll());
-      await _run('PackLibraryLoaderService.loadLibrary', () => PackLibraryLoaderService.instance.loadLibrary());
-      await _run('TrainingPackLibraryV2.loadFromFolder', () => TrainingPackLibraryV2.instance.loadFromFolder());
+      await _run(
+        'TrainingPackAssetLoader.loadAll',
+        () => TrainingPackAssetLoader.instance.loadAll(),
+      );
+      await _run(
+        'PackLibraryLoaderService.loadLibrary',
+        () => PackLibraryLoaderService.instance.loadLibrary(),
+      );
+      await _run(
+        'TrainingPackLibraryV2.loadFromFolder',
+        () => TrainingPackLibraryV2.instance.loadFromFolder(),
+      );
     } catch (e, s) {
       ErrorLogger.instance.logError('Failed to load assets', e, s);
       rethrow;
@@ -74,12 +88,30 @@ class AppBootstrap {
 
   static Future<void> _initServices() async {
     try {
-      await _run('PackFavoriteService.load', () => PackFavoriteService.instance.load());
-      await _run('PackRatingService.load', () => PackRatingService.instance.load());
-      await _run('TrainingPackCommentsService.load', () => TrainingPackCommentsService.instance.load());
-      await _run('FavoritePackService.init', () => FavoritePackService.instance.init());
-      await _run('PinnedPackService.init', () => PinnedPackService.instance.init());
-      await _run('UserProfilePreferenceService.load', () => UserProfilePreferenceService.instance.load());
+      await _run(
+        'PackFavoriteService.load',
+        () => PackFavoriteService.instance.load(),
+      );
+      await _run(
+        'PackRatingService.load',
+        () => PackRatingService.instance.load(),
+      );
+      await _run(
+        'TrainingPackCommentsService.load',
+        () => TrainingPackCommentsService.instance.load(),
+      );
+      await _run(
+        'FavoritePackService.init',
+        () => FavoritePackService.instance.init(),
+      );
+      await _run(
+        'PinnedPackService.init',
+        () => PinnedPackService.instance.init(),
+      );
+      await _run(
+        'UserProfilePreferenceService.load',
+        () => UserProfilePreferenceService.instance.load(),
+      );
     } catch (e, s) {
       ErrorLogger.instance.logError('Failed to initialize services', e, s);
       rethrow;

--- a/lib/widgets/mistake_inline_theory_prompt.dart
+++ b/lib/widgets/mistake_inline_theory_prompt.dart
@@ -6,12 +6,14 @@ import '../services/inline_theory_linker_cache.dart';
 import '../services/analytics_service.dart';
 import '../screens/theory_lesson_viewer_screen.dart';
 
-typedef LessonMatchProvider = Future<List<TheoryMiniLessonNode>> Function(
-    List<String> tags);
-typedef AnalyticsLogger = Future<void> Function(
-    String event, Map<String, dynamic> params);
+typedef LessonMatchProvider =
+    Future<List<TheoryMiniLessonNode>> Function(List<String> tags);
+typedef AnalyticsLogger =
+    Future<void> Function(String event, Map<String, dynamic> params);
 
-Future<List<TheoryMiniLessonNode>> _defaultMatchProvider(List<String> tags) async {
+Future<List<TheoryMiniLessonNode>> _defaultMatchProvider(
+  List<String> tags,
+) async {
   final cache = InlineTheoryLinkerCache.instance;
   await cache.ensureReady();
   return cache.getMatchesForTags(tags);
@@ -27,6 +29,8 @@ class MistakeInlineTheoryPrompt extends StatefulWidget {
   final String spotId;
   final LessonMatchProvider matchProvider;
   final AnalyticsLogger log;
+  final void Function(String spotId, String packId, String? lessonId)?
+  onTheoryViewed;
 
   const MistakeInlineTheoryPrompt({
     super.key,
@@ -35,8 +39,9 @@ class MistakeInlineTheoryPrompt extends StatefulWidget {
     required this.spotId,
     LessonMatchProvider? matchProvider,
     AnalyticsLogger? log,
-  })  : matchProvider = matchProvider ?? _defaultMatchProvider,
-        log = log ?? _defaultLog;
+    this.onTheoryViewed,
+  }) : matchProvider = matchProvider ?? _defaultMatchProvider,
+       log = log ?? _defaultLog;
 
   @override
   State<MistakeInlineTheoryPrompt> createState() =>
@@ -77,6 +82,7 @@ class _MistakeInlineTheoryPromptState extends State<MistakeInlineTheoryPrompt> {
         fullscreenDialog: true,
       ),
     );
+    widget.onTheoryViewed?.call(widget.spotId, widget.packId, lesson.id);
   }
 
   Future<void> _open() async {

--- a/test/widgets/mistake_inline_theory_prompt_test.dart
+++ b/test/widgets/mistake_inline_theory_prompt_test.dart
@@ -24,34 +24,45 @@ void main() {
   group('MistakeInlineTheoryPrompt', () {
     testWidgets('shows and opens single lesson', (tester) async {
       SharedPreferences.setMockInitialValues({});
-      final lesson =
-          TheoryMiniLessonNode(id: 'l1', title: 'L1', content: 'c', tags: ['a']);
+      final lesson = TheoryMiniLessonNode(
+        id: 'l1',
+        title: 'L1',
+        content: 'c',
+        tags: ['a'],
+      );
       final provider = _FakeProvider([lesson]);
       final logger = _EventLogger();
 
-      await tester.pumpWidget(MaterialApp(
-        home: MistakeInlineTheoryPrompt(
-          tags: const ['a'],
-          packId: 'p1',
-          spotId: 's1',
-          matchProvider: provider.call,
-          log: logger.call,
+      await tester.pumpWidget(
+        MaterialApp(
+          home: MistakeInlineTheoryPrompt(
+            tags: const ['a'],
+            packId: 'p1',
+            spotId: 's1',
+            matchProvider: provider.call,
+            log: logger.call,
+          ),
         ),
-      ));
+      );
       await tester.pumpAndSettle();
 
       expect(find.text('Learn now (Theory • 1)'), findsOneWidget);
       expect(
-          logger.events.any((e) =>
-              e['event'] == 'theory_suggested_after_mistake' && e['count'] == 1),
-          isTrue);
+        logger.events.any(
+          (e) =>
+              e['event'] == 'theory_suggested_after_mistake' && e['count'] == 1,
+        ),
+        isTrue,
+      );
 
       await tester.tap(find.text('Learn now (Theory • 1)'));
       await tester.pumpAndSettle();
 
       expect(find.text('L1'), findsOneWidget);
       expect(
-          logger.events.any((e) => e['event'] == 'theory_link_opened'), isTrue);
+        logger.events.any((e) => e['event'] == 'theory_link_opened'),
+        isTrue,
+      );
     });
 
     testWidgets('shows list when multiple lessons', (tester) async {
@@ -63,15 +74,17 @@ void main() {
       final provider = _FakeProvider(lessons);
       final logger = _EventLogger();
 
-      await tester.pumpWidget(MaterialApp(
-        home: MistakeInlineTheoryPrompt(
-          tags: const ['a'],
-          packId: 'p1',
-          spotId: 's1',
-          matchProvider: provider.call,
-          log: logger.call,
+      await tester.pumpWidget(
+        MaterialApp(
+          home: MistakeInlineTheoryPrompt(
+            tags: const ['a'],
+            packId: 'p1',
+            spotId: 's1',
+            matchProvider: provider.call,
+            log: logger.call,
+          ),
         ),
-      ));
+      );
       await tester.pumpAndSettle();
 
       await tester.tap(find.text('Learn now (Theory • 2)'));
@@ -79,35 +92,44 @@ void main() {
 
       expect(find.text('L1'), findsOneWidget);
       expect(
-          logger.events.any((e) =>
-              e['event'] == 'theory_list_opened' && e['count'] == 2),
-          isTrue);
+        logger.events.any(
+          (e) => e['event'] == 'theory_list_opened' && e['count'] == 2,
+        ),
+        isTrue,
+      );
 
       await tester.tap(find.text('L1'));
       await tester.pumpAndSettle();
 
       expect(find.text('L1'), findsOneWidget);
       expect(
-          logger.events.where((e) => e['event'] == 'theory_link_opened').length,
-          1);
+        logger.events.where((e) => e['event'] == 'theory_link_opened').length,
+        1,
+      );
     });
 
     testWidgets('preference disables prompt', (tester) async {
       SharedPreferences.setMockInitialValues({});
-      final lesson =
-          TheoryMiniLessonNode(id: 'l1', title: 'L1', content: 'c', tags: ['a']);
+      final lesson = TheoryMiniLessonNode(
+        id: 'l1',
+        title: 'L1',
+        content: 'c',
+        tags: ['a'],
+      );
       final provider = _FakeProvider([lesson]);
       final logger = _EventLogger();
 
-      await tester.pumpWidget(MaterialApp(
-        home: MistakeInlineTheoryPrompt(
-          tags: const ['a'],
-          packId: 'p1',
-          spotId: 's1',
-          matchProvider: provider.call,
-          log: logger.call,
+      await tester.pumpWidget(
+        MaterialApp(
+          home: MistakeInlineTheoryPrompt(
+            tags: const ['a'],
+            packId: 'p1',
+            spotId: 's1',
+            matchProvider: provider.call,
+            log: logger.call,
+          ),
         ),
-      ));
+      );
       await tester.pumpAndSettle();
 
       await tester.tap(find.text("Don't show for this pack"));
@@ -115,18 +137,58 @@ void main() {
 
       expect(find.text('Learn now (Theory • 1)'), findsNothing);
 
-      await tester.pumpWidget(MaterialApp(
-        home: MistakeInlineTheoryPrompt(
-          tags: const ['a'],
-          packId: 'p1',
-          spotId: 's1',
-          matchProvider: provider.call,
-          log: logger.call,
+      await tester.pumpWidget(
+        MaterialApp(
+          home: MistakeInlineTheoryPrompt(
+            tags: const ['a'],
+            packId: 'p1',
+            spotId: 's1',
+            matchProvider: provider.call,
+            log: logger.call,
+          ),
         ),
-      ));
+      );
       await tester.pumpAndSettle();
 
       expect(find.text('Learn now (Theory • 1)'), findsNothing);
+    });
+
+    testWidgets('fires onTheoryViewed after closing lesson', (tester) async {
+      SharedPreferences.setMockInitialValues({});
+      final lesson = TheoryMiniLessonNode(
+        id: 'l1',
+        title: 'L1',
+        content: 'c',
+        tags: ['a'],
+      );
+      final provider = _FakeProvider([lesson]);
+      final logger = _EventLogger();
+      final viewed = <List<String?>>[];
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: MistakeInlineTheoryPrompt(
+            tags: const ['a'],
+            packId: 'p1',
+            spotId: 's1',
+            matchProvider: provider.call,
+            log: logger.call,
+            onTheoryViewed: (spot, pack, lessonId) {
+              viewed.add([spot, pack, lessonId]);
+            },
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Learn now (Theory • 1)'));
+      await tester.pumpAndSettle();
+      await tester.pageBack();
+      await tester.pumpAndSettle();
+
+      expect(viewed, [
+        ['s1', 'p1', 'l1'],
+      ]);
     });
   });
 }

--- a/test/widgets/training_play_screen_retest_after_theory_test.dart
+++ b/test/widgets/training_play_screen_retest_after_theory_test.dart
@@ -1,0 +1,248 @@
+import 'dart:collection';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/app_bootstrap.dart';
+import 'package:poker_analyzer/controllers/pack_run_controller.dart';
+import 'package:poker_analyzer/models/action_entry.dart';
+import 'package:poker_analyzer/models/card_model.dart';
+import 'package:poker_analyzer/models/evaluation_result.dart';
+import 'package:poker_analyzer/models/player_model.dart';
+import 'package:poker_analyzer/models/training_spot.dart';
+import 'package:poker_analyzer/models/training_spot_attempt.dart';
+import 'package:poker_analyzer/screens/training_play_screen.dart';
+import 'package:poker_analyzer/models/theory_mini_lesson_node.dart';
+import 'package:poker_analyzer/services/service_registry.dart';
+import 'package:poker_analyzer/services/training_session_controller.dart';
+import 'package:poker_analyzer/services/training_session_fingerprint_service.dart';
+import 'package:poker_analyzer/models/recall_snippet_result.dart';
+import 'package:poker_analyzer/services/user_action_logger.dart';
+import '../test_stubs.dart';
+
+class _FakeFingerprintService extends TrainingSessionFingerprintService {
+  @override
+  Future<String> startSession() async => 's1';
+
+  @override
+  Future<void> logAttempt(
+    TrainingSpotAttempt attempt, {
+    List<String> shownTheoryTags = const [],
+  }) async {}
+}
+
+class _FakePackRunController extends PackRunController {
+  _FakePackRunController() : super(packId: 'p1', sessionId: 's1', state: null);
+
+  @override
+  Future<RecallSnippetResult?> onResult(
+    String spotId,
+    bool correct,
+    List<String> tags,
+  ) async => null;
+}
+
+class _FakeTrainingSessionController extends TrainingSessionController {
+  final Queue<EvaluationResult> _queue;
+  _FakeTrainingSessionController(this._queue)
+    : super(registry: ServiceRegistry(), packId: 'p1');
+
+  void setSpot(TrainingSpot spot) => replaySpot(spot);
+
+  @override
+  Future<EvaluationResult> evaluateSpot(
+    BuildContext context,
+    TrainingSpot spot,
+    String userAction, {
+    int attempts = 3,
+  }) async {
+    return _queue.removeFirst();
+  }
+}
+
+TrainingSpot _spot() => TrainingSpot(
+  playerCards: const [[], []],
+  boardCards: const [],
+  actions: const <ActionEntry>[],
+  heroIndex: 0,
+  numberOfPlayers: 2,
+  playerTypes: const [PlayerType.unknown, PlayerType.unknown],
+  positions: const ['SB', 'BB'],
+  stacks: const [10, 10],
+  tags: const ['a'],
+);
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('TrainingPlayScreen retry after theory', () {
+    testWidgets('shows CTA and retries after tap', (tester) async {
+      SharedPreferences.setMockInitialValues({
+        'auto_retest_after_theory': false,
+      });
+      await UserActionLogger.instance.load();
+      AppBootstrap.testRegistry = ServiceRegistry()
+        ..register<TrainingSessionFingerprintService>(
+          _FakeFingerprintService(),
+        );
+
+      final queue = Queue<EvaluationResult>()
+        ..add(
+          EvaluationResult(
+            correct: false,
+            expectedAction: 'FOLD',
+            userEquity: 0,
+            expectedEquity: 0,
+          ),
+        )
+        ..add(
+          EvaluationResult(
+            correct: true,
+            expectedAction: 'FOLD',
+            userEquity: 0,
+            expectedEquity: 0,
+          ),
+        );
+      final controller = _FakeTrainingSessionController(queue)
+        ..setSpot(_spot());
+
+      final lesson = TheoryMiniLessonNode(
+        id: 'l1',
+        title: 'L1',
+        content: 'c',
+        tags: const ['a'],
+      );
+
+      await tester.pumpWidget(
+        Provider<TrainingSessionController>.value(
+          value: controller,
+          child: MaterialApp(
+            home: TrainingPlayScreen(
+              packController: _FakePackRunController(),
+              lessonMatchProvider: (_) async => [lesson],
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('PUSH'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Learn now (Theory • 1)'));
+      await tester.pumpAndSettle();
+      await tester.pageBack();
+      await tester.pumpAndSettle();
+
+      expect(find.text('Retry now'), findsOneWidget);
+      await tester.tap(find.text('Retry now'));
+      await tester.pumpAndSettle();
+      expect(find.text('PUSH'), findsOneWidget);
+
+      await tester.tap(find.text('FOLD'));
+      await tester.pumpAndSettle();
+
+      final events = UserActionLogger.instance.events;
+      expect(
+        events.any((e) => e['event'] == 'retest_suggested_after_theory'),
+        isTrue,
+      );
+      expect(
+        events.any((e) => e['event'] == 'retest_started_after_theory'),
+        isTrue,
+      );
+      expect(
+        events.any(
+          (e) =>
+              e['event'] == 'retest_outcome_after_theory' &&
+              e['success'] == true,
+        ),
+        isTrue,
+      );
+    });
+
+    testWidgets('auto-retest triggers instantly', (tester) async {
+      SharedPreferences.setMockInitialValues({
+        'auto_retest_after_theory': true,
+      });
+      await UserActionLogger.instance.load();
+      AppBootstrap.testRegistry = ServiceRegistry()
+        ..register<TrainingSessionFingerprintService>(
+          _FakeFingerprintService(),
+        );
+
+      final queue = Queue<EvaluationResult>()
+        ..add(
+          EvaluationResult(
+            correct: false,
+            expectedAction: 'FOLD',
+            userEquity: 0,
+            expectedEquity: 0,
+          ),
+        )
+        ..add(
+          EvaluationResult(
+            correct: true,
+            expectedAction: 'FOLD',
+            userEquity: 0,
+            expectedEquity: 0,
+          ),
+        );
+      final controller = _FakeTrainingSessionController(queue)
+        ..setSpot(_spot());
+
+      final lesson = TheoryMiniLessonNode(
+        id: 'l1',
+        title: 'L1',
+        content: 'c',
+        tags: const ['a'],
+      );
+
+      await tester.pumpWidget(
+        Provider<TrainingSessionController>.value(
+          value: controller,
+          child: MaterialApp(
+            home: TrainingPlayScreen(
+              packController: _FakePackRunController(),
+              lessonMatchProvider: (_) async => [lesson],
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('PUSH'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Learn now (Theory • 1)'));
+      await tester.pumpAndSettle();
+      await tester.pageBack();
+      await tester.pumpAndSettle();
+
+      expect(find.text('Retry now'), findsNothing);
+      expect(find.text('PUSH'), findsOneWidget);
+
+      await tester.tap(find.text('FOLD'));
+      await tester.pumpAndSettle();
+
+      final events = UserActionLogger.instance.events;
+      expect(
+        events.any((e) => e['event'] == 'retest_suggested_after_theory'),
+        isTrue,
+      );
+      expect(
+        events.any((e) => e['event'] == 'retest_started_after_theory'),
+        isTrue,
+      );
+      expect(
+        events.any(
+          (e) =>
+              e['event'] == 'retest_outcome_after_theory' &&
+              e['success'] == true,
+        ),
+        isTrue,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add callback on theory prompts and notify when lessons close
- offer Retry now CTA with optional Auto-retest toggle in play screen
- expose test registry setter for easier service injection

## Testing
- `flutter analyze` *(fails: file_picker plugins and numerous missing references)*
- `flutter test test/widgets/mistake_inline_theory_prompt_test.dart test/widgets/training_play_screen_retest_after_theory_test.dart` *(fails: missing files and compile errors)*

------
https://chatgpt.com/codex/tasks/task_e_689aa762d5e0832aaeae06ee4cadd18f