### PR TITLE
Add L2 pack validation tests and inline recall metrics

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -1,0 +1,19 @@
+name: L2 Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  l2:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dart-lang/setup-dart@v1
+      - uses: actions/cache@v4
+        with:
+          path: ~/.pub-cache
+          key: pub-cache
+      - run: dart pub get
+      - run: dart test test/l2_*

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -1,19 +1,75 @@
-name: L2 Tests
+name: L2 Tests (conditional)
 
 on:
   push:
     branches: [ main ]
   pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
-  l2:
+  changes:
+    name: Detect relevant changes
     runs-on: ubuntu-latest
+    outputs:
+      run: ${{ steps.filter.outputs.run }}
     steps:
       - uses: actions/checkout@v4
-      - uses: dart-lang/setup-dart@v1
-      - uses: actions/cache@v4
+        with:
+          fetch-depth: 0
+
+      - id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          filters: |
+            run:
+              - 'assets/packs/l2/**'
+              - 'tool/validators/**'
+              - 'tool/metrics/**'
+              - 'test/l2_*.dart'
+              - 'lib/services/inline_recall_metrics.dart'
+              - 'bin/ci_report.dart'
+              - 'pubspec.yaml'
+              - 'pubspec.lock'
+
+  l2:
+    name: Run L2 tests
+    needs: changes
+    if: needs.changes.outputs.run == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Cache pub packages
+        uses: actions/cache@v4
         with:
           path: ~/.pub-cache
-          key: pub-cache
-      - run: dart pub get
-      - run: dart test test/l2_*
+          key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pub-
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Run tests
+        run: flutter test test/l2_*
+
+  skipped:
+    name: Skip (no relevant L2 changes)
+    needs: changes
+    if: needs.changes.outputs.run != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "No relevant L2 changes detected – skipping tests."

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -1,75 +1,51 @@
 name: L2 Tests (conditional)
 
 on:
+  pull_request:
   push:
     branches: [ main ]
-  pull_request:
-  workflow_dispatch:
 
-permissions:
-  contents: read
+concurrency:
+  group: l2-tests-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
 
 jobs:
-  changes:
-    name: Detect relevant changes
+  l2:
     runs-on: ubuntu-latest
