### PR TITLE
feat: add starter pack picker

### DIFF
--- a/lib/services/pack_library_service.dart
+++ b/lib/services/pack_library_service.dart
@@ -28,6 +28,13 @@ class PackLibraryService {
     return List<String>.unmodifiable(packLibrary.keys);
   }
 
+  Future<List<TrainingPackTemplateV2>> listStarters() async {
+    await TrainingPackLibraryV2.instance.loadFromFolder();
+    final list =
+        TrainingPackLibraryV2.instance.filterBy(type: TrainingType.pushFold);
+    return list.where((p) => p.tags.contains('starter')).toList();
+  }
+
   Future<TrainingPackTemplateV2?> recommendedStarter() async {
     await TrainingPackLibraryV2.instance.loadFromFolder();
     final list =

--- a/lib/services/starter_pack_telemetry.dart
+++ b/lib/services/starter_pack_telemetry.dart
@@ -10,6 +10,12 @@ Map<String, Object?> starterBannerPayload(String packId, int spotCount) => {
       'spotCount': spotCount,
     };
 
+Map<String, Object?> starterPickerOpenedPayload() => {};
+
+Map<String, Object?> starterPickerSelectedPayload(
+        String packId, int spotCount) =>
+    {'packId': packId, 'spotCount': spotCount};
+
 class StarterPackTelemetry {
   const StarterPackTelemetry({AnalyticsService? analytics})
       : _analytics = analytics ?? AnalyticsService.instance;
@@ -24,6 +30,20 @@ class StarterPackTelemetry {
     await _analytics.logEvent(
       event,
       starterBannerPayload(packId, spotCount),
+    );
+  }
+
+  Future<void> logPickerOpened() async {
+    await _analytics.logEvent(
+      'starter_banner_picker_opened',
+      starterPickerOpenedPayload(),
+    );
+  }
+
+  Future<void> logPickerSelected(String packId, int spotCount) async {
+    await _analytics.logEvent(
+      'starter_banner_picker_selected',
+      starterPickerSelectedPayload(packId, spotCount),
     );
   }
 }

--- a/test/services/starter_pack_telemetry_test.dart
+++ b/test/services/starter_pack_telemetry_test.dart
@@ -11,4 +11,14 @@ void main() {
     final payload = starterBannerPayload('p2', 10);
     expect(payload, {'packId': 'p2', 'spotCount': 10});
   });
+
+  test('starter picker opened payload', () {
+    final payload = starterPickerOpenedPayload();
+    expect(payload, {});
+  });
+
+  test('starter picker selected payload', () {
+    final payload = starterPickerSelectedPayload('p3', 15);
+    expect(payload, {'packId': 'p3', 'spotCount': 15});
+  });
 }


### PR DESCRIPTION
## Summary
- allow selecting alternative starter packs from onboarding banner
- add telemetry for pack picker open and selection
- expose pack library helper for listing starter packs
- cover new telemetry payload helpers with tests

## Testing
- `dart test test/services/starter_pack_telemetry_test.dart` *(fails: command not found: dart)*
- `flutter test test/services/starter_pack_telemetry_test.dart` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_689b38ee0cc0832a8698ddb7f9cd2227