### PR TITLE
feat: add L3 flop board generator

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -23,11 +23,13 @@ jobs:
           filters: |
             l2:
               - 'assets/packs/l2/**'
+              - 'assets/packs/l3/**'
               - 'assets/theory/**'
               - 'tool/validators/**'
               - 'tool/metrics/**'
               - 'tool/autogen/**'
               - 'test/l2_*.dart'
+              - 'test/l3_*.dart'
               - 'pubspec.*'
 
       - name: Skip (no relevant L2 changes)
@@ -62,6 +64,16 @@ jobs:
         run: dart run tool/validators/preset_validator.dart --dir build/tmp/l2
       - name: Run L2 tests
         run: dart test test/l2_*
+      - name: Generate L3 boards (seed 111)
+        run: dart run tool/autogen/l3_board_generator.dart --preset all --seed 111 --out build/tmp/l3/111
+      - name: Generate L3 boards (seed 222)
+        run: dart run tool/autogen/l3_board_generator.dart --preset all --seed 222 --out build/tmp/l3/222
+      - name: Generate L3 boards (seed 333)
+        run: dart run tool/autogen/l3_board_generator.dart --preset all --seed 333 --out build/tmp/l3/333
+      - name: Validate L3 distribution
+        run: dart run tool/validators/l3_distribution_validator.dart --dir build/tmp/l3
+      - name: Run L3 tests
+        run: dart test test/l3_*
       - run: dart run tool/metrics/l2_metrics_report.dart --packs assets/packs/l2 --snippets assets/theory/l2/snippets.yaml --out build/reports/l2_report.md
       - run: |
           echo "::group::L2 Metrics"

--- a/test/l3_autogen_distribution_test.dart
+++ b/test/l3_autogen_distribution_test.dart
@@ -1,0 +1,35 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+import '../tool/autogen/l3_presets.dart';
+
+void main() {
+  const seeds = ['111', '222', '333'];
+
+  for (final preset in allPresets) {
+    test('preset ' + preset, () async {
+      for (final seed in seeds) {
+        final outDir = 'build/tmp/l3_test/$preset/$seed';
+        final gen = await Process.run('dart', [
+          'run',
+          'tool/autogen/l3_board_generator.dart',
+          '--preset',
+          preset,
+          '--seed',
+          seed,
+          '--out',
+          outDir,
+        ]);
+        expect(gen.exitCode, 0, reason: gen.stderr.toString());
+        final val = await Process.run('dart', [
+          'run',
+          'tool/validators/l3_distribution_validator.dart',
+          '--dir',
+          outDir,
+        ]);
+        expect(val.exitCode, 0, reason: val.stderr.toString());
+      }
+    });
+  }
+}

