### PR TITLE
chore: enable unused import lints

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -48,9 +48,7 @@ analyzer:
     undefined_prefixed_name: ignore
     # и типовой «линт-шум»
     dead_code: ignore
-    unused_import: ignore
     unused_element: ignore
-    unnecessary_import: ignore
     prefer_const_constructors: ignore
     prefer_final_fields: ignore
     prefer_const_literals_to_create_immutables: ignore


### PR DESCRIPTION
## Summary
- stop ignoring unused and unnecessary imports in analysis options

## Testing
- `dart analyze lib/screens/v2/training_pack_play_screen_v2.dart` *(fails: command not found)*
- `apt-get install -y dart` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689abc996378832a8d100f3e65fbdf89