### PR TITLE
fix: add missing localization import and simplify push/fould tests

### DIFF
--- a/lib/screens/v2/training_pack_play_screen_v2.dart
+++ b/lib/screens/v2/training_pack_play_screen_v2.dart
@@ -13,6 +13,7 @@ import '../../services/spaced_review_service.dart';
 import '../../services/sr_queue_builder.dart';
 import '../../services/pinned_learning_service.dart';
 import '../../utils/push_fold.dart';
+import '../../l10n/app_localizations.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../../models/action_entry.dart';
 

--- a/test/push_fold_helpers_test.dart
+++ b/test/push_fold_helpers_test.dart
@@ -1,7 +1,5 @@
 import 'package:test/test.dart';
 import 'package:poker_analyzer/utils/push_fold.dart';
-import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
-import 'package:poker_analyzer/models/v2/hand_data.dart';
 import 'package:poker_analyzer/models/action_entry.dart';
 
 void main() {
@@ -12,29 +10,17 @@ void main() {
   });
 
   test('actionsForStreet returns [] for OOR', () {
-    final spot = TrainingPackSpot(
-      id: 's',
-      hand: HandData(
-        actions: {
-          0: [ActionEntry(0, 0, 'push'), ActionEntry(0, 1, 'fold')],
-        },
-      ),
-    );
-    final res = actionsForStreet(spot.hand.actions, 5);
+    final actions = {
+      0: [ActionEntry(0, 0, 'push'), ActionEntry(0, 1, 'fold')],
+    };
+    final res = actionsForStreet(actions, 5);
     expect(res, isEmpty);
   });
 
   test('isPushFoldSpot detects hero push and villain fold', () {
-    final spot = TrainingPackSpot(
-      id: 's',
-      hand: HandData(
-        heroIndex: 0,
-        playerCount: 2,
-        actions: {
-          0: [ActionEntry(0, 0, 'push'), ActionEntry(0, 1, 'fold')],
-        },
-      ),
-    );
-    expect(isPushFoldSpot(spot.hand.actions, 0, 0), isTrue);
+    final actions = {
+      0: [ActionEntry(0, 0, 'push'), ActionEntry(0, 1, 'fold')],
+    };
+    expect(isPushFoldSpot(actions, 0, 0), isTrue);
   });
 }


### PR DESCRIPTION
## Summary
- import AppLocalizations in training_pack_play_screen_v2
- streamline push fold helper tests to avoid Flutter widget dependencies

## Testing
- `flutter test test/push_fold_helpers_test.dart` *(fails: Because every version of flutter_localizations from sdk depends on intl 0.19.0 and poker_analyzer depends on intl ^0.20.2, flutter_localizations from sdk is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689ad52b79ec832aafce711b7b773ad7