### PR TITLE
Filter SR queue by modality and guard push/fold spots

### DIFF
--- a/lib/services/sr_queue_builder.dart
+++ b/lib/services/sr_queue_builder.dart
@@ -14,6 +14,7 @@ List<SRQueueItem> buildSrQueue(
   Set<String> baseSpotIds, {
   DateTime? now,
   int limit = 50,
+  String? modalityTag,
 }) {
   final ids = service.dueSpotIds(now ?? DateTime.now(), limit: limit);
   final res = <SRQueueItem>[];
@@ -21,8 +22,11 @@ List<SRQueueItem> buildSrQueue(
     if (baseSpotIds.contains(id)) continue;
     final packId = service.packIdForSpot(id);
     if (packId == null) continue;
-    final tpl = service.templates.templates.firstWhereOrNull((t) => t.id == packId);
-    final s = tpl?.spots.firstWhereOrNull((s) => s.id == id);
+    final tpl =
+        service.templates.templates.firstWhereOrNull((t) => t.id == packId);
+    if (tpl == null) continue;
+    if (modalityTag != null && !tpl.tags.contains(modalityTag)) continue;
+    final s = tpl.spots.firstWhereOrNull((s) => s.id == id);
     if (s != null) {
       res.add(
         SRQueueItem(

--- a/test/services/sr_queue_builder_test.dart
+++ b/test/services/sr_queue_builder_test.dart
@@ -32,4 +32,39 @@ void main() {
     queue.removeAt(0);
     expect(queue.isEmpty, true);
   });
+
+  test('buildSrQueue filters by modality tag', () async {
+    final storage = TemplateStorageService();
+    final spot1 = TrainingPackSpot(id: 's1');
+    final spot2 = TrainingPackSpot(id: 's2');
+    storage
+      ..addTemplate(
+        TrainingPackTemplate(
+          id: 'p1',
+          name: 'P1',
+          createdAt: DateTime.now(),
+          spots: [spot1],
+          tags: ['pushfold'],
+        ),
+      )
+      ..addTemplate(
+        TrainingPackTemplate(
+          id: 'p2',
+          name: 'P2',
+          createdAt: DateTime.now(),
+          spots: [spot2],
+        ),
+      );
+    final svc = SpacedReviewService(templates: storage);
+    await svc.recordMistake('s1', 'p1');
+    await svc.recordMistake('s2', 'p2');
+    final queue = buildSrQueue(
+      svc,
+      {},
+      now: DateTime.now().add(const Duration(days: 1)),
+      modalityTag: 'pushfold',
+    );
+    expect(queue.length, 1);
+    expect(queue.first.spot.id, 's1');
+  });
 }


### PR DESCRIPTION
## Summary
- filter spaced-review queue to match push/fold packs
- add typed action checks with graceful fallback for non push/fold spots
- test SR queue filtering by modality tag

## Testing
- `dart test` *(fails: Flutter SDK is not available)*

------
https://chatgpt.com/codex/tasks/task_e_689acd70d0e4832a83cb2b6966103ed5