### PR TITLE
chore: drop stray import and align SDK floor

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -63,3 +63,6 @@ analyzer:
 linter:
   rules:
     # без строгих правил до момента, когда вернёмся к сервисам
+    avoid_unused_constructor_parameters: true
+    unnecessary_import: true
+    unused_local_variable: true

--- a/lib/screens/v2/training_pack_play_screen_v2.dart
+++ b/lib/screens/v2/training_pack_play_screen_v2.dart
@@ -11,7 +11,6 @@ import '../../services/user_error_rate_service.dart';
 import '../../services/spaced_review_service.dart';
 import '../../services/sr_queue_builder.dart';
 import '../../services/pinned_learning_service.dart';
-import 'package:collection/collection.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class TrainingPackPlayScreenV2 extends TrainingPackPlayBase {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: 'none' # Remove this line if you want to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=3.6.0 <4.0.0"
+  sdk: ">=3.3.0 <4.0.0"
 
 executables:
   batch_generate: bin/batch_generate.dart


### PR DESCRIPTION
## Summary
- remove unused SharedPreferences import reference to collection? Wait: remove unused collection import
- relax Dart SDK constraint to 3.3.0 and add lint rules to flag unused constructs

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689abb25e1b8832a8ef42e42378b72c5