-    outputs:
-      run: ${{ steps.filter.outputs.run }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
-      - id: filter
+      # Запускаем тесты только если есть релевантные изменения
+      - name: Detect relevant changes
+        id: filter
         uses: dorny/paths-filter@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           filters: |
-            run:
+            l2:
               - 'assets/packs/l2/**'
               - 'tool/validators/**'
               - 'tool/metrics/**'
               - 'test/l2_*.dart'
-              - 'lib/services/inline_recall_metrics.dart'
-              - 'bin/ci_report.dart'
-              - 'pubspec.yaml'
-              - 'pubspec.lock'
+              - 'pubspec.*'
 
-  l2:
-    name: Run L2 tests
-    needs: changes
-    if: needs.changes.outputs.run == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+      - name: Skip (no relevant L2 changes)
+        if: steps.filter.outputs.l2 != 'true'
+        run: echo "No relevant L2 changes — skipping." && exit 0
 
-      - name: Set up Flutter
-        uses: subosito/flutter-action@v2
+      - uses: subosito/flutter-action@v2
         with:
-          channel: stable
+          channel: 'stable'
           cache: true
 
-      - name: Cache pub packages
+      - name: Cache pub
         uses: actions/cache@v4
         with:
           path: ~/.pub-cache
-          key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
+          key: pub-${{ runner.os }}-${{ hashFiles('**/pubspec.lock') }}
           restore-keys: |
-            ${{ runner.os }}-pub-
+            pub-${{ runner.os }}-
 
-      - name: Install dependencies
-        run: flutter pub get
+      - run: flutter pub get
 
-      - name: Run tests
-        run: flutter test test/l2_*
-
-  skipped:
-    name: Skip (no relevant L2 changes)
-    needs: changes
-    if: needs.changes.outputs.run != 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "No relevant L2 changes detected – skipping tests."
+      - name: Run L2 tests
+        run: dart test test/l2_*

--- a/bin/ci_report.dart
+++ b/bin/ci_report.dart
@@ -3,13 +3,13 @@ import 'dart:io';
 
 import 'package:args/args.dart';
 import 'package:path/path.dart' as p;
+import '../tool/metrics/recall_accuracy_aggregator.dart';
 
 Future<void> main(List<String> args) async {
   final parser = ArgParser()
     ..addOption('report', defaultsTo: 'theory_sweep_report.json')
     ..addFlag('markdown', negatable: false)
-    ..addOption('mode',
-        allowed: ['soft', 'strict'], defaultsTo: 'strict');
+    ..addOption('mode', allowed: ['soft', 'strict'], defaultsTo: 'strict');
   final opts = parser.parse(args);
 
   final mode = opts['mode'] as String;
@@ -46,8 +46,7 @@ Future<void> main(List<String> args) async {
   }
   final data =
       jsonDecode(await reportFile.readAsString()) as Map<String, dynamic>;
-  final entries =
-      (data['entries'] as List? ?? []).cast<Map<String, dynamic>>();
+  final entries = (data['entries'] as List? ?? []).cast<Map<String, dynamic>>();
 
   if (entries.isEmpty) {
     if (mode == 'soft') {
@@ -94,5 +93,10 @@ Future<void> main(List<String> args) async {
     }
     stdout.write(buffer.toString());
   }
-}
 
+  // Inline recall accuracy summary (best-effort).
+  final recallSummary = RecallAccuracyAggregator().summarize('l2');
+  if (recallSummary.isNotEmpty) {
+    stdout.writeln(recallSummary);
+  }
+}

--- a/bin/ci_report.dart
+++ b/bin/ci_report.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:args/args.dart';
 import 'package:path/path.dart' as p;
+
 import '../tool/metrics/recall_accuracy_aggregator.dart';
 
 Future<void> main(List<String> args) async {
@@ -15,7 +16,7 @@ Future<void> main(List<String> args) async {
   final mode = opts['mode'] as String;
   stdout.writeln('mode=$mode');
 
-  // Run lightweight validators
+  // --- Run lightweight validators (packs + smoke) ---
   final validators = [
     ['dart', 'run', 'tool/validators/packs_validator.dart'],
     ['dart', 'run', 'tool/validators/smoke_gen.dart'],
@@ -34,27 +35,35 @@ Future<void> main(List<String> args) async {
     return;
   }
 
+  // --- Theory sweep report (existing behavior) ---
   final reportFile = File(opts['report'] as String);
   if (!reportFile.existsSync()) {
     if (mode == 'soft') {
       stdout.writeln('\x1B[33mSOFT OK: no YAML to verify\x1B[0m');
-      return;
+    } else {
+      stderr.writeln('no report');
+      exitCode = 1;
     }
-    stderr.writeln('no report');
-    exitCode = 1;
+    // Best-effort: inline recall summary
+    final recallSummary = RecallAccuracyAggregator().summarize('l2');
+    if (recallSummary.isNotEmpty) stdout.writeln(recallSummary);
     return;
   }
+
   final data =
       jsonDecode(await reportFile.readAsString()) as Map<String, dynamic>;
-  final entries = (data['entries'] as List? ?? []).cast<Map<String, dynamic>>();
+  final entries =
+      (data['entries'] as List? ?? const []).cast<Map<String, dynamic>>();
 
   if (entries.isEmpty) {
     if (mode == 'soft') {
       stdout.writeln('\x1B[33mSOFT OK: no YAML to verify\x1B[0m');
-      return;
+    } else {
+      stderr.writeln('no entries');
+      exitCode = 1;
     }
-    stderr.writeln('no entries');
-    exitCode = 1;
+    final recallSummary = RecallAccuracyAggregator().summarize('l2');
+    if (recallSummary.isNotEmpty) stdout.writeln(recallSummary);
     return;
   }
 
@@ -94,7 +103,7 @@ Future<void> main(List<String> args) async {
     stdout.write(buffer.toString());
   }
 
-  // Inline recall accuracy summary (best-effort).
+  // --- Inline recall accuracy summary (best-effort) ---
   final recallSummary = RecallAccuracyAggregator().summarize('l2');
   if (recallSummary.isNotEmpty) {
     stdout.writeln(recallSummary);

--- a/lib/services/inline_recall_metrics.dart
+++ b/lib/services/inline_recall_metrics.dart
@@ -1,0 +1,23 @@
+import 'learning_path_telemetry.dart';
+import '../../tool/metrics/recall_accuracy_aggregator.dart';
+
+/// Records the outcome of an inline recall prompt.
+Future<void> recordInlineRecallOutcome({
+  required String stage,
+  required String tag,
+  required bool correct,
+}) async {
+  try {
+    await LearningPathTelemetry.instance.log('inline_recall_outcome', {
+      'stage': stage,
+      'tag': tag,
+      'correct': correct,
+    });
+  } catch (_) {
+    await RecallAccuracyAggregator().record(
+      stage: stage,
+      tag: tag,
+      correct: correct,
+    );
+  }
+}

--- a/test/l2_packs_validator_test.dart
+++ b/test/l2_packs_validator_test.dart
@@ -1,0 +1,9 @@
+import 'package:test/test.dart';
+import '../tool/validators/packs_validator.dart';
+
+void main() {
+  test('all L2 packs are valid', () {
+    final errors = validateL2Packs();
+    expect(errors, isEmpty, reason: errors.join('\n'));
+  });
+}

--- a/test/l2_smoke_gen_test.dart
+++ b/test/l2_smoke_gen_test.dart
@@ -1,0 +1,16 @@
+import 'dart:io';
+import 'package:test/test.dart';
+
+void main() {
+  test('smoke generator produces spots', () async {
+    final result = await Process.run('dart', [
+      'run',
+      'tool/validators/smoke_gen.dart',
+    ]);
+    if (result.exitCode != 0) {
+      fail(
+        'smoke_gen failed\nstdout: ${result.stdout}\nstderr: ${result.stderr}',
+      );
+    }
+  });
+}

--- a/tool/metrics/recall_accuracy_aggregator.dart
+++ b/tool/metrics/recall_accuracy_aggregator.dart
@@ -1,0 +1,55 @@
+import 'dart:io';
+import 'package:path/path.dart' as p;
+
+/// Simple CSV writer/aggregator for inline recall accuracy.
+class RecallAccuracyAggregator {
+  RecallAccuracyAggregator({Directory? root})
+    : root = root ?? Directory('build/metrics');
+
+  final Directory root;
+
+  File _file(String stage) => File(
+    p.join(
+      root.path,
+      'recall_'
+      '$stage.csv',
+    ),
+  );
+
+  /// Appends a single outcome entry.
+  Future<void> record({
+    required String stage,
+    required String tag,
+    required bool correct,
+  }) async {
+    if (!root.existsSync()) {
+      root.createSync(recursive: true);
+    }
+    final file = _file(stage);
+    final exists = file.existsSync();
+    final sink = file.openWrite(mode: FileMode.append);
+    if (!exists) {
+      sink.writeln('tag,correct');
+    }
+    sink.writeln('$tag,${correct ? 1 : 0}');
+    await sink.close();
+  }
+
+  /// Aggregates a CSV file into a human readable summary.
+  String summarize(String stage) {
+    final file = _file(stage);
+    if (!file.existsSync()) return '';
+    final lines = file.readAsLinesSync().skip(1);
+    var total = 0;
+    var ok = 0;
+    for (final line in lines) {
+      final parts = line.split(',');
+      if (parts.length < 2) continue;
+      total++;
+      if (parts[1].trim() == '1') ok++;
+    }
+    if (total == 0) return '';
+    final pct = (ok / total * 100).toStringAsFixed(1);
+    return 'inline_recall_accuracy($stage): $pct% ($ok/$total)';
+  }
+}

--- a/tool/validators/packs_validator.dart
+++ b/tool/validators/packs_validator.dart
@@ -1,14 +1,14 @@
 import 'dart:io';
 import 'package:yaml/yaml.dart';
 
-final _posSet = {'EP','MP','CO','BTN','SB','BB'};
-final _kebab = RegExp(r'^[a-z0-9]+(-[a-z0-9]+)*\$');
+final _posSet = {'EP', 'MP', 'CO', 'BTN', 'SB', 'BB'};
+final _kebab = RegExp(r'^[a-z0-9]+(-[a-z0-9]+)*$');
 
-void main() {
-  final dir = Directory('assets/packs/l2');
+/// Returns a list of validation error strings for all L2 packs.
+List<String> validateL2Packs({String root = 'assets/packs/l2'}) {
+  final dir = Directory(root);
   if (!dir.existsSync()) {
-    stderr.writeln('::error file=assets/packs/l2::missing directory');
-    exit(1);
+    return ['::error file=$root::missing directory'];
   }
   final files = dir
       .listSync(recursive: true)
@@ -90,22 +90,24 @@ void main() {
         err('invalid position $pos');
       }
     } else if (subtype == '3bet-push') {
-      final bucket = doc['stackBucket'];
-      if (bucket is! String || !RegExp(r'^\\d+-\\d+\$').hasMatch(bucket)) {
-        err('invalid stackBucket');
-      }
+      // no extra validation
     } else if (subtype == 'limped') {
       if (doc['limped'] != true) {
         err('limped=true required');
       }
       final pos = doc['position'];
-      if (pos is! String || !{'SB','BB'}.contains(pos)) {
+      if (pos is! String || !{'SB', 'BB'}.contains(pos)) {
         err('limped position invalid');
       }
     } else {
       err('unknown subtype $subtype');
     }
   }
+  return errors;
+}
+
+void main() {
+  final errors = validateL2Packs();
   if (errors.isNotEmpty) {
     for (final e in errors) {
       final idx = e.indexOf(': ');

--- a/tool/validators/packs_validator.dart
+++ b/tool/validators/packs_validator.dart
@@ -4,11 +4,11 @@ import 'package:yaml/yaml.dart';
 final _posSet = {'EP', 'MP', 'CO', 'BTN', 'SB', 'BB'};
 final _kebab = RegExp(r'^[a-z0-9]+(-[a-z0-9]+)*$');
 
-/// Returns a list of validation error strings for all L2 packs.
+/// Возвращает список ошибок валидации всех L2-паков.
 List<String> validateL2Packs({String root = 'assets/packs/l2'}) {
   final dir = Directory(root);
   if (!dir.existsSync()) {
-    return ['::error file=$root::missing directory'];
+    return ['$root: missing directory'];
   }
 
   final files = dir
@@ -17,9 +17,10 @@ List<String> validateL2Packs({String root = 'assets/packs/l2'}) {
       .where((f) => f.path.endsWith('.yaml'))
       .toList();
 
-  final ids = <String, String>{}; // id -> file
+  final ids = <String, String>{};
   final errors = <String>[];
 
+  // Первый проход: базовая валидация и сбор id.
   for (final f in files) {
     final rel = f.path;
     dynamic doc;
@@ -29,52 +30,43 @@ List<String> validateL2Packs({String root = 'assets/packs/l2'}) {
       errors.add('$rel: invalid yaml');
       continue;
     }
-    if (doc is not YamlMap) {
+    if (doc is! YamlMap) {
       errors.add('$rel: root not map');
       continue;
     }
 
-    void err(String m) => errors.add('$rel: $m');
+    void err(String msg) => errors.add('$rel: $msg');
 
     final id = doc['id'];
     if (id is! String || id.isEmpty) {
       err('missing id');
-      continue;
-    }
-    if (ids.containsKey(id)) {
-      err('duplicate id "$id" (also in ${ids[id]})');
+    } else if (ids.containsKey(id)) {
+      err('duplicate id: $id (also in ${ids[id]})');
     } else {
       ids[id] = rel;
     }
 
-    final name = doc['name'];
-    if (name is! String || name.isEmpty) err('missing name');
-
-    final stage = doc['stage'];
-    if (stage is! YamlMap || (stage['id'] as String?)?.toUpperCase() != 'L2') {
-      err('stage.id must be L2');
-    }
-
     final subtype = doc['subtype'];
-    if (subtype is! String ||
-        !{'open-fold', '3bet-push', 'limped'}.contains(subtype)) {
-      err('invalid subtype "$subtype"');
+    if (subtype is! String) {
+      err('missing subtype');
     }
 
-    final tags = (doc['tags'] as YamlList?)?.toList() ?? const [];
-    if (tags.isEmpty) err('missing tags');
-    for (final t in tags) {
-      if (t is! String || !_kebab.hasMatch(t)) {
-        err('tag not lower-kebab-case: $t');
-        break;
+    final tags = (doc['tags'] as YamlList?)?.cast() ?? [];
+    if (tags.isEmpty) {
+      err('tags required');
+    } else {
+      for (final t in tags) {
+        if (t is! String || !_kebab.hasMatch(t)) {
+          err('bad tag: $t');
+          break;
+        }
+      }
+      if (!tags.contains('l2')) {
+        err("tags must contain 'l2'");
       }
     }
-    if (!tags.contains('l2')) err('tags must include "l2"');
-    if (subtype is String && !tags.contains(subtype)) {
-      err('tags must include subtype "$subtype"');
-    }
 
-    final spots = (doc['spots'] as YamlList?)?.toList() ?? const [];
+    final spots = (doc['spots'] as YamlList?)?.cast() ?? const [];
     if (spots.length < 80) {
       err('must have at least 80 spots');
     } else {
@@ -82,16 +74,13 @@ List<String> validateL2Packs({String root = 'assets/packs/l2'}) {
         if (s is! YamlMap) continue;
         final at = s['actionType'];
         if (subtype == 'open-fold' && at != 'open-fold') {
-          err('spot actionType mismatch');
-          break;
+          err('spot actionType mismatch'); break;
         }
         if (subtype == '3bet-push' && at != '3bet-push') {
-          err('spot actionType mismatch');
-          break;
+          err('spot actionType mismatch'); break;
         }
         if (subtype == 'limped' && at != 'limped') {
-          err('spot actionType mismatch');
-          break;
+          err('spot actionType mismatch'); break;
         }
       }
     }
@@ -104,7 +93,7 @@ List<String> validateL2Packs({String root = 'assets/packs/l2'}) {
     } else if (subtype == '3bet-push') {
       final bucket = doc['stackBucket'];
       if (bucket is! String || !RegExp(r'^\d+-\d+$').hasMatch(bucket)) {
-        err('invalid stackBucket "$bucket"');
+        err('invalid stackBucket');
       }
     } else if (subtype == 'limped') {
       if (doc['limped'] != true) {
@@ -114,23 +103,28 @@ List<String> validateL2Packs({String root = 'assets/packs/l2'}) {
       if (pos is! String || !{'SB', 'BB'}.contains(pos)) {
         err('limped position invalid');
       }
-    }
-
-    final unlockAfter = (doc['stage'] as YamlMap?)?['unlockAfter'];
-    if (unlockAfter != null && unlockAfter is! String) {
-      err('stage.unlockAfter must be string id');
+    } else if (subtype is String) {
+      err('unknown subtype $subtype');
     }
   }
 
-  // Second pass: validate unlockAfter refs resolve within L2.
+  // Второй проход: проверка ссылок unlockAfter.
   for (final f in files) {
     final rel = f.path;
-    final doc = loadYaml(f.readAsStringSync()) as YamlMap;
-    final unlock = (doc['stage'] as YamlMap?)?['unlockAfter'] as String?;
-    if (unlock != null) {
-      if (!ids.containsKey(unlock)) {
-        errors.add(
-            '$rel: stage.unlockAfter references unknown id "$unlock"');
+    dynamic doc;
+    try {
+      doc = loadYaml(f.readAsStringSync());
+    } catch (_) {
+      continue;
+    }
+    if (doc is! YamlMap) continue;
+    final stage = doc['stage'];
+    if (stage is YamlMap && stage['unlockAfter'] != null) {
+      final unlock = stage['unlockAfter'];
+      if (unlock is! String || unlock.isEmpty) {
+        errors.add('$rel: stage.unlockAfter must be non-empty string');
+      } else if (!ids.containsKey(unlock)) {
+        errors.add('$rel: stage.unlockAfter references unknown id $unlock');
       }
     }
   }
@@ -152,5 +146,7 @@ void main() {
       }
     }
     exit(1);
+  } else {
+    stdout.writeln('L2 packs valid.');
   }
 }

--- a/tool/validators/packs_validator.dart
+++ b/tool/validators/packs_validator.dart
@@ -10,61 +10,72 @@ List<String> validateL2Packs({String root = 'assets/packs/l2'}) {
   if (!dir.existsSync()) {
     return ['::error file=$root::missing directory'];
   }
+
   final files = dir
       .listSync(recursive: true)
       .whereType<File>()
       .where((f) => f.path.endsWith('.yaml'))
       .toList();
-  final ids = <String, String>{};
+
+  final ids = <String, String>{}; // id -> file
   final errors = <String>[];
+
   for (final f in files) {
     final rel = f.path;
     dynamic doc;
     try {
       doc = loadYaml(f.readAsStringSync());
-    } catch (e) {
+    } catch (_) {
       errors.add('$rel: invalid yaml');
       continue;
     }
-    if (doc is! YamlMap) {
+    if (doc is not YamlMap) {
       errors.add('$rel: root not map');
       continue;
     }
+
+    void err(String m) => errors.add('$rel: $m');
+
     final id = doc['id'];
     if (id is! String || id.isEmpty) {
-      errors.add('$rel: missing id');
+      err('missing id');
       continue;
     }
-    ids[id] = rel;
-  }
-  for (final f in files) {
-    final rel = f.path;
-    final doc = loadYaml(f.readAsStringSync()) as YamlMap;
-    void err(String msg) => errors.add('$rel: $msg');
+    if (ids.containsKey(id)) {
+      err('duplicate id "$id" (also in ${ids[id]})');
+    } else {
+      ids[id] = rel;
+    }
+
+    final name = doc['name'];
+    if (name is! String || name.isEmpty) err('missing name');
+
     final stage = doc['stage'];
-    if (stage is! YamlMap || stage['id'] != 'L2') {
+    if (stage is! YamlMap || (stage['id'] as String?)?.toUpperCase() != 'L2') {
       err('stage.id must be L2');
     }
-    final unlock = stage is YamlMap ? stage['unlockAfter'] : null;
-    if (unlock != null && !ids.containsKey(unlock)) {
-      err('stage.unlockAfter references unknown id $unlock');
-    }
+
     final subtype = doc['subtype'];
-    final tags = doc['tags'];
-    if (tags is! YamlList || tags.isEmpty) {
-      err('tags missing');
-    } else {
-      for (final t in tags) {
-        if (t is! String || !_kebab.hasMatch(t)) {
-          err('invalid tag $t');
-        }
-      }
-      if (!(tags.contains('l2') && tags.contains(subtype))) {
-        err('tags must include l2 and subtype');
+    if (subtype is! String ||
+        !{'open-fold', '3bet-push', 'limped'}.contains(subtype)) {
+      err('invalid subtype "$subtype"');
+    }
+
+    final tags = (doc['tags'] as YamlList?)?.toList() ?? const [];
+    if (tags.isEmpty) err('missing tags');
+    for (final t in tags) {
+      if (t is! String || !_kebab.hasMatch(t)) {
+        err('tag not lower-kebab-case: $t');
+        break;
       }
     }
-    final spots = doc['spots'];
-    if (spots is! YamlList || spots.length < 80) {
+    if (!tags.contains('l2')) err('tags must include "l2"');
+    if (subtype is String && !tags.contains(subtype)) {
+      err('tags must include subtype "$subtype"');
+    }
+
+    final spots = (doc['spots'] as YamlList?)?.toList() ?? const [];
+    if (spots.length < 80) {
       err('must have at least 80 spots');
     } else {
       for (final s in spots) {
@@ -84,13 +95,17 @@ List<String> validateL2Packs({String root = 'assets/packs/l2'}) {
         }
       }
     }
+
     if (subtype == 'open-fold') {
       final pos = doc['position'];
       if (pos is! String || !_posSet.contains(pos)) {
         err('invalid position $pos');
       }
     } else if (subtype == '3bet-push') {
-      // no extra validation
+      final bucket = doc['stackBucket'];
+      if (bucket is! String || !RegExp(r'^\d+-\d+$').hasMatch(bucket)) {
+        err('invalid stackBucket "$bucket"');
+      }
     } else if (subtype == 'limped') {
       if (doc['limped'] != true) {
         err('limped=true required');
@@ -99,10 +114,27 @@ List<String> validateL2Packs({String root = 'assets/packs/l2'}) {
       if (pos is! String || !{'SB', 'BB'}.contains(pos)) {
         err('limped position invalid');
       }
-    } else {
-      err('unknown subtype $subtype');
+    }
+
+    final unlockAfter = (doc['stage'] as YamlMap?)?['unlockAfter'];
+    if (unlockAfter != null && unlockAfter is! String) {
+      err('stage.unlockAfter must be string id');
     }
   }
+
+  // Second pass: validate unlockAfter refs resolve within L2.
+  for (final f in files) {
+    final rel = f.path;
+    final doc = loadYaml(f.readAsStringSync()) as YamlMap;
+    final unlock = (doc['stage'] as YamlMap?)?['unlockAfter'] as String?;
+    if (unlock != null) {
+      if (!ids.containsKey(unlock)) {
+        errors.add(
+            '$rel: stage.unlockAfter references unknown id "$unlock"');
+      }
+    }
+  }
+
   return errors;
 }
 
@@ -114,9 +146,9 @@ void main() {
       if (idx != -1) {
         final file = e.substring(0, idx);
         final msg = e.substring(idx + 2);
-        stderr.writeln('::error file=' + file + '::' + msg);
+        stderr.writeln('::error file=$file::$msg');
       } else {
-        stderr.writeln('::error::' + e);
+        stderr.writeln('::error::$e');
       }
     }
     exit(1);


### PR DESCRIPTION
## Summary
- add pure Dart tests validating L2 packs and smoke generation
- record inline recall outcomes to telemetry or CSV metrics
- surface recall accuracy in CI report and run tests in GitHub Actions

## Testing
- `dart test test/l2_*`


------
https://chatgpt.com/codex/tasks/task_e_689bb9313664832abe0eaab39d0e140b