### PR TITLE
chore: fix l2 ci report and metrics

### DIFF
--- a/bin/ci_report.dart
+++ b/bin/ci_report.dart
@@ -30,82 +30,68 @@ Future<void> main(List<String> args) async {
       validatorFailed = true;
     }
   }
-  if (validatorFailed && mode == 'strict') {
-    exitCode = 1;
-    return;
-  }
-
-  // --- Theory sweep report (existing behavior) ---
-  final reportFile = File(opts['report'] as String);
-  if (!reportFile.existsSync()) {
-    if (mode == 'soft') {
-      stdout.writeln('\x1B[33mSOFT OK: no YAML to verify\x1B[0m');
+  Map<String, List<String>> issues = {};
+  if (!(validatorFailed && mode == 'strict')) {
+    final reportFile = File(opts['report'] as String);
+    if (!reportFile.existsSync()) {
+      if (mode == 'soft') {
+        stdout.writeln('\x1B[33mSOFT OK: no YAML to verify\x1B[0m');
+      } else {
+        stderr.writeln('no report');
+        exitCode = 1;
+      }
     } else {
-      stderr.writeln('no report');
-      exitCode = 1;
-    }
-    // Best-effort: inline recall summary
-    final recallSummary = RecallAccuracyAggregator().summarize('l2');
-    if (recallSummary.isNotEmpty) stdout.writeln(recallSummary);
-    return;
-  }
-
-  final data =
-      jsonDecode(await reportFile.readAsString()) as Map<String, dynamic>;
-  final entries =
-      (data['entries'] as List? ?? const []).cast<Map<String, dynamic>>();
-
-  if (entries.isEmpty) {
-    if (mode == 'soft') {
-      stdout.writeln('\x1B[33mSOFT OK: no YAML to verify\x1B[0m');
-    } else {
-      stderr.writeln('no entries');
-      exitCode = 1;
-    }
-    final recallSummary = RecallAccuracyAggregator().summarize('l2');
-    if (recallSummary.isNotEmpty) stdout.writeln(recallSummary);
-    return;
-  }
-
-  final issues = <String, List<String>>{
-    'needs_upgrade': [],
-    'needs_heal': [],
-    'failed': [],
-  };
-
-  for (final e in entries) {
-    final action = e['action'] as String? ?? '';
-    if (!issues.containsKey(action)) continue;
-    final file = p.relative(e['file'] as String? ?? '');
-    final oldHash = e['oldHash'] ?? '';
-    final newHash = e['newHash'] ?? '';
-    final msg = '$action: $oldHash -> $newHash';
-    final level = action == 'needs_upgrade' ? 'warning' : 'error';
-    stderr.writeln('::$level file=$file::$msg');
-    issues[action]!.add(file);
-  }
-
-  final hasIssues = issues.values.any((l) => l.isNotEmpty);
-  if (hasIssues && mode == 'strict') {
-    exitCode = 1;
-  }
-
-  if (opts['markdown'] as bool) {
-    final buffer = StringBuffer('### Theory Sweep Summary\n')
-      ..writeln('- mode=$mode');
-    for (final entry in issues.entries) {
-      if (entry.value.isEmpty) continue;
-      buffer.writeln('- **${entry.key}**');
-      for (final f in entry.value) {
-        buffer.writeln('  - `$f`');
+      final data =
+          jsonDecode(await reportFile.readAsString()) as Map<String, dynamic>;
+      final entries =
+          (data['entries'] as List? ?? const []).cast<Map<String, dynamic>>();
+      if (entries.isEmpty) {
+        if (mode == 'soft') {
+          stdout.writeln('\x1B[33mSOFT OK: no YAML to verify\x1B[0m');
+        } else {
+          stderr.writeln('no entries');
+          exitCode = 1;
+        }
+      } else {
+        issues = <String, List<String>>{
+          'needs_upgrade': [],
+          'needs_heal': [],
+          'failed': [],
+        };
+        for (final e in entries) {
+          final action = e['action'] as String? ?? '';
+          if (!issues.containsKey(action)) continue;
+          final file = p.relative(e['file'] as String? ?? '');
+          final oldHash = e['oldHash'] ?? '';
+          final newHash = e['newHash'] ?? '';
+          final msg = '$action: $oldHash -> $newHash';
+          final level = action == 'needs_upgrade' ? 'warning' : 'error';
+          stderr.writeln('::$level file=$file::$msg');
+          issues[action]!.add(file);
+        }
+        final hasIssues = issues.values.any((l) => l.isNotEmpty);
+        if (hasIssues && mode == 'strict') {
+          exitCode = 1;
+        }
+        if (opts['markdown'] as bool) {
+          final buffer = StringBuffer('### Theory Sweep Summary\n')
+            ..writeln('- mode=$mode');
+          for (final entry in issues.entries) {
+            if (entry.value.isEmpty) continue;
+            buffer.writeln('- **${entry.key}**');
+            for (final f in entry.value) {
+              buffer.writeln('  - `$f`');
+            }
+          }
+          stdout.write(buffer.toString());
+        }
       }
     }
-    stdout.write(buffer.toString());
+  } else {
+    exitCode = 1;
   }
 
   // --- Inline recall accuracy summary (best-effort) ---
   final recallSummary = RecallAccuracyAggregator().summarize('l2');
-  if (recallSummary.isNotEmpty) {
-    stdout.writeln(recallSummary);
-  }
+  if (recallSummary.isNotEmpty) stdout.writeln(recallSummary);
 }

--- a/lib/services/inline_recall_metrics.dart
+++ b/lib/services/inline_recall_metrics.dart
@@ -1,5 +1,4 @@
 import 'learning_path_telemetry.dart';
-import '../../tool/metrics/recall_accuracy_aggregator.dart';
 
 /// Records the outcome of an inline recall prompt.
 Future<void> recordInlineRecallOutcome({
@@ -14,10 +13,6 @@ Future<void> recordInlineRecallOutcome({
       'correct': correct,
     });
   } catch (_) {
-    await RecallAccuracyAggregator().record(
-      stage: stage,
-      tag: tag,
-      correct: correct,
-    );
+    // TODO: fallback aggregation is handled in tool/ scripts.
   }
 }


### PR DESCRIPTION
## Summary
- streamline CI report parsing and always emit L2 recall summary
- drop illegal recall aggregator import from inline metrics service

## Testing
- `dart format bin/ci_report.dart lib/services/inline_recall_metrics.dart`
- `flutter test test/l2_*` *(fails: test file not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bc3f048d4832a9a4f02f03849a60d