### PR TITLE
ci: harden L2 workflow

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -25,6 +25,7 @@ jobs:
               - 'assets/packs/l2/**'
               - 'tool/validators/**'
               - 'tool/metrics/**'
+              - 'tool/autogen/**'
               - 'test/l2_*.dart'
               - 'pubspec.*'
 
@@ -36,6 +37,8 @@ jobs:
         with:
           channel: 'stable'
           cache: true
+
+      - run: dart --version
 
       - name: Cache pub
         uses: actions/cache@v4

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -87,7 +87,8 @@ dev_dependencies:
   fake_cloud_firestore: ^3.1.0
   firebase_auth_mocks: ^0.14.0
   mocktail: ^1.0.4
-  yaml: ^3.1.1
+  args: ^2.5.0
+  yaml: ^3.1.2
   yaml_edit: ^2.2.2
 
 dependency_overrides:


### PR DESCRIPTION
## Summary
- add args and yaml dev dependencies for generators
- ensure L2 tests run when tool/autogen changes and surface dart version

## Testing
- `flutter pub get`
- `dart run tool/autogen/l2_pack_generator.dart --preset all --seed 111 --out build/tmp/l2/111`
- `dart run tool/autogen/l2_pack_generator.dart --preset all --seed 222 --out build/tmp/l2/222`
- `dart run tool/autogen/l2_pack_generator.dart --preset all --seed 333 --out build/tmp/l2/333`
- `dart run tool/validators/preset_validator.dart --dir build/tmp/l2`
- `dart test test/l2_*`


------
https://chatgpt.com/codex/tasks/task_e_689bd233aa2c832aa412a208d3ade26f