### PR TITLE
Guard SR queue build and clean unused variable

### DIFF
--- a/lib/screens/v2/training_pack_play_screen_v2.dart
+++ b/lib/screens/v2/training_pack_play_screen_v2.dart
@@ -113,14 +113,16 @@ class _TrainingPackPlayScreenV2State
       await _startNew();
     }
     final sr = context.read<SpacedReviewService>();
-    final queue = buildSrQueue(
-      sr,
-      {
-        ..._spots.map((s) => s.id),
-        ..._pool.map((s) => s.id),
-        ...widget.template.spots.map((s) => s.id),
-      }.toSet(),
-    );
+    final queue = _srEnabled
+        ? buildSrQueue(
+            sr,
+            {
+              ..._spots.map((s) => s.id),
+              ..._pool.map((s) => s.id),
+              ...widget.template.spots.map((s) => s.id),
+            }.toSet(),
+          )
+        : const <SRQueueItem>[];
     setState(() {
       _srQueue
         ..clear()
@@ -892,7 +894,6 @@ class _TrainingPackPlayScreenV2State
     final width = MediaQuery.of(context).size.width;
     final scale = (width / 375).clamp(0.8, 1.0);
     final spot = _srCurrent?.spot ?? _spots[_index];
-    final progress = (_index + 1) / _spots.length;
     final actions = _heroActions(spot);
     final pushAction = actions.isEmpty ? 'push' : actions.first;
     return Scaffold(


### PR DESCRIPTION
## Summary
- Only build spaced review queue when interleave is enabled
- Remove unused `progress` variable in training screen

## Testing
- `flutter analyze` *(fails: The current Dart SDK version is 3.3.4. Because poker_analyzer requires SDK version >=3.6.0 <4.0.0)*
- `flutter test` *(fails: The current Dart SDK version is 3.5.0-70.0.dev. Because poker_analyzer requires SDK version >=3.6.0 <4.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_689ab8632834832ab0d221589288d841