### PR TITLE
feat: gate theory verify and skip empty reports

### DIFF
--- a/.github/workflows/theory-integrity.yml
+++ b/.github/workflows/theory-integrity.yml
@@ -26,54 +26,34 @@ jobs:
           fetch-depth: 0
 
       - name: Detect theory changes
-        id: detect
-        shell: bash
-        run: |
-          set -euo pipefail
-          # Determine diff base safely for PRs vs pushes
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            BASE_SHA="${{ github.event.pull_request.base.sha }}"
-          else
-            # Fallback: compare with default branch
-            BASE_REF="${{ github.base_ref || 'origin/main' }}"
-            git fetch --no-tags --depth=1 origin "${BASE_REF#origin/}" || true
-            BASE_SHA="$(git rev-parse ${BASE_REF#origin/} || echo '')"
-          fi
-
-          if [[ -z "${BASE_SHA}" ]]; then
-            echo "No BASE_SHA — treating as changes present"
-            echo "has_changes=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # Paths that define theory
-          CHANGED="$(git diff --name-only "${BASE_SHA}"...HEAD | grep -E '^(assets/.*\\.ya?ml|assets/.*/theory/|theory/|yaml_out/)' || true)"
-
-          if [[ -n "${CHANGED}" ]]; then
-            echo "Theory changes detected:"
-            echo "${CHANGED}"
-            echo "has_changes=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "No theory changes -> skip strict verify"
-            echo "has_changes=false" >> "$GITHUB_OUTPUT"
-          fi
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          filters: |
+            theory:
+              - 'theory/**'
+              - 'content/theory/**'
+              - 'theory_index.json'
+              - 'training_packs/**.yaml'
+              - 'packs/**.yaml'
 
       - name: Set up Flutter
-        if: steps.detect.outputs.has_changes == 'true'
+        if: steps.filter.outputs.theory == 'true'
         uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
           cache: true
 
       - name: Install dependencies
-        if: steps.detect.outputs.has_changes == 'true'
+        if: steps.filter.outputs.theory == 'true'
         run: flutter pub get
 
       - name: Strict verify
-        if: steps.detect.outputs.has_changes == 'true'
+        if: steps.filter.outputs.theory == 'true'
         env:
           MODE: strict
         run: |
           echo "mode=$MODE"
-          tool/theory_verify.sh --mode "$MODE"
+          bash tool/theory_verify.sh
 

--- a/tool/theory_verify.sh
+++ b/tool/theory_verify.sh
@@ -1,23 +1,24 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-MODE="${MODE:-}"
-if [[ -z "${MODE}" && "${1:-}" == "--mode" ]]; then
-  MODE="${2:-}"
-  shift 2 || true
-fi
-
+# Resolve report dir (defaults to build/theory_report); can be overridden by REPORT_DIR env
 REPORT_DIR_DEFAULT="build/theory_report"
 REPORT_DIR="${REPORT_DIR:-$REPORT_DIR_DEFAULT}"
-if [[ "${1:-}" == "--report-dir" ]]; then
-  REPORT_DIR="${2:-$REPORT_DIR_DEFAULT}"
-  shift 2 || true
-fi
 
+echo "Theory verifier: MODE=${MODE:-strict}"
+echo "REPORT_DIR=${REPORT_DIR}"
+
+# --- Early success when no report to check ---
 if [[ ! -d "$REPORT_DIR" ]] || [[ -z "$(ls -A "$REPORT_DIR" 2>/dev/null || true)" ]]; then
   echo "no report (no theory changes) — skipping verification"
   echo "::notice title=Theory Integrity::No theory changes detected; verifier skipped."
   exit 0
 fi
 
-dart run bin/ci_report.dart --mode "$MODE"
+# --- Existing strict verification logic below ---
+if ! dart run bin/ci_report.dart --mode "${MODE:-strict}"; then
+  echo "::error title=Theory Integrity::Violations found"
+  exit 1
+fi
+
+echo "Theory verification passed."


### PR DESCRIPTION
## Summary
- gate Theory Integrity workflow on changes to theory files
- make theory verifier succeed when report directory is missing or empty
- add logging for mode and report dir

## Testing
- `bash tool/theory_verify.sh`


------
https://chatgpt.com/codex/tasks/task_e_689ba923a5fc832a829613ef6407667e