### PR TITLE
Add ActionEntry copyWith and deep-copy documentation

### DIFF
--- a/lib/models/action_entry.dart
+++ b/lib/models/action_entry.dart
@@ -60,19 +60,73 @@ class ActionEntry {
   Map<String, dynamic> toJson() => _$ActionEntryToJson(this);
 
   /// Creates a copy of this [ActionEntry].
-  ActionEntry copy() => ActionEntry(
+  ActionEntry copy() => copyWith();
+
+  /// Returns a copy of this [ActionEntry] with the given fields replaced.
+  ActionEntry copyWith({
+    int? street,
+    int? playerIndex,
+    String? action,
+    double? amount,
+    bool? generated,
+    String? manualEvaluation,
+    String? customLabel,
+    DateTime? timestamp,
+    double? potAfter,
+    double? potOdds,
+    double? equity,
+    double? ev,
+    double? icmEv,
+  }) =>
+      ActionEntry(
+        street ?? this.street,
+        playerIndex ?? this.playerIndex,
+        action ?? this.action,
+        amount: amount ?? this.amount,
+        generated: generated ?? this.generated,
+        manualEvaluation: manualEvaluation ?? this.manualEvaluation,
+        customLabel: customLabel ?? this.customLabel,
+        timestamp: timestamp ?? this.timestamp,
+        potAfter: potAfter ?? this.potAfter,
+        potOdds: potOdds ?? this.potOdds,
+        equity: equity ?? this.equity,
+        ev: ev ?? this.ev,
+        icmEv: icmEv ?? this.icmEv,
+      );
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ActionEntry &&
+        other.street == street &&
+        other.playerIndex == playerIndex &&
+        other.action == action &&
+        other.amount == amount &&
+        other.generated == generated &&
+        other.manualEvaluation == manualEvaluation &&
+        other.customLabel == customLabel &&
+        other.potAfter == potAfter &&
+        other.potOdds == potOdds &&
+        other.equity == equity &&
+        other.ev == ev &&
+        other.icmEv == icmEv &&
+        other.timestamp == timestamp;
+  }
+
+  @override
+  int get hashCode => Object.hash(
         street,
         playerIndex,
         action,
-        amount: amount,
-        generated: generated,
-        manualEvaluation: manualEvaluation,
-        customLabel: customLabel,
-        timestamp: timestamp,
-        potAfter: potAfter,
-        potOdds: potOdds,
-        equity: equity,
-        ev: ev,
-        icmEv: icmEv,
+        amount,
+        generated,
+        manualEvaluation,
+        customLabel,
+        potAfter,
+        potOdds,
+        equity,
+        ev,
+        icmEv,
+        timestamp,
       );
 }

--- a/lib/screens/create_pack_screen.dart
+++ b/lib/screens/create_pack_screen.dart
@@ -80,16 +80,10 @@ class _CreatePackScreenState extends State<CreatePackScreen> {
     final boardCards = [
       for (final c in hand.board) CardModel(rank: c[0], suit: c.substring(1))
     ];
-    final actions = <ActionEntry>[];
-    for (final list in hand.actions.values) {
-      for (final a in list) {
-        actions.add(ActionEntry(a.street, a.playerIndex, a.action,
-            amount: a.amount,
-            generated: a.generated,
-            manualEvaluation: a.manualEvaluation,
-            customLabel: a.customLabel));
-      }
-    }
+    // Deep copy actions to avoid mutating original hand data
+    final List<ActionEntry> actions = hand.actions.values
+        .expand((list) => list.map((a) => a.copy()))
+        .toList();
     final stacks = [
       for (var i = 0; i < hand.playerCount; i++)
         hand.stacks['$i']?.round() ?? 0

--- a/lib/screens/v2/training_pack_play_screen.dart
+++ b/lib/screens/v2/training_pack_play_screen.dart
@@ -297,16 +297,10 @@ class _TrainingPackPlayScreenState
     final boardCards = [
       for (final c in hand.board) CardModel(rank: c[0], suit: c.substring(1))
     ];
-    final actions = <ActionEntry>[];
-    for (final list in hand.actions.values) {
-      for (final a in list) {
-        actions.add(ActionEntry(a.street, a.playerIndex, a.action,
-            amount: a.amount,
-            generated: a.generated,
-            manualEvaluation: a.manualEvaluation,
-            customLabel: a.customLabel));
-      }
-    }
+    // Deep copy actions to avoid mutating original hand data
+    final List<ActionEntry> actions = hand.actions.values
+        .expand((list) => list.map((a) => a.copy()))
+        .toList();
     final stacks = [
       for (var i = 0; i < hand.playerCount; i++)
         hand.stacks['$i']?.round() ?? 0

--- a/lib/screens/v2/training_pack_play_screen_v2.dart
+++ b/lib/screens/v2/training_pack_play_screen_v2.dart
@@ -511,7 +511,7 @@ class _TrainingPackPlayScreenV2State
     final boardCards = [
       for (final c in hand.board) CardModel(rank: c[0], suit: c.substring(1)),
     ];
-    // Deep copy actions to avoid mutating original hand data in result screen
+    // Deep copy actions to avoid mutating original hand data
     final List<ActionEntry> actions = hand.actions.values
         .expand((list) => list.map((a) => a.copy()))
         .toList();

--- a/lib/screens/v2/training_session_screen.dart
+++ b/lib/screens/v2/training_session_screen.dart
@@ -52,16 +52,10 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
     final boardCards = [
       for (final c in hand.board) CardModel(rank: c[0], suit: c.substring(1))
     ];
-    final actions = <ActionEntry>[];
-    for (final list in hand.actions.values) {
-      for (final a in list) {
-        actions.add(ActionEntry(a.street, a.playerIndex, a.action,
-            amount: a.amount,
-            generated: a.generated,
-            manualEvaluation: a.manualEvaluation,
-            customLabel: a.customLabel));
-      }
-    }
+    // Deep copy actions to avoid mutating original hand data
+    final List<ActionEntry> actions = hand.actions.values
+        .expand((list) => list.map((a) => a.copy()))
+        .toList();
     final stacks = [
       for (var i = 0; i < hand.playerCount; i++) hand.stacks['$i']?.round() ?? 0
     ];

--- a/test/action_entry_test.dart
+++ b/test/action_entry_test.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poker_analyzer/models/action_entry.dart';
+
+void main() {
+  test('ActionEntry.copy creates independent instance', () {
+    final a = ActionEntry(0, 1, 'push', ev: 1.0);
+    final b = a.copy();
+    expect(identical(a, b), isFalse);
+    expect(b.ev, 1.0);
+    b.manualEvaluation = 'good';
+    expect(a.manualEvaluation, isNull);
+  });
+
+  test('ActionEntry.copyWith overrides selected fields', () {
+    final a = ActionEntry(0, 1, 'push', ev: 1.0);
+    final b = a.copyWith(action: 'call', ev: 2.0);
+    expect(b.action, 'call');
+    expect(b.ev, 2.0);
+    expect(a.action, 'push');
+    expect(a.ev, 1.0);
+  });
+}


### PR DESCRIPTION
## Summary
- add `copyWith`, equality and hashCode implementations to `ActionEntry`
- ensure `_toSpot` helpers deep copy actions and document why
- cover `ActionEntry.copy`/`copyWith` with new unit tests

## Testing
- `flutter test test/action_entry_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b1843ecf4832a979226f5b1751a0b