### PR TITLE
refactor: make ActionEntry immutable

### DIFF
--- a/lib/models/action_entry.dart
+++ b/lib/models/action_entry.dart
@@ -20,21 +20,21 @@ class ActionEntry {
   final bool generated;
 
   /// Пользовательская оценка качества действия, заданная вручную
-  String? manualEvaluation;
+  final String? manualEvaluation;
 
   /// Пользовательская метка действия при типе 'custom'
-  String? customLabel;
+  final String? customLabel;
 
   /// Размер банка после применения действия
-  double potAfter;
+  final double potAfter;
 
-  double? potOdds;
+  final double? potOdds;
 
-  double? equity;
+  final double? equity;
 
-  double? ev;
+  final double? ev;
 
-  double? icmEv;
+  final double? icmEv;
 
   /// Время, когда было совершено действие
   final DateTime timestamp;

--- a/lib/screens/create_pack_screen.dart
+++ b/lib/screens/create_pack_screen.dart
@@ -80,10 +80,9 @@ class _CreatePackScreenState extends State<CreatePackScreen> {
     final boardCards = [
       for (final c in hand.board) CardModel(rank: c[0], suit: c.substring(1))
     ];
-    // Deep copy actions to avoid mutating original hand data
-    final List<ActionEntry> actions = hand.actions.values
-        .expand((list) => list.map((a) => a.copy()))
-        .toList();
+    // Flatten actions; ActionEntry is immutable so no per-item copy needed
+    final List<ActionEntry> actions =
+        hand.actions.values.expand((list) => list).toList();
     final stacks = [
       for (var i = 0; i < hand.playerCount; i++)
         hand.stacks['$i']?.round() ?? 0

--- a/lib/screens/hand_editor_screen.dart
+++ b/lib/screens/hand_editor_screen.dart
@@ -110,7 +110,8 @@ class _HandEditorScreenState extends State<HandEditorScreen>
     final heroEv = List<double?>.filled(4, null);
     int street = 0;
     void apply(List<ActionEntry> list) {
-      for (final a in list) {
+      for (var i = 0; i < list.length; i++) {
+        final a = list[i];
         final prevBet = bets[a.playerIndex];
         switch (a.action) {
           case 'fold':
@@ -155,21 +156,24 @@ class _HandEditorScreenState extends State<HandEditorScreen>
             actions[a.playerIndex] = PlayerAction.push;
             break;
         }
-        a.potAfter = pot;
+        var updated = a.copyWith(potAfter: pot);
         if (a.playerIndex == _heroIndex &&
             (a.action == 'call' || a.action == 'push')) {
-          final toCall = (bets[a.playerIndex] - prevBet).clamp(0, double.infinity);
-          a.potOdds = toCall == 0 ? null : (toCall / pot * 100);
-          heroPo[street] = a.potOdds;
+          final toCall =
+              (bets[a.playerIndex] - prevBet).clamp(0, double.infinity);
+          final potOdds = toCall == 0 ? null : (toCall / pot * 100);
+          heroPo[street] = potOdds;
           final potAfter = pot;
-          a.ev = a.equity == null
+          final ev = a.equity == null
               ? null
               : (a.equity! / 100) * (potAfter) - toCall;
-          heroEv[street] = a.ev;
+          heroEv[street] = ev;
+          updated =
+              updated.copyWith(potOdds: potOdds, ev: ev);
         } else {
-          a.potOdds = null;
-          a.ev = null;
+          updated = updated.copyWith(potOdds: null, ev: null);
         }
+        list[i] = updated;
       }
     }
 

--- a/lib/screens/packs_library_screen.dart
+++ b/lib/screens/packs_library_screen.dart
@@ -401,10 +401,11 @@ class _PacksLibraryScreenState extends State<PacksLibraryScreen> {
     if (ok != true) return;
     for (final s in pack.spots) {
       final hero = s.hand.heroIndex;
-      for (final a in s.hand.actions[0] ?? []) {
+      final acts = s.hand.actions[0] ?? [];
+      for (var i = 0; i < acts.length; i++) {
+        final a = acts[i];
         if (a.playerIndex == hero) {
-          a.ev = null;
-          a.icmEv = null;
+          acts[i] = a.copyWith(ev: null, icmEv: null);
         }
       }
       s.evalResult = null;

--- a/lib/screens/training_spot_analysis_screen.dart
+++ b/lib/screens/training_spot_analysis_screen.dart
@@ -68,7 +68,11 @@ class _TrainingSpotAnalysisScreenState extends State<TrainingSpotAnalysisScreen>
 
   void _setManualEvaluation(ActionEntry entry, String? value) {
     setState(() {
-      entry.manualEvaluation = value;
+      final idx = widget.spot.actions.indexOf(entry);
+      if (idx != -1) {
+        widget.spot.actions[idx] =
+            entry.copyWith(manualEvaluation: value);
+      }
     });
   }
 

--- a/lib/screens/v2/training_pack_play_screen.dart
+++ b/lib/screens/v2/training_pack_play_screen.dart
@@ -297,10 +297,9 @@ class _TrainingPackPlayScreenState
     final boardCards = [
       for (final c in hand.board) CardModel(rank: c[0], suit: c.substring(1))
     ];
-    // Deep copy actions to avoid mutating original hand data
-    final List<ActionEntry> actions = hand.actions.values
-        .expand((list) => list.map((a) => a.copy()))
-        .toList();
+    // Flatten actions; ActionEntry is immutable so no per-item copy needed
+    final List<ActionEntry> actions =
+        hand.actions.values.expand((list) => list).toList();
     final stacks = [
       for (var i = 0; i < hand.playerCount; i++)
         hand.stacks['$i']?.round() ?? 0

--- a/lib/screens/v2/training_pack_play_screen_v2.dart
+++ b/lib/screens/v2/training_pack_play_screen_v2.dart
@@ -511,10 +511,9 @@ class _TrainingPackPlayScreenV2State
     final boardCards = [
       for (final c in hand.board) CardModel(rank: c[0], suit: c.substring(1)),
     ];
-    // Deep copy actions to avoid mutating original hand data
-    final List<ActionEntry> actions = hand.actions.values
-        .expand((list) => list.map((a) => a.copy()))
-        .toList();
+    // Flatten actions; ActionEntry is immutable so no per-item copy needed
+    final List<ActionEntry> actions =
+        hand.actions.values.expand((list) => list).toList();
     final stacks = [
       for (var i = 0; i < hand.playerCount; i++)
         hand.stacks['$i']?.round() ?? 0,

--- a/lib/screens/v2/training_pack_template_list_core.dart
+++ b/lib/screens/v2/training_pack_template_list_core.dart
@@ -1452,9 +1452,10 @@ class _TrainingPackTemplateListScreenState
         .map((c) => '${c.rank}${c.suit}')
         .join(' ');
     final actions = <ActionEntry>[for (final a in hand.actions) if (a.street == 0) a];
-    for (final a in actions) {
+    for (var i = 0; i < actions.length; i++) {
+      final a = actions[i];
       if (a.playerIndex == hand.heroIndex) {
-        a.ev = hand.evLoss ?? 0;
+        actions[i] = a.copyWith(ev: hand.evLoss ?? 0);
         break;
       }
     }

--- a/lib/screens/v2/training_session_screen.dart
+++ b/lib/screens/v2/training_session_screen.dart
@@ -52,10 +52,9 @@ class _TrainingSessionScreenState extends State<TrainingSessionScreen> {
     final boardCards = [
       for (final c in hand.board) CardModel(rank: c[0], suit: c.substring(1))
     ];
-    // Deep copy actions to avoid mutating original hand data
-    final List<ActionEntry> actions = hand.actions.values
-        .expand((list) => list.map((a) => a.copy()))
-        .toList();
+    // Flatten actions; ActionEntry is immutable so no per-item copy needed
+    final List<ActionEntry> actions =
+        hand.actions.values.expand((list) => list).toList();
     final stacks = [
       for (var i = 0; i < hand.playerCount; i++) hand.stacks['$i']?.round() ?? 0
     ];

--- a/lib/services/evaluation_executor_service.dart
+++ b/lib/services/evaluation_executor_service.dart
@@ -482,10 +482,13 @@ class EvaluationExecutorService implements EvaluationExecutor {
             },
           );
           final acts = spot.hand.actions[0] ?? [];
-          for (final a in acts) {
+          for (var i = 0; i < acts.length; i++) {
+            final a = acts[i];
             if (a.playerIndex == hero && a.action == heroAct) {
-              a.ev = res['ev'] as double;
-              if (withIcm) a.icmEv = res['icm'] as double;
+              acts[i] = a.copyWith(
+                ev: res['ev'] as double,
+                icmEv: withIcm ? res['icm'] as double : a.icmEv,
+              );
               break;
             }
           }

--- a/lib/services/offline_evaluator_service.dart
+++ b/lib/services/offline_evaluator_service.dart
@@ -44,9 +44,11 @@ class OfflineEvaluatorService {
       if (cached != null && cached['ev'] != null) {
         final hero = spot.hand.heroIndex;
         final acts = spot.hand.actions[0] ?? [];
-        for (final a in acts) {
+        for (var i = 0; i < acts.length; i++) {
+          final a = acts[i];
           if (a.playerIndex == hero && a.action == 'push') {
-            a.ev = (cached['ev'] as num).toDouble();
+            acts[i] =
+                a.copyWith(ev: (cached['ev'] as num).toDouble());
             return;
           }
         }
@@ -72,10 +74,15 @@ class OfflineEvaluatorService {
       if (cached != null && cached['icm'] != null) {
         final hero = spot.hand.heroIndex;
         final acts = spot.hand.actions[0] ?? [];
-        for (final a in acts) {
+        for (var i = 0; i < acts.length; i++) {
+          final a = acts[i];
           if (a.playerIndex == hero && a.action == 'push') {
-            a.icmEv = (cached['icm'] as num).toDouble();
-            if (cached['ev'] != null) a.ev ??= (cached['ev'] as num).toDouble();
+            acts[i] = a.copyWith(
+              icmEv: (cached['icm'] as num).toDouble(),
+              ev: cached['ev'] != null
+                  ? (cached['ev'] as num).toDouble()
+                  : a.ev,
+            );
             return;
           }
         }
@@ -100,10 +107,10 @@ class OfflineEvaluatorService {
           anteBb: anteBb,
         );
         final acts = spot.hand.actions[0] ?? [];
-        for (final a in acts) {
+        for (var i = 0; i < acts.length; i++) {
+          final a = acts[i];
           if (a.playerIndex == hero && a.action == 'push') {
-            a.ev = ev;
-            a.icmEv = icm;
+            acts[i] = a.copyWith(ev: ev, icmEv: icm);
             break;
           }
         }

--- a/lib/services/pack_generator_service.dart
+++ b/lib/services/pack_generator_service.dart
@@ -390,13 +390,13 @@ class PackGeneratorService {
         heroHand: range[i],
         anteBb: 0,
       );
-      actions[0]![0].ev = chipEv;
-      actions[0]![0].icmEv = computeIcmPushEV(
+      final icmEv = computeIcmPushEV(
         chipStacksBb: stacks,
         heroIndex: heroIndex,
         heroHand: range[i],
         chipPushEv: chipEv,
       );
+      actions[0]![0] = actions[0]![0].copyWith(ev: chipEv, icmEv: icmEv);
       spots.add(
         TrainingPackSpot(
           id: 'finaltable_${i + 1}',

--- a/lib/services/push_fold_ev_service.dart
+++ b/lib/services/push_fold_ev_service.dart
@@ -50,13 +50,16 @@ class PushFoldEvService {
     final stack = spot.hand.stacks['$hero']?.round();
     if (hand == null || stack == null) return;
     final acts = spot.hand.actions[0] ?? [];
-    for (final a in acts) {
+    for (var i = 0; i < acts.length; i++) {
+      final a = acts[i];
       if (a.playerIndex == hero && a.action == 'push') {
-        a.ev = computePushEV(
-          heroBbStack: stack,
-          bbCount: spot.hand.playerCount - 1,
-          heroHand: hand,
-          anteBb: anteBb,
+        acts[i] = a.copyWith(
+          ev: computePushEV(
+            heroBbStack: stack,
+            bbCount: spot.hand.playerCount - 1,
+            heroHand: hand,
+            anteBb: anteBb,
+          ),
         );
         break;
       }
@@ -74,7 +77,8 @@ class PushFoldEvService {
       for (var i = 0; i < spot.hand.playerCount; i++)
         spot.hand.stacks['$i']?.round() ?? 0
     ];
-    for (final a in acts) {
+    for (var i = 0; i < acts.length; i++) {
+      final a = acts[i];
       if (a.playerIndex == hero && a.action == 'push') {
         final chipEv = a.ev ?? computePushEV(
           heroBbStack: stack,
@@ -82,12 +86,15 @@ class PushFoldEvService {
           heroHand: hand,
           anteBb: anteBb,
         );
-        a.icmEv = computeIcmPushEV(
-          chipStacksBb: stacks,
-          heroIndex: hero,
-          heroHand: hand,
-          chipPushEv: chipEv,
-          payouts: payouts,
+        acts[i] = a.copyWith(
+          ev: a.ev ?? chipEv,
+          icmEv: computeIcmPushEV(
+            chipStacksBb: stacks,
+            heroIndex: hero,
+            heroHand: hand,
+            chipPushEv: chipEv,
+            payouts: payouts,
+          ),
         );
         break;
       }

--- a/lib/services/remote_ev_service.dart
+++ b/lib/services/remote_ev_service.dart
@@ -90,10 +90,10 @@ class RemoteEvService {
   void _apply(TrainingPackSpot spot, {double? ev, double? icm}) {
     final hero = spot.hand.heroIndex;
     final acts = spot.hand.actions[0] ?? [];
-    for (final a in acts) {
+    for (var i = 0; i < acts.length; i++) {
+      final a = acts[i];
       if (a.playerIndex == hero && a.action == 'push') {
-        if (ev != null) a.ev = ev;
-        if (icm != null) a.icmEv = icm;
+        acts[i] = a.copyWith(ev: ev ?? a.ev, icmEv: icm ?? a.icmEv);
         break;
       }
     }

--- a/lib/services/training_pack_author_service.dart
+++ b/lib/services/training_pack_author_service.dart
@@ -146,13 +146,14 @@ class TrainingPackAuthorService {
           heroHand: hand,
           anteBb: 0,
         );
-        actions[0]![0].ev = chipEv;
-        actions[0]![0].icmEv = computeIcmPushEV(
+        final icmEv = computeIcmPushEV(
           chipStacksBb: playerStacks,
           heroIndex: heroIndex,
           heroHand: hand,
           chipPushEv: chipEv,
         );
+        actions[0]![0] =
+            actions[0]![0].copyWith(ev: chipEv, icmEv: icmEv);
         stacks = {
           for (var j = 0; j < playerStacks.length; j++)
             '$j': playerStacks[j].toDouble()

--- a/lib/services/training_pack_template_ui_service.dart
+++ b/lib/services/training_pack_template_ui_service.dart
@@ -64,13 +64,14 @@ class TrainingPackTemplateUiService {
                     heroHand: hand,
                     anteBb: template.anteBb,
                   );
-                  actions[0]![0].ev = ev;
-                  actions[0]![0].icmEv = computeIcmPushEV(
+                  final icm = computeIcmPushEV(
                     chipStacksBb: template.playerStacksBb,
                     heroIndex: 0,
                     heroHand: hand,
                     chipPushEv: ev,
                   );
+                  actions[0]![0] =
+                      actions[0]![0].copyWith(ev: ev, icmEv: icm);
                   final stacks = {
                     for (var j = 0; j < template.playerStacksBb.length; j++)
                       '$j': template.playerStacksBb[j].toDouble()
@@ -176,13 +177,14 @@ class TrainingPackTemplateUiService {
                     heroHand: hand,
                     anteBb: template.anteBb,
                   );
-                  actions[0]![0].ev = ev;
-                  actions[0]![0].icmEv = computeIcmPushEV(
+                  final icm = computeIcmPushEV(
                     chipStacksBb: template.playerStacksBb,
                     heroIndex: 0,
                     heroHand: hand,
                     chipPushEv: ev,
                   );
+                  actions[0]![0] =
+                      actions[0]![0].copyWith(ev: ev, icmEv: icm);
                   final stacks = {
                     for (var j = 0; j < template.playerStacksBb.length; j++)
                       '$j': template.playerStacksBb[j].toDouble()

--- a/plugins/LocalEvPlugin.dart
+++ b/plugins/LocalEvPlugin.dart
@@ -14,16 +14,24 @@ class LocalEvService {
     final hand = handCode(spot.hand.heroCards);
     final stack = spot.hand.stacks['$hero']?.round();
     if (hand == null || stack == null) return;
-    for (final a in spot.hand.actions[0] ?? []) {
-      if (a.playerIndex == hero &&
-          (a.action == 'push' || a.action == 'call' || a.action == 'raise')) {
-        a.ev = computePushEV(
-          heroBbStack: stack,
-          bbCount: spot.hand.playerCount - 1,
-          heroHand: hand,
-          anteBb: anteBb,
-        );
-        break;
+    final acts = spot.hand.actions[0];
+    if (acts != null) {
+      for (var i = 0; i < acts.length; i++) {
+        final a = acts[i];
+        if (a.playerIndex == hero &&
+            (a.action == 'push' ||
+                a.action == 'call' ||
+                a.action == 'raise')) {
+          acts[i] = a.copyWith(
+            ev: computePushEV(
+              heroBbStack: stack,
+              bbCount: spot.hand.playerCount - 1,
+              heroHand: hand,
+              anteBb: anteBb,
+            ),
+          );
+          break;
+        }
       }
     }
   }
@@ -42,33 +50,38 @@ class LocalEvService {
       for (final a in spot.hand.actions[0] ?? [])
         if (a.playerIndex != hero && a.action == 'call') a.playerIndex
     ];
-    for (final a in spot.hand.actions[0] ?? []) {
-      if (a.playerIndex == hero &&
-          (a.action == 'push' || a.action == 'call' || a.action == 'raise')) {
-        final ev = computePushEV(
-          heroBbStack: stack,
-          bbCount: spot.hand.playerCount - 1,
-          heroHand: hand,
-          anteBb: anteBb,
-        );
-        final icm = callers.length > 1
-            ? computeMultiwayIcmEV(
-                chipStacksBb: stacks,
-                heroIndex: hero,
-                chipPushEv: ev,
-                callerIndices: callers,
-                payouts: payouts,
-              )
-            : computeLocalIcmPushEV(
-                chipStacksBb: stacks,
-                heroIndex: hero,
-                heroHand: hand,
-                anteBb: anteBb,
-                payouts: payouts,
-              );
-        a.ev = ev;
-        a.icmEv = icm;
-        break;
+    final acts = spot.hand.actions[0];
+    if (acts != null) {
+      for (var i = 0; i < acts.length; i++) {
+        final a = acts[i];
+        if (a.playerIndex == hero &&
+            (a.action == 'push' ||
+                a.action == 'call' ||
+                a.action == 'raise')) {
+          final ev = computePushEV(
+            heroBbStack: stack,
+            bbCount: spot.hand.playerCount - 1,
+            heroHand: hand,
+            anteBb: anteBb,
+          );
+          final icm = callers.length > 1
+              ? computeMultiwayIcmEV(
+                  chipStacksBb: stacks,
+                  heroIndex: hero,
+                  chipPushEv: ev,
+                  callerIndices: callers,
+                  payouts: payouts,
+                )
+              : computeLocalIcmPushEV(
+                  chipStacksBb: stacks,
+                  heroIndex: hero,
+                  heroHand: hand,
+                  anteBb: anteBb,
+                  payouts: payouts,
+                );
+          acts[i] = a.copyWith(ev: ev, icmEv: icm);
+          break;
+        }
       }
     }
   }

--- a/test/action_entry_test.dart
+++ b/test/action_entry_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 import 'package:poker_analyzer/models/action_entry.dart';
 
 void main() {
@@ -7,8 +7,6 @@ void main() {
     final b = a.copy();
     expect(identical(a, b), isFalse);
     expect(b.ev, 1.0);
-    b.manualEvaluation = 'good';
-    expect(a.manualEvaluation, isNull);
   });
 
   test('ActionEntry.copyWith overrides selected fields', () {
@@ -18,5 +16,12 @@ void main() {
     expect(b.ev, 2.0);
     expect(a.action, 'push');
     expect(a.ev, 1.0);
+  });
+
+  test('Attempting mutation throws', () {
+    final a = ActionEntry(0, 1, 'push');
+    expect(() {
+      (a as dynamic).manualEvaluation = 'good';
+    }, throwsNoSuchMethodError);
   });
 }

--- a/test/booster_similarity_engine_test.dart
+++ b/test/booster_similarity_engine_test.dart
@@ -15,7 +15,9 @@ TrainingPackSpot _spot(
   if (board != null) hand.board.addAll(board);
   if (ev != null) {
     final acts = hand.actions[0];
-    if (acts.isNotEmpty) acts.first.ev = ev;
+    if (acts.isNotEmpty) {
+      acts[0] = acts.first.copyWith(ev: ev);
+    }
   }
   return TrainingPackSpot(id: id, hand: hand);
 }

--- a/test/services/offline_evaluator_service_test.dart
+++ b/test/services/offline_evaluator_service_test.dart
@@ -35,10 +35,10 @@ class _TestPathProvider extends PathProviderPlatform {
 void _apply(TrainingPackSpot spot, {double? ev, double? icm}) {
   final hero = spot.hand.heroIndex;
   final acts = spot.hand.actions[0] ?? [];
-  for (final a in acts) {
+  for (var i = 0; i < acts.length; i++) {
+    final a = acts[i];
     if (a.playerIndex == hero && a.action == 'push') {
-      if (ev != null) a.ev = ev;
-      if (icm != null) a.icmEv = icm;
+      acts[i] = a.copyWith(ev: ev ?? a.ev, icmEv: icm ?? a.icmEv);
       break;
     }
   }

--- a/tool/import_mistake_packs.dart
+++ b/tool/import_mistake_packs.dart
@@ -70,10 +70,16 @@ void main(List<String> args) {
         final heroEv = _double(_cell(row, idx['heroEv']));
         final heroIcm = _double(_cell(row, idx['heroIcmEv']));
         if (heroEv != null || heroIcm != null) {
-          for (final a in acts[0] ?? []) {
-            if (a.playerIndex == 0) {
-              if (heroEv != null) a.ev = heroEv;
-              if (heroIcm != null) a.icmEv = heroIcm;
+          final list0 = acts[0];
+          if (list0 != null) {
+            for (var k = 0; k < list0.length; k++) {
+              final a = list0[k];
+              if (a.playerIndex == 0) {
+                list0[k] = a.copyWith(
+                  ev: heroEv ?? a.ev,
+                  icmEv: heroIcm ?? a.icmEv,
+                );
+              }
             }
           }
         }


### PR DESCRIPTION
## Summary
- make `ActionEntry` immutable with value-based copy/copyWith
- replace in-place `ActionEntry` mutations with `copyWith`
- remove per-action deep copies when building training spots
- update unit tests for immutability

## Testing
- `dart analyze` *(fails: command not found)*
- `dart test test/action_entry_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b1abaed98832abb468f737010ac62