### PR TITLE
feat: add L2 metrics reporter and CI integration

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -62,3 +62,12 @@ jobs:
         run: dart run tool/validators/preset_validator.dart --dir build/tmp/l2
       - name: Run L2 tests
         run: dart test test/l2_*
+      - run: dart run tool/metrics/l2_metrics_report.dart --packs assets/packs/l2 --snippets assets/theory/l2/snippets.yaml --out build/reports/l2_report.md
+      - run: |
+          echo "::group::L2 Metrics"
+          cat build/reports/l2_report.md
+          echo "::endgroup::"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: l2_report.md
+          path: build/reports/l2_report.md

--- a/test/l2_metrics_smoke_test.dart
+++ b/test/l2_metrics_smoke_test.dart
@@ -1,0 +1,23 @@
+import 'dart:io';
+import 'package:test/test.dart';
+
+void main() {
+  test('l2 metrics smoke', () async {
+    final result = await Process.run('dart', [
+      'run',
+      'tool/metrics/l2_metrics_report.dart',
+      '--packs',
+      'assets/packs/l2',
+      '--snippets',
+      'assets/theory/l2/snippets.yaml',
+      '--out',
+      'build/tmp/l2_report.md',
+    ]);
+    expect(result.exitCode, 0);
+    final output = result.stdout.toString();
+    expect(output, contains('coverage'));
+    expect(output, contains('open-fold'));
+    expect(output, contains('3bet-push'));
+    expect(output, contains('limped'));
+  });
+}

