### PR TITLE
feat: preload starter packs on first launch

### DIFF
--- a/assets/packs_builtin/manifest.json
+++ b/assets/packs_builtin/manifest.json
@@ -1,0 +1,9 @@
+[
+  {
+    "id": "pf_basic_cash_v1",
+    "title": "Push/Fold — Cash Basics",
+    "locale": "en",
+    "file": "pf_basic_cash_v1.json",
+    "version": 1
+  }
+]

--- a/assets/packs_builtin/pf_basic_cash_v1.json
+++ b/assets/packs_builtin/pf_basic_cash_v1.json
@@ -1,0 +1,13 @@
+{
+  "id": "pf_basic_cash_v1",
+  "name": "Push/Fold — Cash Basics",
+  "trainingType": "pushFold",
+  "gameType": "cash",
+  "bb": 20,
+  "tags": ["starter"],
+  "spots": [
+    {"id": "s1"}
+  ],
+  "spotCount": 1,
+  "meta": {"schemaVersion": "2.0"}
+}

--- a/lib/app_bootstrap.dart
+++ b/lib/app_bootstrap.dart
@@ -14,6 +14,7 @@ import 'services/evaluation_executor_service.dart';
 import 'services/training_pack_service.dart';
 import 'services/service_registry.dart';
 import 'services/pack_library_loader_service.dart';
+import 'services/built_in_pack_bootstrap_service.dart';
 import 'services/xp_goal_panel_booster_injector.dart';
 import 'services/training_session_fingerprint_service.dart';
 import 'services/training_session_context_service.dart';
@@ -75,6 +76,10 @@ class AppBootstrap {
       await _run(
         'PackLibraryLoaderService.loadLibrary',
         () => PackLibraryLoaderService.instance.loadLibrary(),
+      );
+      await _run(
+        'BuiltInPackBootstrapService.importIfNeeded',
+        () => const BuiltInPackBootstrapService().importIfNeeded(),
       );
       await _run(
         'TrainingPackLibraryV2.loadFromFolder',

--- a/lib/services/built_in_pack_bootstrap_service.dart
+++ b/lib/services/built_in_pack_bootstrap_service.dart
@@ -1,0 +1,57 @@
+import 'dart:convert';
+import 'package:flutter/services.dart' show rootBundle;
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/v2/training_pack_template_v2.dart';
+import 'pack_library_service.dart';
+
+/// Handles seeding of built-in starter packs on first launch.
+class BuiltInPackBootstrapService {
+  const BuiltInPackBootstrapService({
+    PackLibraryService? library,
+    SharedPreferences? prefs,
+  })  : _library = library ?? PackLibraryService.instance,
+        _prefs = prefs;
+
+  final PackLibraryService _library;
+  final SharedPreferences? _prefs;
+
+  /// Current bootstrap version.
+  static const int _version = 1;
+  static const String _manifestPath = 'assets/packs_builtin/manifest.json';
+
+  Future<void> importIfNeeded() async {
+    final prefs = _prefs ?? await SharedPreferences.getInstance();
+    final key = 'builtinPacksImported:v$_version';
+    final already = prefs.getBool(key) ?? false;
+    if (_library.count() > 0 && already) return;
+
+    List<dynamic> manifest;
+    try {
+      final raw = await rootBundle.loadString(_manifestPath);
+      final data = jsonDecode(raw);
+      if (data is! List) return;
+      manifest = data;
+    } catch (_) {
+      return;
+    }
+
+    for (final item in manifest) {
+      if (item is! Map) continue;
+      final id = item['id']?.toString();
+      final file = item['file']?.toString();
+      if (id == null || file == null) continue;
+      try {
+        final packRaw =
+            await rootBundle.loadString('assets/packs_builtin/$file');
+        final map = jsonDecode(packRaw) as Map<String, dynamic>;
+        final tpl = TrainingPackTemplateV2.fromJson(map);
+        _library.addOrUpdate(tpl);
+      } catch (_) {
+        // Swallow errors to avoid blocking startup
+      }
+    }
+
+    await prefs.setBool(key, true);
+  }
+}

--- a/lib/services/pack_library_service.dart
+++ b/lib/services/pack_library_service.dart
@@ -9,6 +9,12 @@ class PackLibraryService {
   PackLibraryService._();
   static final instance = PackLibraryService._();
 
+  int count() => packLibrary.length;
+
+  void addOrUpdate(TrainingPackTemplateV2 template) {
+    packLibrary[template.id] = List<TrainingPackSpot>.from(template.spots);
+  }
+
   /// Returns spots for the pack identified by [id].
   ///
   /// If the [id] is unknown, an empty list is returned.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -148,6 +148,8 @@ flutter:
     - assets/skills/cash/
     - assets/paths/
     - assets/precompiled_packs/
+    - assets/packs_builtin/manifest.json
+    - assets/packs_builtin/
     - assets/icm_scenarios/
     - assets/ab_experiments.json
     - assets/autogen_presets/

--- a/test/services/built_in_pack_bootstrap_service_test.dart
+++ b/test/services/built_in_pack_bootstrap_service_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:poker_analyzer/services/built_in_pack_bootstrap_service.dart';
+import 'package:poker_analyzer/generated/pack_library.g.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    packLibrary.clear();
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('imports packs when library empty', () async {
+    expect(packLibrary.isEmpty, true);
+    await const BuiltInPackBootstrapService().importIfNeeded();
+    expect(packLibrary.isNotEmpty, true);
+  });
+
+  test('import is idempotent', () async {
+    await const BuiltInPackBootstrapService().importIfNeeded();
+    final count = packLibrary.length;
+    await const BuiltInPackBootstrapService().importIfNeeded();
+    expect(packLibrary.length, count);
+  });
+}


### PR DESCRIPTION
## Summary
- seed built-in starter packs on first launch with `BuiltInPackBootstrapService`
- expose `count` and `addOrUpdate` in `PackLibraryService`
- bootstrap service hooked into `AppBootstrap`
- add starter pack assets and tests

## Testing
- `flutter pub get` *(fails: command not found)*
- `dart format lib/services/built_in_pack_bootstrap_service.dart lib/services/pack_library_service.dart lib/app_bootstrap.dart test/services/built_in_pack_bootstrap_service_test.dart` *(fails: command not found)*
- `flutter test test/services/built_in_pack_bootstrap_service_test.dart` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_689b2b1c3204832a82f397e8b090a8a8