### PR TITLE
feat: normalize pushfold actions

### DIFF
--- a/test/push_fold_helpers_test.dart
+++ b/test/push_fold_helpers_test.dart
@@ -1,0 +1,31 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/screens/v2/training_pack_play_screen_v2.dart';
+import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
+import 'package:poker_analyzer/models/v2/hand_data.dart';
+import 'package:poker_analyzer/models/action_entry.dart';
+import 'package:poker_analyzer/models/v2/training_pack_template.dart';
+
+void main() {
+  final template = TrainingPackTemplate(id: 't', name: 'T');
+  final screen = TrainingPackPlayScreenV2(template: template, spots: const []);
+  final state = screen.createState() as dynamic;
+
+  test('normalize maps shove/all-in to push', () {
+    expect(state._normalize('shove'), 'push');
+    expect(state._normalize('all-in'), 'push');
+    expect(state._normalize('fold'), 'fold');
+  });
+
+  test('_actsForStreet returns [] for OOR', () {
+    final spot = TrainingPackSpot(
+      id: 's',
+      hand: HandData(
+        actions: {
+          0: [ActionEntry(0, 0, 'push'), ActionEntry(0, 1, 'fold')],
+        },
+      ),
+    );
+    final res = state._actsForStreet(spot, 5) as List<ActionEntry>;
+    expect(res, isEmpty);
+  });
+}


### PR DESCRIPTION
## Summary
- make push/fold action parsing alias-safe and bounds-safe
- add helper tests for push/fold normalization and bounds

## Testing
- `dart test test/push_fold_helpers_test.dart` *(fails: Because poker_analyzer depends on flutter_test from sdk which doesn't exist (the Flutter SDK is not available))*
- `dart analyze lib/screens/v2/training_pack_play_screen_v2.dart test/push_fold_helpers_test.dart` *(fails: Target of URI doesn't exist: 'package:shared_preferences/shared_preferences.dart' and other missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_689acf249374832a9d503f573f85e59f