### PR TITLE
feat: add L2 theory snippets and recall cooldown

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -23,6 +23,7 @@ jobs:
           filters: |
             l2:
               - 'assets/packs/l2/**'
+              - 'assets/theory/**'
               - 'tool/validators/**'
               - 'tool/metrics/**'
               - 'tool/autogen/**'
@@ -49,6 +50,8 @@ jobs:
             pub-${{ runner.os }}-
 
       - run: flutter pub get
+      - name: Check L2 theory snippet coverage
+        run: dart run tool/validators/theory_snippet_coverage.dart --packs assets/packs/l2 --snippets assets/theory/l2/snippets.yaml --min 0.90
       - name: Generate L2 packs (seed 111)
         run: dart run tool/autogen/l2_pack_generator.dart --preset all --seed 111 --out build/tmp/l2/111
       - name: Generate L2 packs (seed 222)

--- a/assets/theory/l2/snippets.yaml
+++ b/assets/theory/l2/snippets.yaml
@@ -1,0 +1,51 @@
+13-18bb:
+  title: '13-18bb'
+  body: 'Guidelines for playing a 13-18bb stack.'
+19-25bb:
+  title: '19-25bb'
+  body: 'Guidelines for playing a 19-25bb stack.'
+26-32bb:
+  title: '26-32bb'
+  body: 'Guidelines for playing a 26-32bb stack.'
+33-40bb:
+  title: '33-40bb'
+  body: 'Guidelines for playing a 33-40bb stack.'
+3bet-push:
+  title: '3bet Push'
+  body: 'When to 3-bet shove effectively.'
+41-50bb:
+  title: '41-50bb'
+  body: 'Guidelines for playing a 41-50bb stack.'
+8-12bb:
+  title: '8-12bb'
+  body: 'Guidelines for playing an 8-12bb stack.'
+bb:
+  title: 'Big Blind'
+  body: 'Concepts specific to the big blind.'
+btn:
+  title: 'Button'
+  body: 'Concepts specific to the button position.'
+co:
+  title: 'Cutoff'
+  body: 'Concepts specific to the cutoff position.'
+ep:
+  title: 'Early Position'
+  body: 'Playing from early position.'
+limped:
+  title: 'Limped Pot'
+  body: 'Strategy for limped pots.'
+mp:
+  title: 'Middle Position'
+  body: 'Concepts specific to middle position.'
+open-fold:
+  title: 'Open or Fold'
+  body: 'Deciding when to open-raise or fold.'
+pushfold:
+  title: 'Push/Fold'
+  body: 'General push/fold strategy.'
+sb:
+  title: 'Small Blind'
+  body: 'Concepts specific to the small blind.'
+vs-open:
+  title: 'Versus Open'
+  body: 'Adjustments against an open raise.'

--- a/lib/screens/training_play_screen.dart
+++ b/lib/screens/training_play_screen.dart
@@ -22,6 +22,7 @@ import '../services/mistake_tag_classifier.dart';
 import '../services/user_error_rate_service.dart';
 import '../services/spaced_review_service.dart';
 import '../services/inline_recall_metrics.dart';
