### PR TITLE
chore: remove unused ActionEntry import

### DIFF
--- a/lib/screens/v2/training_pack_play_screen_v2.dart
+++ b/lib/screens/v2/training_pack_play_screen_v2.dart
@@ -15,7 +15,6 @@ import '../../services/pinned_learning_service.dart';
 import '../../utils/push_fold.dart';
 import '../../l10n/app_localizations.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import '../../models/action_entry.dart';
 
 class TrainingPackPlayScreenV2 extends TrainingPackPlayBase {
   const TrainingPackPlayScreenV2({
@@ -511,22 +510,7 @@ class _TrainingPackPlayScreenV2State
     final boardCards = [
       for (final c in hand.board) CardModel(rank: c[0], suit: c.substring(1)),
     ];
-    final actions = <ActionEntry>[];
-    for (final list in hand.actions.values) {
-      for (final a in list) {
-        actions.add(
-          ActionEntry(
-            a.street,
-            a.playerIndex,
-            a.action,
-            amount: a.amount,
-            generated: a.generated,
-            manualEvaluation: a.manualEvaluation,
-            customLabel: a.customLabel,
-          ),
-        );
-      }
-    }
+    final actions = hand.actions.values.expand((list) => list).toList();
     final stacks = [
       for (var i = 0; i < hand.playerCount; i++)
         hand.stacks['$i']?.round() ?? 0,


### PR DESCRIPTION
## Summary
- drop leftover ActionEntry import from training pack play screen
- flatten hand actions using expand to avoid manual copies

## Testing
- `dart format lib/screens/v2/training_pack_play_screen_v2.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)
- `flutter test` *(fails: command not found)
- `apt-get install -y dart` *(fails: unable to locate package)*
- `apt-get install -y flutter` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689adbc3d5d0832a94fbfa8df68a741a