### PR TITLE
Deep-copy ActionEntry in _toSpot to avoid shared state

### DIFF
--- a/lib/models/action_entry.dart
+++ b/lib/models/action_entry.dart
@@ -58,4 +58,21 @@ class ActionEntry {
   factory ActionEntry.fromJson(Map<String, dynamic> j) =>
       _$ActionEntryFromJson(j);
   Map<String, dynamic> toJson() => _$ActionEntryToJson(this);
+
+  /// Creates a copy of this [ActionEntry].
+  ActionEntry copy() => ActionEntry(
+        street,
+        playerIndex,
+        action,
+        amount: amount,
+        generated: generated,
+        manualEvaluation: manualEvaluation,
+        customLabel: customLabel,
+        timestamp: timestamp,
+        potAfter: potAfter,
+        potOdds: potOdds,
+        equity: equity,
+        ev: ev,
+        icmEv: icmEv,
+      );
 }

--- a/lib/screens/v2/training_pack_play_screen_v2.dart
+++ b/lib/screens/v2/training_pack_play_screen_v2.dart
@@ -511,8 +511,9 @@ class _TrainingPackPlayScreenV2State
     final boardCards = [
       for (final c in hand.board) CardModel(rank: c[0], suit: c.substring(1)),
     ];
-    final actions = hand.actions.values
-        .expand((list) => list.map((a) => ActionEntry.fromJson(a.toJson())))
+    // Deep copy actions to avoid mutating original hand data in result screen
+    final List<ActionEntry> actions = hand.actions.values
+        .expand((list) => list.map((a) => a.copy()))
         .toList();
     final stacks = [
       for (var i = 0; i < hand.playerCount; i++)


### PR DESCRIPTION
## Summary
- add lightweight `copy` helper to `ActionEntry`
- use `copy` when building spot actions to avoid mutating original hand data

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b171bc470832a8fa8fad3482e90cc