### PR TITLE
feat: introduce spaced review service for mistakes

### DIFF
--- a/lib/providers/training_providers.dart
+++ b/lib/providers/training_providers.dart
@@ -13,6 +13,7 @@ import '../services/real_time_stack_range_service.dart';
 import '../services/progress_forecast_service.dart';
 import '../services/mistake_review_pack_service.dart';
 import '../services/dynamic_pack_adjustment_service.dart';
+import '../services/spaced_review_service.dart';
 import '../services/mistake_streak_service.dart';
 import '../services/session_note_service.dart';
 import '../services/session_pin_service.dart';
@@ -162,6 +163,11 @@ List<SingleChildWidget> buildTrainingProviders() {
       create: (context) => MistakeReviewPackService(
         hands: context.read<SavedHandManagerService>(),
         cloud: mistakeCloud,
+      )..init(),
+    ),
+    ChangeNotifierProvider(
+      create: (context) => SpacedReviewService(
+        templates: context.read<TemplateStorageService>(),
       )..init(),
     ),
     Provider(

--- a/lib/screens/training_home_screen.dart
+++ b/lib/screens/training_home_screen.dart
@@ -11,6 +11,7 @@ import '../services/training_pack_stats_service.dart';
 import '../services/adaptive_training_service.dart';
 import '../services/mistake_review_pack_service.dart';
 import '../services/dynamic_pack_adjustment_service.dart';
+import '../services/spaced_review_service.dart';
 import 'training_session_screen.dart';
 import '../services/weak_spot_recommendation_service.dart';
 import '../services/daily_spotlight_service.dart';
@@ -274,6 +275,8 @@ class _RecommendedCarouselState extends State<_RecommendedCarousel> {
         .read<WeakSpotRecommendationService>()
         .buildPack();
     if (weak != null) list.insert(0, weak);
+    final sr = await context.read<SpacedReviewService>().duePack(log: false);
+    if (sr != null) list.insert(0, sr);
     final review = await MistakeReviewPackService.latestTemplate(context);
     if (review != null) list.insert(0, review);
     final adjust = context.read<DynamicPackAdjustmentService>();
@@ -517,6 +520,9 @@ class _PackCard extends StatelessWidget {
             onPressed: completed
                 ? null
                 : () async {
+                    if (template.id == SpacedReviewService.dueTemplateId) {
+                      await context.read<SpacedReviewService>().logDueOpened();
+                    }
                     await context.read<TrainingSessionService>().startSession(
                       template,
                     );

--- a/lib/screens/training_play_screen.dart
+++ b/lib/screens/training_play_screen.dart
@@ -20,6 +20,7 @@ import '../widgets/mistake_inline_theory_prompt.dart';
 import '../services/analytics_service.dart';
 import '../services/mistake_tag_classifier.dart';
 import '../services/user_error_rate_service.dart';
+import '../services/spaced_review_service.dart';
 
 class TrainingPlayScreen extends StatefulWidget {
   final LessonMatchProvider? lessonMatchProvider;
@@ -157,6 +158,13 @@ class _TrainingPlayScreenState extends State<TrainingPlayScreen> {
       isCorrect: res.correct,
       ts: DateTime.now(),
     );
+    if (!res.correct) {
+      await context
+          .read<SpacedReviewService>()
+          .recordMistake(spot.id, controller.template?.id ?? controller.packId);
+    }
+    await context.read<SpacedReviewService>().recordReviewOutcome(
+          spot.id, controller.template?.id ?? controller.packId, res.correct);
     await AppBootstrap.registry
         .get<TrainingSessionFingerprintService>()
         .logAttempt(attempt, shownTheoryTags: tags.toList());

--- a/lib/screens/v2/training_pack_play_screen_v2.dart
+++ b/lib/screens/v2/training_pack_play_screen_v2.dart
@@ -5,6 +5,7 @@ import '../../services/app_settings_service.dart';
 import '../../services/user_preferences_service.dart';
 import '../../services/adaptive_spot_scheduler.dart';
 import '../../services/user_error_rate_service.dart';
+import '../../services/spaced_review_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class TrainingPackPlayScreenV2 extends TrainingPackPlayBase {
@@ -700,12 +701,18 @@ class _TrainingPackPlayScreenV2State
         await context
             .read<MistakeReviewPackService>()
             .addSpot(widget.original, spot);
+        await context
+            .read<SpacedReviewService>()
+            .recordMistake(spot.id, widget.template.id);
         if (mounted) {
           ScaffoldMessenger.of(context).showSnackBar(
             const SnackBar(content: Text('Сохранено в Повторы ошибок')),
           );
         }
       }
+      await context
+          .read<SpacedReviewService>()
+          .recordReviewOutcome(spot.id, widget.template.id, !incorrect);
       if (_autoAdvance && !incorrect) {
         await Future.delayed(const Duration(seconds: 2));
         if (!mounted) return;

--- a/lib/services/spaced_review_service.dart
+++ b/lib/services/spaced_review_service.dart
@@ -1,0 +1,214 @@
+import 'dart:convert';
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:collection/collection.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/v2/training_pack_template.dart';
+import '../models/v2/training_pack_spot.dart';
+import 'template_storage_service.dart';
+import 'user_error_rate_service.dart';
+import 'notification_service.dart';
+import 'analytics_service.dart';
+
+class _SRItem {
+  String packId;
+  int box;
+  int due; // epoch day
+  int last; // epoch seconds
+  _SRItem({required this.packId, required this.box, required this.due, required this.last});
+
+  Map<String, dynamic> toJson() => {
+        'p': packId,
+        'b': box,
+        'd': due,
+        'l': last,
+      };
+
+  static _SRItem fromJson(Map<String, dynamic> json) => _SRItem(
+        packId: json['p'] as String,
+        box: json['b'] as int,
+        due: json['d'] as int,
+        last: json['l'] as int,
+      );
+}
+
+class SpacedReviewService extends ChangeNotifier {
+  SpacedReviewService({required this.templates});
+
+  static const String dueTemplateId = 'sr_due_pack';
+  static const _prefsKey = 'sr_v1';
+  static const _intervals = [1, 3, 7, 14, 30];
+  static const _notifId = 104;
+
+  final TemplateStorageService templates;
+  final Map<String, _SRItem> _data = {};
+  bool _loaded = false;
+
+  Future<void> init() async {
+    await _load();
+    await _scheduleNotification();
+  }
+
+  Future<void> _load() async {
+    if (_loaded) return;
+    final prefs = await SharedPreferences.getInstance();
+    final str = prefs.getString(_prefsKey);
+    if (str != null) {
+      final raw = jsonDecode(str) as Map<String, dynamic>;
+      raw.forEach((k, v) {
+        _data[k] = _SRItem.fromJson(Map<String, dynamic>.from(v));
+      });
+    }
+    _loaded = true;
+  }
+
+  Future<void> _save() async {
+    final prefs = await SharedPreferences.getInstance();
+    final map = <String, dynamic>{};
+    _data.forEach((k, v) => map[k] = v.toJson());
+    await prefs.setString(_prefsKey, jsonEncode(map));
+  }
+
+  int _epochDay(DateTime d) => d.toUtc().millisecondsSinceEpoch ~/ 86400000;
+  int _epochSec(DateTime d) => d.toUtc().millisecondsSinceEpoch ~/ 1000;
+
+  Future<void> recordMistake(String spotId, String packId) async {
+    await _load();
+    final now = DateTime.now();
+    _data[spotId] = _SRItem(
+      packId: packId,
+      box: 1,
+      due: _epochDay(now) + 1,
+      last: _epochSec(now),
+    );
+    await _save();
+    unawaited(AnalyticsService.instance
+        .logEvent('sr_enqueued', {'spotId': spotId, 'packId': packId}));
+    await _scheduleNotification();
+    notifyListeners();
+  }
+
+  Future<void> recordReviewOutcome(
+      String spotId, String packId, bool correct) async {
+    await _load();
+    final entry = _data[spotId];
+    if (entry == null) return;
+    final now = DateTime.now();
+    final boxFrom = entry.box;
+    double avg = 0.0;
+    if (correct) {
+      final tags = _spotTags(packId, spotId).toSet();
+      final rates = await UserErrorRateService.instance
+          .getRates(packId: packId, tags: tags);
+      if (rates.isNotEmpty) {
+        avg = rates.values.reduce((a, b) => a + b) / rates.length;
+      }
+      var nextBox = entry.box + 1;
+      if (avg < 0.15) nextBox += 1;
+      final maxBox = avg > 0.5 ? 3 : 5;
+      if (nextBox > maxBox) nextBox = maxBox;
+      entry.box = nextBox;
+      entry.due = _epochDay(now) + _intervals[entry.box - 1];
+    } else {
+      entry.box = 1;
+      entry.due = _epochDay(now) + 1;
+    }
+    entry.last = _epochSec(now);
+    await _save();
+    unawaited(AnalyticsService.instance.logEvent('sr_review_outcome', {
+      'spotId': spotId,
+      'packId': packId,
+      'boxFrom': boxFrom,
+      'boxTo': entry.box,
+      'ewmaBefore': avg,
+      'correct': correct,
+    }));
+    await _scheduleNotification();
+    notifyListeners();
+  }
+
+  List<String> dueSpotIds(DateTime today, {int limit = 10}) {
+    final day = _epochDay(today);
+    final entries = _data.entries
+        .where((e) => e.value.due <= day)
+        .toList()
+      ..sort((a, b) => a.value.due.compareTo(b.value.due));
+    return entries.take(limit).map((e) => e.key).toList();
+  }
+
+  int dueCount(DateTime today) {
+    final day = _epochDay(today);
+    return _data.values.where((e) => e.due <= day).length;
+  }
+
+  Future<TrainingPackTemplate?> duePack({int limit = 10, bool log = true}) async {
+    await _load();
+    final ids = dueSpotIds(DateTime.now(), limit: limit);
+    if (ids.isEmpty) return null;
+    final map = <String, TrainingPackSpot>{};
+    for (final t in templates.templates) {
+      for (final s in t.spots) {
+        map[s.id] = s;
+      }
+    }
+    final spots = <TrainingPackSpot>[];
+    for (final id in ids) {
+      final s = map[id];
+      if (s != null) {
+        spots.add(TrainingPackSpot.fromJson(s.toJson()));
+      }
+    }
+    if (spots.isEmpty) return null;
+    if (log) {
+      unawaited(AnalyticsService.instance
+          .logEvent('sr_due_opened', {'count': spots.length}));
+    }
+    return TrainingPackTemplate(
+      id: dueTemplateId,
+      name: 'Review Mistakes',
+      createdAt: DateTime.now(),
+      spots: spots,
+    );
+  }
+
+  Future<void> logDueOpened() async {
+    await _load();
+    unawaited(AnalyticsService.instance
+        .logEvent('sr_due_opened', {'count': dueCount(DateTime.now())}));
+  }
+
+  Future<void> _scheduleNotification() async {
+    try {
+      final now = DateTime.now();
+      var when = DateTime(now.year, now.month, now.day, 10);
+      var dayFor = now;
+      if (when.isBefore(now)) {
+        when = when.add(const Duration(days: 1));
+        dayFor = dayFor.add(const Duration(days: 1));
+      }
+      final count = dueCount(dayFor);
+      if (count > 0) {
+        await NotificationService.schedule(
+            id: _notifId,
+            when: when,
+            body: 'You have $count reviews due');
+      } else {
+        await NotificationService.cancel(_notifId);
+      }
+    } catch (_) {}
+  }
+
+  List<String> _spotTags(String packId, String spotId) {
+    final tpl = templates.templates.firstWhereOrNull((t) => t.id == packId);
+    final spot = tpl?.spots.firstWhereOrNull((s) => s.id == spotId);
+    return spot?.tags ?? const <String>[];
+  }
+
+  @visibleForTesting
+  _SRItem? debugEntry(String spotId) => _data[spotId];
+
+  @visibleForTesting
+  int debugEpochDay(DateTime d) => _epochDay(d);
+}

--- a/test/services/spaced_review_service_test.dart
+++ b/test/services/spaced_review_service_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/services/spaced_review_service.dart';
+import 'package:poker_analyzer/services/template_storage_service.dart';
+import 'package:poker_analyzer/services/user_error_rate_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await UserErrorRateService.instance.reset();
+  });
+
+  test('recordMistake and promotion/demotion', () async {
+    final svc = SpacedReviewService(templates: TemplateStorageService());
+    await svc.init();
+    await svc.recordMistake('s1', 'p1');
+    final entry = svc.debugEntry('s1')!;
+    final today = svc.debugEpochDay(DateTime.now());
+    expect(entry.box, 1);
+    expect(entry.due, today + 1);
+
+    await svc.recordReviewOutcome('s1', 'p1', true);
+    final entry2 = svc.debugEntry('s1')!;
+    expect(entry2.box, 3);
+    expect(entry2.due, today + 7);
+
+    await svc.recordReviewOutcome('s1', 'p1', false);
+    final entry3 = svc.debugEntry('s1')!;
+    expect(entry3.box, 1);
+    expect(entry3.due, today + 1);
+  });
+
+  test('dueSpotIds filters by today', () async {
+    final svc = SpacedReviewService(templates: TemplateStorageService());
+    await svc.init();
+    await svc.recordMistake('a', 'p1');
+    await svc.recordMistake('b', 'p1');
+    svc.debugEntry('b')!.due =
+        svc.debugEpochDay(DateTime.now().subtract(const Duration(days: 1)));
+    final dueToday = svc.dueSpotIds(DateTime.now());
+    expect(dueToday, contains('b'));
+    expect(dueToday, isNot(contains('a')));
+  });
+
+  test('ewma high clamps box', () async {
+    final svc = SpacedReviewService(templates: TemplateStorageService());
+    await svc.init();
+    for (var i = 0; i < 3; i++) {
+      await UserErrorRateService.instance.recordAttempt(
+          packId: 'p2', tags: {'t'}, isCorrect: false, ts: DateTime.now());
+    }
+    await svc.recordMistake('s2', 'p2');
+    await svc.recordReviewOutcome('s2', 'p2', true);
+    final entry = svc.debugEntry('s2')!;
+    expect(entry.box, lessThanOrEqualTo(3));
+  });
+}


### PR DESCRIPTION
## Summary
- add SpacedReviewService to schedule mistake reviews with interval boxes and EWMA-aware promotions
- log mistakes and review outcomes in training screens
- surface daily spaced-review micro-pack on home screen

## Testing
- `flutter test test/services/spaced_review_service_test.dart` *(fails: command not found)*
- `dart test test/services/spaced_review_service_test.dart` *(fails: command not found)*
- `apt-get install -y dart` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689ab13b5e74832a964f902e54b083e1