### PR TITLE
feat: stabilize starter pack sort order

### DIFF
--- a/lib/widgets/starter_packs_onboarding_banner.dart
+++ b/lib/widgets/starter_packs_onboarding_banner.dart
@@ -345,7 +345,12 @@ class _StarterPacksOnboardingBannerState
                   final aTotal = _totalHands(a);
                   final bTotal = _totalHands(b);
                   if (aTotal != bTotal) return bTotal.compareTo(aTotal);
-                  return a.name.toLowerCase().compareTo(b.name.toLowerCase());
+                  final nameCmp =
+                      a.name.toLowerCase().compareTo(b.name.toLowerCase());
+                  if (nameCmp != 0) return nameCmp;
+
+                  // New deterministic tiebreaker:
+                  return a.id.compareTo(b.id);
                 });
 
                 final isPinnedFirst =


### PR DESCRIPTION
## Summary
- ensure starter pack chooser sorts deterministically by adding id tiebreaker

## Testing
- `dart format lib/widgets/starter_packs_onboarding_banner.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b924e0fec832aaef37f87eacf5e5a