### PR TITLE
feat: skip theory verification when report is missing

### DIFF
--- a/tool/theory_verify.sh
+++ b/tool/theory_verify.sh
@@ -4,12 +4,19 @@ set -euo pipefail
 MODE="${MODE:-}"
 if [[ -z "${MODE}" && "${1:-}" == "--mode" ]]; then
   MODE="${2:-}"
+  shift 2 || true
 fi
 
-REPORT_DIR="${REPORT_DIR:-build/theory_report}"
+REPORT_DIR_DEFAULT="build/theory_report"
+REPORT_DIR="${REPORT_DIR:-$REPORT_DIR_DEFAULT}"
+if [[ "${1:-}" == "--report-dir" ]]; then
+  REPORT_DIR="${2:-$REPORT_DIR_DEFAULT}"
+  shift 2 || true
+fi
 
 if [[ ! -d "$REPORT_DIR" ]] || [[ -z "$(ls -A "$REPORT_DIR" 2>/dev/null || true)" ]]; then
   echo "no report (no theory changes) — skipping verification"
+  echo "::notice title=Theory Integrity::No theory changes detected; verifier skipped."
   exit 0
 fi
 


### PR DESCRIPTION
## Summary
- allow overriding report dir via `--report-dir` flag
- skip theory verification when the report directory is empty or missing and emit a GitHub Actions notice

## Testing
- `./tool/theory_verify.sh && printf 'ran\n'`

------
https://chatgpt.com/codex/tasks/task_e_689ba703a0b4832a8ecf6d94c0e85e54