### PR TITLE
Align intl version with Flutter

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
   printing: ^5.12.0
   provider: ^6.0.5
   flutter_colorpicker: ^1.0.3
-  intl: ^0.20.2
+  intl: ^0.19.0
   freezed_annotation: ^2.2.0
   json_annotation: ^4.8.1
   flutter_localizations:


### PR DESCRIPTION
## Summary
- Align intl dependency to `^0.19.0` to match Flutter's pinned version.

## Testing
- `flutter pub get` *(fails: lottie ^3.3.1 requires Dart >=3.6.0)*
- `dart test test/push_fold_helpers_test.dart` *(fails: Flutter SDK not available for flutter_test)*

------
https://chatgpt.com/codex/tasks/task_e_689ad7aca990832abb9f04b407a0a0bd