### PR TITLE
chore: narrow dart async import

### DIFF
--- a/lib/widgets/starter_packs_onboarding_banner.dart
+++ b/lib/widgets/starter_packs_onboarding_banner.dart
@@ -1,4 +1,4 @@
-import 'dart:async';
+import 'dart:async' show unawaited;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';


### PR DESCRIPTION
## Summary
- narrow `dart:async` import in starter pack banner to just `unawaited`

## Testing
- `dart format lib/widgets/starter_packs_onboarding_banner.dart` *(command not found)*
- `flutter format lib/widgets/starter_packs_onboarding_banner.dart` *(command not found)*
- `apt-get install -y dart` *(unable to locate package)*
- `snap install flutter --classic` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b47f8dbd8832a85dc59d423bfcbb5