### PR TITLE
Disable pack chooser button during selection

### DIFF
--- a/lib/widgets/starter_packs_onboarding_banner.dart
+++ b/lib/widgets/starter_packs_onboarding_banner.dart
@@ -415,7 +415,7 @@ class _StarterPacksOnboardingBannerState
               children: [
                 if (_hasChooser)
                   TextButton(
-                    onPressed: _launching ? null : _choose,
+                    onPressed: (_launching || _choosing) ? null : _choose,
                     child: Text(t.starter_packs_choose),
                   ),
                 if (_hasChooser) const SizedBox(width: 8),


### PR DESCRIPTION
## Summary
- Disable starter pack chooser button while a chooser is active to avoid re-entrant taps

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689b739989dc832aa423f54768d93dbc