### PR TITLE
Dispose analyzer controller

### DIFF
--- a/lib/controllers/poker_analyzer_controller.dart
+++ b/lib/controllers/poker_analyzer_controller.dart
@@ -1,4 +1,5 @@
 import 'dart:collection';
+import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
 
@@ -78,21 +79,28 @@ class PokerAnalyzerController extends ChangeNotifier {
   /// table state.
   void loadSpot(TrainingSpot spot) {
     _update(() {
-      _numberOfPlayers = spot.numberOfPlayers;
+      final playerCount = [
+        spot.numberOfPlayers,
+        spot.positions.length,
+        spot.playerTypes.length,
+        spot.stacks.length,
+      ].reduce(math.min);
+
+      _numberOfPlayers = playerCount;
       _playerPositions
         ..clear()
         ..addAll({
-          for (var i = 0; i < spot.positions.length; i++) i: spot.positions[i]
+          for (var i = 0; i < playerCount; i++) i: spot.positions[i]
         });
       _playerTypes
         ..clear()
         ..addAll({
-          for (var i = 0; i < spot.playerTypes.length; i++) i: spot.playerTypes[i]
+          for (var i = 0; i < playerCount; i++) i: spot.playerTypes[i]
         });
       _players
         ..clear()
         ..addAll([
-          for (var i = 0; i < spot.numberOfPlayers; i++)
+          for (var i = 0; i < playerCount; i++)
             PlayerModel(
               name: 'Player ${i + 1}',
               type: spot.playerTypes[i],

--- a/lib/screens/poker_analyzer_core.dart
+++ b/lib/screens/poker_analyzer_core.dart
@@ -39,6 +39,12 @@ class PokerAnalyzerScreenState extends State<PokerAnalyzerScreen>
   }
 
   @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
   void loadTrainingSpot(TrainingSpot spot) {
     _controller.loadSpot(spot);
   }


### PR DESCRIPTION
## Summary
- dispose `PokerAnalyzerController` when screen is disposed
- harden `loadSpot` against inconsistent imported data by clamping to available player data

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b4b43b32c832aa17d6ce574f3ae04