--- a/tool/metrics/l2_metrics_report.dart
+++ b/tool/metrics/l2_metrics_report.dart
@@ -1,0 +1,148 @@
+import 'dart:io';
+
+class _SubtypeStats {
+  int packs = 0;
+  int spots = 0;
+  void add(int spotCount) {
+    packs += 1;
+    spots += spotCount;
+  }
+}
+
+Map<String, String> _parseArgs(List<String> args) {
+  final map = <String, String>{};
+  for (var i = 0; i < args.length; i++) {
+    final arg = args[i];
+    if (arg.startsWith('--') && i + 1 < args.length) {
+      map[arg.substring(2)] = args[++i];
+    }
+  }
+  return map;
+}
+
+String _renderHistogram(Map<String, int> counts) {
+  if (counts.isEmpty) return '';
+  final maxCount = counts.values.fold<int>(0, (a, b) => a > b ? a : b);
+  final buffer = StringBuffer();
+  final keys = counts.keys.toList()..sort();
+  for (final key in keys) {
+    final count = counts[key]!;
+    final barLen = maxCount == 0 ? 0 : ((count / maxCount) * 20).round();
+    final bar = ''.padRight(barLen, '#');
+    buffer.writeln('- $key: $count $bar');
+  }
+  return buffer.toString();
+}
+
+Set<String> _parseSnippetKeys(String content) {
+  final keys = <String>{};
+  for (final line in content.split('\n')) {
+    final match = RegExp(r'^(\S+):').firstMatch(line);
+    if (match != null) keys.add(match.group(1)!);
+  }
+  return keys;
+}
+
+Map<String, Object> _parsePack(String content) {
+  final subtypeMatch = RegExp(
+    r'^subtype:\s*(\S+)',
+    multiLine: true,
+  ).firstMatch(content);
+  final subtype = subtypeMatch?.group(1) ?? 'unknown';
+
+  final tags = <String>[];
+  final tagSection = RegExp(
+    r'^tags:\n((?:\s+-\s*\S+\n)+)',
+    multiLine: true,
+  ).firstMatch(content);
+  if (tagSection != null) {
+    final lines = tagSection.group(1)!.trim().split('\n');
+    for (final line in lines) {
+      final m = RegExp(r'-\s*(\S+)').firstMatch(line);
+      if (m != null) tags.add(m.group(1)!);
+    }
+  }
+
+  final spots = RegExp(
+    r'^\s{4}id:',
+    multiLine: true,
+  ).allMatches(content).length;
+
+  return {'subtype': subtype, 'tags': tags, 'spots': spots};
+}
+
+void main(List<String> args) async {
+  final argMap = _parseArgs(args);
+  final packsDir = Directory(argMap['packs'] ?? 'assets/packs/l2');
+  final snippetsFile = File(
+    argMap['snippets'] ?? 'assets/theory/l2/snippets.yaml',
+  );
+  final outFile = File(argMap['out'] ?? 'build/reports/l2_report.md');
+
+  final subtypeStats = <String, _SubtypeStats>{};
+  final tagUniverse = <String>{};
+  final bucketCounts = <String, int>{};
+  final positionCounts = <String, int>{};
+
+  final snippetKeys = _parseSnippetKeys(await snippetsFile.readAsString());
+  final bucketTags = snippetKeys.where((k) => k.contains('bb')).toSet();
+  final positionTags = {'ep', 'mp', 'co', 'btn', 'sb', 'bb'};
+
+  final packFiles = packsDir
+      .listSync(recursive: true)
+      .whereType<File>()
+      .where((f) => f.path.endsWith('.yaml'));
+
+  for (final file in packFiles) {
+    final parsed = _parsePack(await file.readAsString());
+    final subtype = parsed['subtype'] as String;
+    final spots = parsed['spots'] as int;
+    final tags = parsed['tags'] as List<String>;
+    subtypeStats.putIfAbsent(subtype, () => _SubtypeStats()).add(spots);
+    tagUniverse.addAll(tags);
+    for (final tag in tags) {
+      if (bucketTags.contains(tag)) {
+        bucketCounts[tag] = (bucketCounts[tag] ?? 0) + spots;
+      }
+      if (positionTags.contains(tag)) {
+        positionCounts[tag] = (positionCounts[tag] ?? 0) + spots;
+      }
+    }
+  }
+
+  final covered = snippetKeys.intersection(tagUniverse);
+  final coveragePct = snippetKeys.isEmpty
+      ? 0
+      : (covered.length / snippetKeys.length * 100);
+
+  final report = StringBuffer();
+  report.writeln('# L2 Metrics');
+  report.writeln();
+  report.writeln('## Packs');
+  subtypeStats.forEach((subtype, stats) {
+    report.writeln('- $subtype: ${stats.packs} packs, ${stats.spots} spots');
+  });
+  report.writeln();
+  report.writeln('## Tag Coverage');
+  report.writeln('- tag universe: ${tagUniverse.length}');
+  report.writeln(
+    '- snippet coverage: ${coveragePct.toStringAsFixed(1)}% (${covered.length}/${snippetKeys.length})',
+  );
+  report.writeln();
+  report.writeln('## Stack Buckets');
+  report.write(_renderHistogram(bucketCounts));
+  report.writeln('## Positions');
+  report.write(_renderHistogram(positionCounts));
+
+  if (!outFile.parent.existsSync()) {
+    outFile.parent.createSync(recursive: true);
+  }
+  await outFile.writeAsString(report.toString());
+
+  // stdout summary
+  print(
+    'l2 metrics: tag-universe ${tagUniverse.length}, '
+    'coverage ${coveragePct.toStringAsFixed(1)}%',
+  );
+  print(report.toString());
+}


### PR DESCRIPTION
## Summary
- add standalone l2 metrics reporter generating markdown summary
- wire metrics report into CI and expose as artifact
- smoke-test reporter to ensure coverage stats are printed

## Testing
- `dart run tool/metrics/l2_metrics_report.dart --packs assets/packs/l2 --snippets assets/theory/l2/snippets.yaml --out build/reports/l2_report.md`
- `dart test test/l2_metrics_smoke_test.dart test/l2_autogen_smoke_test.dart test/l2_packs_validator_test.dart test/l2_smoke_gen_test.dart` *(fails: flutter_test from sdk which doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_689bd8d96a54832a8d70d09b44f1b178