### PR TITLE
chore: align CI toolchain with Flutter stable

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: CI
+name: ci-pr-fast
 
 on:
   pull_request:
@@ -8,17 +8,16 @@ on:
       - '**/*.md'
 
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
+  group: ci-pr-fast-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
   contents: read
 
 jobs:
-  build:
+  analyze:
     runs-on: ubuntu-latest
     timeout-minutes: 20
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -29,18 +28,25 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: stable
-          cache: true
 
-      - name: Check Flutter version
-        run: flutter --version
+      - name: Show versions
+        run: |
+          flutter --version
+          dart --version
+          DART_VERSION=$(dart --version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+          if [ "$(printf '%s\n' "3.6.0" "$DART_VERSION" | sort -V | head -n1)" != "3.6.0" ]; then
+            echo "Dart $DART_VERSION is below required 3.6.0"
+            exit 1
+          fi
 
       - name: Cache Pub dependencies
         uses: actions/cache@v4
         with:
-          path: ~/.pub-cache
+          path: |
+            ~/.pub-cache
+            .dart_tool/build
           key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-pub-
+          restore-keys: ${{ runner.os }}-pub-
 
       - name: Bootstrap Flutter local.properties
         run: bash scripts/setup_flutter_localprops.sh
@@ -48,11 +54,63 @@ jobs:
       - name: Install dependencies
         run: flutter pub get
 
-      # Тесты только по лейблу в PR
-      - name: Run tests (labeled PRs only)
-        if: ${{ contains(github.event.pull_request.labels.*.name, 'run-tests') }}
-        run: flutter test -r expanded --concurrency=6
+      - name: Flutter analyze
+        run: flutter analyze
 
-      - name: Skip tests (default)
-        if: ${{ !contains(github.event.pull_request.labels.*.name, 'run-tests') }}
-        run: echo "CI tests skipped. Add 'run-tests' label on the PR to enable."
+  tests:
+    runs-on: ubuntu-latest
+    needs: analyze
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Show versions
+        run: |
+          flutter --version
+          dart --version
+          DART_VERSION=$(dart --version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+          if [ "$(printf '%s\n' "3.6.0" "$DART_VERSION" | sort -V | head -n1)" != "3.6.0" ]; then
+            echo "Dart $DART_VERSION is below required 3.6.0"
+            exit 1
+          fi
+
+      - name: Cache Pub dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pub-cache
+            .dart_tool/build
+          key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
+          restore-keys: ${{ runner.os }}-pub-
+
+      - name: Bootstrap Flutter local.properties
+        run: bash scripts/setup_flutter_localprops.sh
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Run Dart tests
+        run: |
+          DART_TESTS=$(rg -L "package:flutter" -g "*_test.dart" -l test || true)
+          if [ -n "$DART_TESTS" ]; then
+            dart test --reporter expanded $DART_TESTS
+          else
+            echo "No pure Dart tests found."
+          fi
+
+      - name: Run Flutter tests
+        run: |
+          FLUTTER_TESTS=$(rg -l "package:flutter" -g "*_test.dart" test || true)
+          if [ -n "$FLUTTER_TESTS" ]; then
+            flutter test --machine $FLUTTER_TESTS
+          else
+            echo "No widget tests found."
+          fi

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,4 +1,4 @@
-name: Unit Tests (PR only, label-gated)
+name: unit-tests
 
 on:
   pull_request:
@@ -18,29 +18,35 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     timeout-minutes: 20
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Set up Flutter
+      - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
           channel: stable
-          cache: true
 
-      - name: Flutter version
-        run: flutter --version
+      - name: Show versions
+        run: |
+          flutter --version
+          dart --version
+          DART_VERSION=$(dart --version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+          if [ "$(printf '%s\n' "3.6.0" "$DART_VERSION" | sort -V | head -n1)" != "3.6.0" ]; then
+            echo "Dart $DART_VERSION is below required 3.6.0"
+            exit 1
+          fi
 
       - name: Cache Pub dependencies
         uses: actions/cache@v4
         with:
-          path: ~/.pub-cache
+          path: |
+            ~/.pub-cache
+            .dart_tool/build
           key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-pub-
+          restore-keys: ${{ runner.os }}-pub-
 
       - name: Bootstrap Flutter local.properties
         run: bash scripts/setup_flutter_localprops.sh
@@ -48,10 +54,28 @@ jobs:
       - name: Install dependencies
         run: flutter pub get
 
-      # Запускаем тесты ТОЛЬКО если на PR есть лейбл run-tests
-      - name: Run smoke tests (labeled PRs only)
+      - name: Flutter analyze
+        run: flutter analyze
+
+      - name: Run Dart tests (labeled PRs only)
         if: ${{ contains(github.event.pull_request.labels.*.name, 'run-tests') }}
-        run: flutter test --no-pub --coverage test/smoke
+        run: |
+          DART_TESTS=$(rg -L "package:flutter" -g "*_test.dart" -l test || true)
+          if [ -n "$DART_TESTS" ]; then
+            dart test --reporter expanded $DART_TESTS
+          else
+            echo "No pure Dart tests found."
+          fi
+
+      - name: Run Flutter tests (labeled PRs only)
+        if: ${{ contains(github.event.pull_request.labels.*.name, 'run-tests') }}
+        run: |
+          FLUTTER_TESTS=$(rg -l "package:flutter" -g "*_test.dart" test || true)
+          if [ -n "$FLUTTER_TESTS" ]; then
+            flutter test --machine $FLUTTER_TESTS
+          else
+            echo "No widget tests found."
+          fi
 
       - name: Skip tests (default)
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'run-tests') }}


### PR DESCRIPTION
## Summary
- move CI to stable Flutter channel with Dart >=3.6 and explicit version checks
- cache pub deps and run analyzer before dart and flutter tests

## Testing
- `flutter test --machine test/auto_theory_stage_seeder_test.dart`
- `dart test --reporter expanded test/graph_path_template_validator_test.dart`

------
https://chatgpt.com/codex/tasks/task_e_689b2619b35c832a90f6e64b594efb1f