### PR TITLE
Assert presence of fold in push/fold guard

### DIFF
--- a/lib/screens/v2/training_pack_play_screen_v2.dart
+++ b/lib/screens/v2/training_pack_play_screen_v2.dart
@@ -870,11 +870,14 @@ class _TrainingPackPlayScreenV2State
     // Debug guard: this screen assumes push/fold UI; trip in dev if a non-P/F spot slips in.
     assert(() {
       final acts = spot.hand.actions[_currentStreet] ?? const [];
+      final heroIdx = spot.hand.heroIndex;
       final hasPush = acts.any((a) =>
-          a.playerIndex == spot.hand.heroIndex &&
-          a.action.toLowerCase() == 'push');
-      return hasPush;
-    }(), 'Expected push/fold spot; missing "push" action for hero on current street');
+          a.playerIndex == heroIdx && a.action.toLowerCase() == 'push');
+      final hasFold = acts.any((a) =>
+          a.playerIndex != heroIdx && a.action.toLowerCase() == 'fold');
+      return hasPush && hasFold;
+    }(),
+        'Expected push/fold spot; missing "push" or "fold" action for players on current street');
 
     return Scaffold(
       backgroundColor: const Color(0xFF1B1C1E),


### PR DESCRIPTION
## Summary
- strengthen push/fold guard by asserting a villain fold in addition to hero push

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689acc37b62c832ab7801cc1c0088675