### PR TITLE
feat: add L2 autogen presets and validation

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -46,6 +46,13 @@ jobs:
             pub-${{ runner.os }}-
 
       - run: flutter pub get
-
+      - name: Generate L2 packs (seed 111)
+        run: dart run tool/autogen/l2_pack_generator.dart --preset all --seed 111 --out build/tmp/l2/111
+      - name: Generate L2 packs (seed 222)
+        run: dart run tool/autogen/l2_pack_generator.dart --preset all --seed 222 --out build/tmp/l2/222
+      - name: Generate L2 packs (seed 333)
+        run: dart run tool/autogen/l2_pack_generator.dart --preset all --seed 333 --out build/tmp/l2/333
+      - name: Validate presets
+        run: dart run tool/validators/preset_validator.dart --dir build/tmp/l2
       - name: Run L2 tests
         run: dart test test/l2_*

--- a/test/l2_autogen_smoke_test.dart
+++ b/test/l2_autogen_smoke_test.dart
@@ -1,0 +1,41 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+import '../tool/autogen/l2_presets.dart';
+
+void main() {
+  const seeds = ['111', '222', '333'];
+
+  for (final preset in allPresets) {
+    test('preset ' + preset, () async {
+      for (final seed in seeds) {
+        final outDir = 'build/tmp/l2_test/$preset/$seed';
+        final gen = await Process.run(
+          'dart',
+          [
+            'run',
+            'tool/autogen/l2_pack_generator.dart',
+            '--preset',
+            preset,
+            '--seed',
+            seed,
+            '--out',
+            outDir,
+          ],
+        );
+        expect(gen.exitCode, 0, reason: gen.stderr.toString());
+        final val = await Process.run(
+          'dart',
+          [
+            'run',
+            'tool/validators/preset_validator.dart',
+            '--dir',
+            outDir,
+          ],
+        );
+        expect(val.exitCode, 0, reason: val.stderr.toString());
+      }
+    });
+  }
+}

--- a/tool/autogen/l2_presets.dart
+++ b/tool/autogen/l2_presets.dart
@@ -1,0 +1,36 @@
+class L2Preset {
+  final String name;
+  final String subtype;
+  final List<String> positions;
+  final List<String> stackBuckets;
+  final bool limped;
+
+  const L2Preset({
+    required this.name,
+    required this.subtype,
+    this.positions = const [],
+    this.stackBuckets = const [],
+    this.limped = false,
+  });
+}
+
+const Map<String, L2Preset> l2Presets = {
+  'open-fold': L2Preset(
+    name: 'open-fold',
+    subtype: 'open-fold',
+    positions: ['EP', 'MP', 'CO', 'BTN', 'SB', 'BB'],
+  ),
+  '3bet-push': L2Preset(
+    name: '3bet-push',
+    subtype: '3bet-push',
+    stackBuckets: ['8-12', '13-18', '19-25', '26-32', '33-40', '41-50'],
+  ),
+  'limped': L2Preset(
+    name: 'limped',
+    subtype: 'limped',
+    positions: ['SB', 'BB'],
+    limped: true,
+  ),
+};
+
+const List<String> allPresets = ['open-fold', '3bet-push', 'limped'];

--- a/tool/validators/preset_validator.dart
+++ b/tool/validators/preset_validator.dart
@@ -1,0 +1,58 @@
+import 'dart:io';
+
+import 'package:args/args.dart';
+import 'package:yaml/yaml.dart';
+
+void main(List<String> args) {
+  final parser = ArgParser()..addOption('dir', mandatory: true);
+  final argResults = parser.parse(args);
+  final dir = Directory(argResults['dir'] as String);
+  if (!dir.existsSync()) {
+    stderr.writeln('Directory not found: ${dir.path}');
+    exit(1);
+  }
+  final files = dir
+      .listSync(recursive: true)
+      .whereType<File>()
+      .where((f) => f.path.endsWith('.yaml'));
+  var hadError = false;
+  final posSet = {'EP', 'MP', 'CO', 'BTN', 'SB', 'BB'};
+  final bucketReg = RegExp(r'^\d+-\d+$');
+  for (final file in files) {
+    final content = file.readAsStringSync();
+    final data = loadYaml(content) as YamlMap;
+    final subtype = data['subtype'];
+    final spots = data['spots'] as YamlList?;
+    if (spots == null || spots.isEmpty) {
+      stderr.writeln('Empty spots in ${file.path}');
+      hadError = true;
+      continue;
+    }
+    for (final spot in spots) {
+      if (spot['actionType'] != subtype) {
+        stderr.writeln('actionType mismatch in ${file.path}');
+        hadError = true;
+        break;
+      }
+    }
+    if (subtype == 'limped') {
+      if (data['limped'] != true) {
+        stderr.writeln('Missing limped:true in ${file.path}');
+        hadError = true;
+      }
+    } else if (subtype == 'open-fold') {
+      final pos = data['position'];
+      if (!posSet.contains(pos)) {
+        stderr.writeln('Invalid position $pos in ${file.path}');
+        hadError = true;
+      }
+    } else if (subtype == '3bet-push') {
+      final bucket = data['stackBucket'];
+      if (bucket is! String || !bucketReg.hasMatch(bucket)) {
+        stderr.writeln('Invalid stackBucket $bucket in ${file.path}');
+        hadError = true;
+      }
+    }
+  }
+  if (hadError) exit(1);
+}


### PR DESCRIPTION
## Summary
- add L2 preset definitions and CLI support for autogen
- add preset validator and smoke tests
- run autogen and validator in CI across multiple seeds

## Testing
- `dart run tool/autogen/l2_pack_generator.dart --preset all --seed 111 --out build/tmp/l2/111` *(fails: Couldn't resolve the package 'args')*
- `dart run tool/autogen/l2_pack_generator.dart --preset all --seed 222 --out build/tmp/l2/222` *(fails: Couldn't resolve the package 'args')*
- `dart run tool/autogen/l2_pack_generator.dart --preset all --seed 333 --out build/tmp/l2/333` *(fails: Couldn't resolve the package 'args')*
- `dart run tool/validators/preset_validator.dart --dir build/tmp/l2` *(fails: Couldn't resolve the package 'args')*
- `dart test test/l2_*` *(fails: Flutter SDK is not available)*


------
https://chatgpt.com/codex/tasks/task_e_689bcf96f040832aab22b928ef0c95d5