--- a/tool/autogen/l3_board_generator.dart
+++ b/tool/autogen/l3_board_generator.dart
@@ -1,0 +1,185 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math';
+
+import 'package:args/args.dart';
+import 'package:path/path.dart' as p;
+
+import 'l3_presets.dart';
+
+const _ranks = [
+  'A',
+  'K',
+  'Q',
+  'J',
+  'T',
+  '9',
+  '8',
+  '7',
+  '6',
+  '5',
+  '4',
+  '3',
+  '2',
+];
+const _suits = ['s', 'h', 'd', 'c'];
+
+List<String> _buildDeck() {
+  return [
+    for (final r in _ranks)
+      for (final s in _suits) '$r$s',
+  ];
+}
+
+List<String> _generateBoard(Random rng) {
+  final deck = _buildDeck();
+  List<String> cards = [];
+  for (var i = 0; i < 5; i++) {
+    final c = deck.removeAt(rng.nextInt(deck.length));
+    cards.add(c);
+  }
+  return cards;
+}
+
+String _texture(List<String> flop) {
+  final suits = flop.map((c) => c[1]).toSet();
+  if (suits.length == 1) return 'monotone';
+  if (suits.length == 2) return 'twoTone';
+  return 'rainbow';
+}
+
+bool _isPaired(List<String> flop) {
+  final ranks = flop.map((c) => c[0]).toList();
+  return ranks[0] == ranks[1] || ranks[0] == ranks[2] || ranks[1] == ranks[2];
+}
+
+bool _isAceHigh(List<String> flop) => flop.any((c) => c[0] == 'A');
+
+bool _isBroadway(List<String> flop) {
+  const broadway = {'A', 'K', 'Q', 'J', 'T'};
+  return flop.where((c) => broadway.contains(c[0])).length >= 2;
+}
+
+Map<String, double> _parseTargetMix(String arg) {
+  final file = File(arg);
+  final content = file.existsSync() ? file.readAsStringSync() : arg;
+  final decoded = json.decode(content) as Map<String, dynamic>;
+  return decoded.map((key, value) => MapEntry(key, (value as num).toDouble()));
+}
+
+Map<String, int> _allocateCounts(Map<String, double> mix, int total) {
+  final counts = <String, int>{};
+  var remaining = total;
+  final entries = mix.entries.toList();
+  for (var i = 0; i < entries.length; i++) {
+    final key = entries[i].key;
+    int count;
+    if (i == entries.length - 1) {
+      count = remaining;
+    } else {
+      count = (entries[i].value * total).round();
+      remaining -= count;
+    }
+    counts[key] = count;
+  }
+  return counts;
+}
+
+void main(List<String> args) {
+  final parser = ArgParser()
+    ..addOption('preset', defaultsTo: 'all')
+    ..addOption('seed', defaultsTo: '42')
+    ..addOption('out', defaultsTo: 'build/tmp/l3')
+    ..addOption('targetMix');
+  final res = parser.parse(args);
+  final presetArg = res['preset'] as String;
+  final seed = int.parse(res['seed'] as String);
+  final outDir = res['out'] as String;
+  final targetMixArg = res['targetMix'] as String?;
+
+  final presets = presetArg == 'all' ? allPresets : [presetArg];
+
+  final rng = Random(seed);
+
+  for (final name in presets) {
+    final preset = l3Presets[name];
+    if (preset == null) {
+      stderr.writeln('Unknown preset $name');
+      exit(1);
+    }
+    final mix =
+        targetMixArg != null ? _parseTargetMix(targetMixArg) : preset.targetMix;
+    _generateForPreset(outDir, name, preset, rng, mix);
+  }
+}
+
+void _generateForPreset(
+  String outDir,
+  String name,
+  L3Preset preset,
+  Random rng,
+  Map<String, double> mix,
+) {
+  const spotCount = 100;
+  final counts = _allocateCounts(mix, spotCount);
+  final boards = <String>[];
+  final textures = <String>[];
+  final used = <String>{};
+
+  for (final entry in counts.entries) {
+    final texture = entry.key;
+    final count = entry.value;
+    for (var i = 0; i < count; i++) {
+      while (true) {
+        final board = _generateBoard(rng);
+        final flop = board.sublist(0, 3);
+        if (_texture(flop) != texture) continue;
+        if (preset.filter != null && !preset.filter!(flop)) continue;
+        final boardStr = board.join();
+        if (used.add(boardStr)) {
+          boards.add(boardStr);
+          textures.add(texture);
+          break;
+        }
+      }
+    }
+  }
+
+  final dir = Directory(p.join(outDir, 'postflop-jam', name));
+  dir.createSync(recursive: true);
+  final id = 'l3-postflop-jam-$name';
+  final file = File(p.join(dir.path, '$id.yaml'));
+  final sb = StringBuffer();
+  sb.writeln('id: $id');
+  sb.writeln('stage:');
+  sb.writeln('  id: L3');
+  sb.writeln('subtype: postflop-jam');
+  sb.writeln('street: flop');
+  sb.writeln('tags:');
+  sb.writeln('  - l3');
+  sb.writeln('  - $name');
+  sb.writeln('spots:');
+  for (var i = 0; i < boards.length; i++) {
+    final spotId = '${id}-s${(i + 1).toString().padLeft(3, '0')}';
+    final board = boards[i];
+    final flop = [
+      board.substring(0, 2),
+      board.substring(2, 4),
+      board.substring(4, 6),
+    ];
+    final texture = textures[i];
+    final tags = <String>['l3', texture];
+    tags.add(_isPaired(flop) ? 'paired' : 'unpaired');
+    if (_isAceHigh(flop)) tags.add('ace-high');
+    if (_isBroadway(flop)) tags.add('broadway');
+    sb.writeln('  -');
+    sb.writeln('    id: $spotId');
+    sb.writeln('    actionType: postflop-jam');
+    sb.writeln('    board: $board');
+    sb.writeln('    tags:');
+    for (final t in tags) {
+      sb.writeln('      - $t');
+    }
+  }
+  file.writeAsStringSync(sb.toString());
+}

