### PR TITLE
feat: add L2.1 theory IDs and tag mapping

### DIFF
--- a/assets/theory_index.json
+++ b/assets/theory_index.json
@@ -1,5 +1,16 @@
 [
   {"id":"th_push","title":"Push/Fold Basics","uri":"theory/push_fold_basics","tags":["push","icm"]},
   {"id":"th_bb_def","title":"BB Defense vs 2.5x","uri":"theory/bb_defense_2_5x","tags":["bb","defense"]},
-  {"id":"th_mono","title":"Monotone Flops Strategy","uri":"theory/monotone_flops","tags":["monotone","postflop"]}
+  {"id":"th_mono","title":"Monotone Flops Strategy","uri":"theory/monotone_flops","tags":["monotone","postflop"]},
+  {"id":"open_fold_overview","title":"Open/Fold Overview","uri":"theory/open_fold_overview","tags":["open_fold","overview"]},
+  {"id":"open_fold_ep_ranges","title":"Open/Fold EP Ranges","uri":"theory/open_fold_ep_ranges","tags":["open_fold","ep"]},
+  {"id":"open_fold_mp_ranges","title":"Open/Fold MP Ranges","uri":"theory/open_fold_mp_ranges","tags":["open_fold","mp"]},
+  {"id":"open_fold_co_ranges","title":"Open/Fold CO Ranges","uri":"theory/open_fold_co_ranges","tags":["open_fold","co"]},
+  {"id":"open_fold_btn_ranges","title":"Open/Fold BTN Ranges","uri":"theory/open_fold_btn_ranges","tags":["open_fold","btn"]},
+  {"id":"open_fold_sb_ranges","title":"Open/Fold SB Ranges","uri":"theory/open_fold_sb_ranges","tags":["open_fold","sb"]},
+  {"id":"3bp_overview","title":"3-Bet Push Overview","uri":"theory/3bp_overview","tags":["3bet_push","overview"]},
+  {"id":"3bp_10_15_bb","title":"3-Bet Push 10-15BB","uri":"theory/3bp_10_15_bb","tags":["3bet_push","10-15bb"]},
+  {"id":"3bp_15_20_bb","title":"3-Bet Push 15-20BB","uri":"theory/3bp_15_20_bb","tags":["3bet_push","15-20bb"]},
+  {"id":"3bp_20_25_bb","title":"3-Bet Push 20-25BB","uri":"theory/3bp_20_25_bb","tags":["3bet_push","20-25bb"]},
+  {"id":"3bp_25_30_bb","title":"3-Bet Push 25-30BB","uri":"theory/3bp_25_30_bb","tags":["3bet_push","25-30bb"]}
 ]

--- a/lib/recall/theory_map.dart
+++ b/lib/recall/theory_map.dart
@@ -1,0 +1,34 @@
+class TheoryMap {
+  static const Map<String, String> _openFoldPosition = {
+    'position:EP': 'open_fold_ep_ranges',
+    'position:MP': 'open_fold_mp_ranges',
+    'position:CO': 'open_fold_co_ranges',
+    'position:BTN': 'open_fold_btn_ranges',
+    'position:SB': 'open_fold_sb_ranges',
+  };
+
+  static const Map<String, String> _threeBetPushStack = {
+    'stack:10-15': '3bp_10_15_bb',
+    'stack:15-20': '3bp_15_20_bb',
+    'stack:20-25': '3bp_20_25_bb',
+    'stack:25-30': '3bp_25_30_bb',
+  };
+
+  static String? idFor(Iterable<String> tags) {
+    final t = tags.map((e) => e.toLowerCase()).toSet();
+    if (t.contains('open_fold')) {
+      for (final entry in _openFoldPosition.entries) {
+        if (t.contains(entry.key)) return entry.value;
+      }
+      return 'open_fold_overview';
+    }
+    if (t.contains('3bet_push')) {
+      for (final entry in _threeBetPushStack.entries) {
+        if (t.contains(entry.key)) return entry.value;
+      }
+      return '3bp_overview';
+    }
+    return null;
+  }
+}
+

--- a/test/theory/theory_integrity_actions_test.dart
+++ b/test/theory/theory_integrity_actions_test.dart
@@ -1,0 +1,48 @@
+import 'package:test/test.dart';
+import 'package:yaml/yaml.dart';
+import 'package:poker_analyzer/recall/theory_map.dart';
+
+void main() {
+  test('action tags resolve to theory ids with overview fallback', () {
+    const yaml = '''
+- tags: [open_fold, position:EP]
+- tags: [open_fold, position:EP]
+- tags: [open_fold, position:EP]
+- tags: [open_fold, position:EP]
+- tags: [open_fold, position:EP]
+- tags: [open_fold, position:EP]
+- tags: [open_fold, position:MP]
+- tags: [open_fold, position:CO]
+- tags: [open_fold, position:BTN]
+- tags: [open_fold, position:SB]
+- tags: [open_fold]
+- tags: [3bet_push, stack:10-15]
+- tags: [3bet_push, stack:10-15]
+- tags: [3bet_push, stack:10-15]
+- tags: [3bet_push, stack:10-15]
+- tags: [3bet_push, stack:10-15]
+- tags: [3bet_push, stack:10-15]
+- tags: [3bet_push, stack:15-20]
+- tags: [3bet_push, stack:20-25]
+- tags: [3bet_push, stack:25-30]
+''';
+
+    final entries = loadYaml(yaml) as YamlList;
+    var mapped = 0;
+    var total = 0;
+    for (final e in entries) {
+      final tags = (e['tags'] as YamlList).cast<String>();
+      final id = TheoryMap.idFor(tags);
+      expect(id, isNotNull);
+      if (id == 'open_fold_overview' || id == '3bp_overview') {
+        // overview fallback
+      } else {
+        mapped++;
+      }
+      total++;
+    }
+    expect(mapped / total, greaterThanOrEqualTo(0.95));
+    // ensure explicit fallback works for 3bet push
+    expect(TheoryMap.idFor(['3bet_push']), '3bp_overview');
+  });
+}


### PR DESCRIPTION
## Summary
- extend theory index with Open/Fold and 3-bet push IDs
- map new action tags to theory IDs with overview fallbacks
- add integrity test ensuring tag coverage

## Testing
- `dart test test/theory/theory_integrity_actions_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b9c7c13b8832a8ed48e1dbb38e782