### PR TITLE
fix: remove duplicate controller getters

### DIFF
--- a/lib/controllers/poker_analyzer_controller.dart
+++ b/lib/controllers/poker_analyzer_controller.dart
@@ -36,6 +36,7 @@ class PokerAnalyzerController extends ChangeNotifier {
     notifyListeners();
   }
 
+  int get numberOfPlayers => _numberOfPlayers;
   set numberOfPlayers(int value) {
     if (_numberOfPlayers == value) return;
     _update(() {
@@ -43,6 +44,7 @@ class PokerAnalyzerController extends ChangeNotifier {
     });
   }
 
+  Map<int, String> get playerPositions => UnmodifiableMapView(_playerPositions);
   void setPlayerPosition(int index, String position) {
     final current = _playerPositions[index];
     if (current == position) return;
@@ -119,8 +121,4 @@ class PokerAnalyzerController extends ChangeNotifier {
 
   /// Convenience getter for the current player count.
   int get playerCount => _players.length;
-
-  /// Public getters used by tests/consumers.
-  int get numberOfPlayers => _numberOfPlayers;
-  Map<int, String> get playerPositions => UnmodifiableMapView(_playerPositions);
 }


### PR DESCRIPTION
## Summary
- relocate `numberOfPlayers` and `playerPositions` getters near setters and drop redundant copies at file end

## Testing
- `flutter test test/controllers/poker_analyzer_controller_test.dart` *(fails: command not found)*
- `dart test test/controllers/poker_analyzer_controller_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b52b4f1b4832aa675e96052e68cda