--- a/tool/autogen/l3_presets.dart
+++ b/tool/autogen/l3_presets.dart
@@ -1,0 +1,46 @@
+class L3Preset {
+  final String name;
+  final Map<String, double> targetMix;
+  final bool Function(List<String> flop)? filter;
+
+  const L3Preset({required this.name, required this.targetMix, this.filter});
+}
+
+bool _paired(List<String> flop) {
+  final ranks = flop.map((c) => c[0]).toList();
+  return ranks[0] == ranks[1] || ranks[0] == ranks[2] || ranks[1] == ranks[2];
+}
+
+bool _unpaired(List<String> flop) => !_paired(flop);
+
+bool _aceHigh(List<String> flop) => flop.any((c) => c[0] == 'A');
+
+const Map<String, L3Preset> l3Presets = {
+  'paired': L3Preset(
+    name: 'paired',
+    targetMix: {'monotone': 0.2, 'twoTone': 0.3, 'rainbow': 0.5},
+    filter: _paired,
+  ),
+  'unpaired': L3Preset(
+    name: 'unpaired',
+    targetMix: {'monotone': 0.2, 'twoTone': 0.3, 'rainbow': 0.5},
+    filter: _unpaired,
+  ),
+  'ace-high': L3Preset(
+    name: 'ace-high',
+    targetMix: {'monotone': 0.2, 'twoTone': 0.3, 'rainbow': 0.5},
+    filter: _aceHigh,
+  ),
+  'broadway': L3Preset(
+    name: 'broadway',
+    targetMix: {'monotone': 0.2, 'twoTone': 0.3, 'rainbow': 0.5},
+    filter: _broadway,
+  ),
+};
+
+List<String> get allPresets => l3Presets.keys.toList();
+
+bool _broadway(List<String> flop) {
+  const broadway = {'A', 'K', 'Q', 'J', 'T'};
+  return flop.where((c) => broadway.contains(c[0])).length >= 2;
+}

--- a/tool/validators/l3_distribution_validator.dart
+++ b/tool/validators/l3_distribution_validator.dart
@@ -1,0 +1,90 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:args/args.dart';
+import 'package:path/path.dart' as p;
+import 'package:yaml/yaml.dart';
+
+import '../autogen/l3_presets.dart';
+
+String _texture(String board) {
+  final flop = [
+    board.substring(0, 2),
+    board.substring(2, 4),
+    board.substring(4, 6),
+  ];
+  final suits = flop.map((c) => c[1]).toSet();
+  if (suits.length == 1) return 'monotone';
+  if (suits.length == 2) return 'twoTone';
+  return 'rainbow';
+}
+
+Map<String, double> _parseTargetMix(String arg) {
+  final file = File(arg);
+  final content = file.existsSync() ? file.readAsStringSync() : arg;
+  final decoded = json.decode(content) as Map<String, dynamic>;
+  return decoded.map((k, v) => MapEntry(k, (v as num).toDouble()));
+}
+
+void main(List<String> args) {
+  final parser = ArgParser()
+    ..addOption('dir', defaultsTo: 'build/tmp/l3')
+    ..addOption('targetMix')
+    ..addOption('tolerance', defaultsTo: '0.1');
+  final res = parser.parse(args);
+  final rootDir = res['dir'] as String;
+  final tol = double.parse(res['tolerance'] as String);
+  final targetMixArg = res['targetMix'] as String?;
+
+  final dir = Directory(rootDir);
+  if (!dir.existsSync()) {
+    stderr.writeln('Directory not found: $rootDir');
+    exit(1);
+  }
+
+  var hasError = false;
+  for (final file
+      in dir
+          .listSync(recursive: true)
+          .whereType<File>()
+          .where((f) => f.path.endsWith('.yaml'))) {
+    final preset = p.basename(p.dirname(file.path));
+    final presetDef = l3Presets[preset];
+    if (presetDef == null) continue;
+    final mix = targetMixArg != null
+        ? _parseTargetMix(targetMixArg)
+        : presetDef.targetMix;
+    final content = loadYaml(file.readAsStringSync()) as Map;
+    final spots = content['spots'] as List?;
+    if (spots == null || spots.isEmpty) {
+      stderr.writeln('Pack ${file.path} has no spots');
+      hasError = true;
+      continue;
+    }
+    if (spots.length != 100) {
+      stderr.writeln(
+        'Pack ${file.path} has ${spots.length} spots, expected 100',
+      );
+      hasError = true;
+    }
+    final counts = <String, int>{};
+    for (final s in spots) {
+      final board = s['board'] as String?;
+      if (board == null) continue;
+      final t = _texture(board);
+      counts[t] = (counts[t] ?? 0) + 1;
+    }
+    final total = spots.length;
+    for (final entry in mix.entries) {
+      final actual = (counts[entry.key] ?? 0) / total;
+      final diff = (actual - entry.value).abs();
+      if (diff > tol) {
+        stderr.writeln(
+          '::warning::${preset} ${entry.key} expected ${entry.value.toStringAsFixed(2)} actual ${actual.toStringAsFixed(2)}',
+        );
+        hasError = true;
+      }
+    }
+  }
+  if (hasError) exit(1);
+}


### PR DESCRIPTION
## Summary
- add L3 flop board generator with texture-aware presets and CLI
- validate L3 distribution with new validator
- exercise L3 generation via new test and CI steps

## Testing
- `flutter test test/l3_autogen_distribution_test.dart` *(fails: No tests ran)*
- `dart run tool/autogen/l3_board_generator.dart --preset paired --seed 111 --out build/tmp/l3_manual/111` *(no output generated)*


------
https://chatgpt.com/codex/tasks/task_e_689bdbafb1c4832a9a4aa7d3133a1b80