### PR TITLE
Add progress bar to starter packs onboarding banner

### DIFF
--- a/lib/widgets/starter_packs_onboarding_banner.dart
+++ b/lib/widgets/starter_packs_onboarding_banner.dart
@@ -44,6 +44,12 @@ class _StarterPacksOnboardingBannerState
         : '$total ${t.hands}';
   }
 
+  double _progressValue(int done, int total) {
+    if (total <= 0) return 0.0;
+    final clamped = done.clamp(0, total);
+    return clamped / total;
+  }
+
   @override
   void initState() {
     super.initState();
@@ -406,11 +412,20 @@ class _StarterPacksOnboardingBannerState
               _pack!.name,
               style: const TextStyle(fontWeight: FontWeight.w600),
             ),
-          if (hands > 0)
+          if (hands > 0) ...[
             Text(
               _progressText(done, hands, t),
               style: const TextStyle(color: Colors.white70),
             ),
+            const SizedBox(height: 4),
+            Semantics(
+              label: _progressText(done, hands, t),
+              child: LinearProgressIndicator(
+                value: _progressValue(done, hands),
+                minHeight: 4,
+              ),
+            ),
+          ],
           const SizedBox(height: 8),
           Align(
             alignment: Alignment.centerRight,


### PR DESCRIPTION
## Summary
- show subtle linear progress bar in starter packs onboarding banner

## Testing
- `dart format lib/widgets/starter_packs_onboarding_banner.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b76071934832ab9d91680c1be3b33