+import '../services/recall_cooldown_service.dart';
 
 class TrainingPlayScreen extends StatefulWidget {
   final LessonMatchProvider? lessonMatchProvider;
@@ -186,9 +187,17 @@ class _TrainingPlayScreenState extends State<TrainingPlayScreen> {
       res.correct,
       tags.toList(),
     );
+    RecallSnippetResult? gated;
+    if (snippet != null) {
+      final cooldown = await RecallCooldownService.instance;
+      if (cooldown.canShow(snippet.tagId)) {
+        await cooldown.markShown(snippet.tagId);
+        gated = snippet;
+      }
+    }
     setState(() {
       _result = res;
-      _recall = snippet;
+      _recall = gated;
       _lastAttempt = attempt;
     });
     if (_retesting) {

--- a/lib/services/recall_cooldown_service.dart
+++ b/lib/services/recall_cooldown_service.dart
@@ -1,0 +1,47 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+class RecallCooldownService {
+  RecallCooldownService._(this._prefs, this._now);
+
+  static RecallCooldownService? _instance;
+
+  static Future<RecallCooldownService> get instance async {
+    _instance ??= await RecallCooldownService.create();
+    return _instance!;
+  }
+
+  static Future<RecallCooldownService> create({
+    SharedPreferences? prefs,
+    DateTime Function()? now,
+  }) async {
+    final p = prefs ?? await SharedPreferences.getInstance();
+    return RecallCooldownService._(p, now ?? DateTime.now);
+  }
+
+  final SharedPreferences _prefs;
+  final DateTime Function() _now;
+  final Map<String, DateTime> _lastShown = {};
+
+  bool canShow(String tag, {Duration cooldown = const Duration(minutes: 10)}) {
+    final now = _now();
+    final last = _lastShown[tag] ?? _load(tag);
+    if (last == null) return true;
+    return now.difference(last) >= cooldown;
+  }
+
+  Future<void> markShown(String tag) async {
+    final now = _now();
+    _lastShown[tag] = now;
+    await _prefs.setInt(_key(tag), now.millisecondsSinceEpoch);
+  }
+
+  DateTime? _load(String tag) {
+    final ms = _prefs.getInt(_key(tag));
+    if (ms == null) return null;
+    final dt = DateTime.fromMillisecondsSinceEpoch(ms);
+    _lastShown[tag] = dt;
+    return dt;
+  }
+
+  static String _key(String tag) => 'recall_last_shown_' + tag;
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -135,6 +135,7 @@ flutter:
     - assets/theory_tracks/
     - assets/mini_lessons/
     - assets/theory_mini_lessons/
+    - assets/theory/l2/
     - assets/theory_lessons/level1/
     - assets/theory_lessons/level2/
     - assets/theory_lessons/level3/

--- a/test/recall_cooldown_test.dart
+++ b/test/recall_cooldown_test.dart
@@ -1,0 +1,21 @@
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:test/test.dart';
+import 'package:poker_analyzer/services/recall_cooldown_service.dart';
+
+void main() {
+  test('recall cooldown blocks within window', () async {
+    SharedPreferences.setMockInitialValues({});
+    var now = DateTime(2024, 1, 1, 12, 0);
+    DateTime fakeNow() => now;
+    final prefs = await SharedPreferences.getInstance();
+    final service = await RecallCooldownService.create(
+      prefs: prefs,
+      now: fakeNow,
+    );
+    expect(service.canShow('tag'), isTrue);
+    await service.markShown('tag');
+    expect(service.canShow('tag'), isFalse);
+    now = now.add(const Duration(minutes: 11));
+    expect(service.canShow('tag'), isTrue);
+  });
+}

--- a/test/theory_snippet_coverage_test.dart
+++ b/test/theory_snippet_coverage_test.dart
@@ -1,0 +1,17 @@
+import 'dart:io';
+import 'package:test/test.dart';
+
+void main() {
+  test('theory snippet coverage >= 0.90', () async {
+    final result = await Process.run('dart', [
+      'run',
+      'tool/validators/theory_snippet_coverage.dart',
+      '--packs', 'assets/packs/l2',
+      '--snippets', 'assets/theory/l2/snippets.yaml',
+      '--min', '0.90',
+    ]);
+    if (result.exitCode != 0) {
+      fail('validator failed: \n${result.stdout}\n${result.stderr}');
+    }
+  });
+}

--- a/tool/validators/theory_snippet_coverage.dart
+++ b/tool/validators/theory_snippet_coverage.dart
@@ -1,0 +1,63 @@
+import 'dart:io';
+import 'package:args/args.dart';
+import 'package:yaml/yaml.dart';
+
+Set<String> _collectTags(String root) {
+  final dir = Directory(root);
+  if (!dir.existsSync()) return {};
+  final files = dir
+      .listSync(recursive: true)
+      .whereType<File>()
+      .where((f) => f.path.endsWith('.yaml'));
+  final tags = <String>{};
+  for (final f in files) {
+    dynamic doc;
+    try {
+      doc = loadYaml(f.readAsStringSync());
+    } catch (_) {
+      continue;
+    }
+    final list = (doc['tags'] as YamlList?)?.cast() ?? const [];
+    for (final t in list) {
+      if (t is String && t != 'l2') {
+        tags.add(t);
+      }
+    }
+  }
+  return tags;
+}
+
+Map<String, dynamic> _loadSnippets(String path) {
+  final file = File(path);
+  if (!file.existsSync()) return {};
+  final data = loadYaml(file.readAsStringSync());
+  if (data is YamlMap) {
+    return Map<String, dynamic>.from(data);
+  }
+  return {};
+}
+
+void main(List<String> args) {
+  final parser = ArgParser()
+    ..addOption('packs', defaultsTo: 'assets/packs/l2')
+    ..addOption('snippets', defaultsTo: 'assets/theory/l2/snippets.yaml')
+    ..addOption('min', defaultsTo: '0.90');
+  final opts = parser.parse(args);
+  final packs = opts['packs'] as String;
+  final snippetsPath = opts['snippets'] as String;
+  final min = double.tryParse(opts['min'] as String) ?? 0.90;
+
+  final tags = _collectTags(packs);
+  final snippets = _loadSnippets(snippetsPath).keys.cast<String>().toSet();
+  final covered = tags.intersection(snippets).length;
+  final coverage = tags.isEmpty ? 1.0 : covered / tags.length;
+  final missing = tags.difference(snippets);
+  for (final tag in missing) {
+    stderr.writeln('::error file=$snippetsPath::missing snippet for tag $tag');
+  }
+  stdout.writeln(
+      'coverage ${(coverage * 100).toStringAsFixed(1)}% ($covered/${tags.length})');
+  if (coverage < min) {
+    exit(1);
+  }
+}


### PR DESCRIPTION
## Summary
- add initial L2 theory snippet library and validator
- gate inline recall with persistent cooldown
- test snippet coverage and recall cooldown

## Testing
- `dart run tool/validators/theory_snippet_coverage.dart --packs assets/packs/l2 --snippets assets/theory/l2/snippets.yaml --min 0.90` *(fails: command not found)*
- `dart test test/recall_cooldown_test.dart test/theory_snippet_coverage_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bd6bedb84832abf21795063c94f95