### PR TITLE
Prefill starter pack progress from cache after selection

### DIFF
--- a/lib/widgets/starter_packs_onboarding_banner.dart
+++ b/lib/widgets/starter_packs_onboarding_banner.dart
@@ -369,6 +369,11 @@ class _StarterPacksOnboardingBannerState
           _handsCompleted = null;
         });
 
+        final cached = prefs.getInt(_kPrefProgress(recommended.id));
+        if (cached != null && cached >= 0 && mounted) {
+          setState(() => _handsCompleted = cached);
+        }
+
         unawaited(
           (PackLibraryService.instance.getById(recommended.id) ??
                   Future.value(recommended))
@@ -404,6 +409,11 @@ class _StarterPacksOnboardingBannerState
         _pack = selected;
         _handsCompleted = null;
       });
+
+      final cached = prefs.getInt(_kPrefProgress(selected.id));
+      if (cached != null && cached >= 0 && mounted) {
+        setState(() => _handsCompleted = cached);
+      }
 
       unawaited(
         (PackLibraryService.instance.getById(selected.id) ??


### PR DESCRIPTION
## Summary
- prefill progress from cached values when a starter pack is chosen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b8357434c832a86b2ec0a9e8f2935