### PR TITLE
feat: add jam/fold evaluator and pack run CLI

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -72,6 +72,20 @@ jobs:
         run: dart run tool/autogen/l3_board_generator.dart --preset all --seed 333 --out build/tmp/l3/333
       - name: Validate L3 distribution
         run: dart run tool/validators/l3_distribution_validator.dart --dir build/tmp/l3
+      - name: PackRun L3 (seed 111)
+        run: dart run tool/l3/pack_run_cli.dart --dir build/tmp/l3/111 --out build/reports/l3_packrun_111.json
+      - name: PackRun L3 (seed 222)
+        run: dart run tool/l3/pack_run_cli.dart --dir build/tmp/l3/222 --out build/reports/l3_packrun_222.json
+      - name: PackRun L3 (seed 333)
+        run: dart run tool/l3/pack_run_cli.dart --dir build/tmp/l3/333 --out build/reports/l3_packrun_333.json
+      - name: Upload L3 PackRun reports
+        uses: actions/upload-artifact@v4
+        with:
+          name: l3_packrun_reports
+          path: |
+            build/reports/l3_packrun_111.json
+            build/reports/l3_packrun_222.json
+            build/reports/l3_packrun_333.json
       - name: Run L3 tests
         run: dart test test/l3_*
       - run: dart run tool/metrics/l2_metrics_report.dart --packs assets/packs/l2 --snippets assets/theory/l2/snippets.yaml --out build/reports/l2_report.md

--- a/lib/l3/jam_fold_evaluator.dart
+++ b/lib/l3/jam_fold_evaluator.dart
@@ -1,0 +1,113 @@
+import 'dart:convert';
+
+class FlopBoard {
+  final List<String> cards; // e.g. ['As','Kd','Th']
+
+  FlopBoard(this.cards) : assert(cards.length == 3);
+
+  factory FlopBoard.fromString(String board) {
+    return FlopBoard([
+      board.substring(0, 2),
+      board.substring(2, 4),
+      board.substring(4, 6),
+    ]);
+  }
+
+  bool get isPaired {
+    final ranks = cards.map((c) => c[0]).toList();
+    return ranks[0] == ranks[1] ||
+        ranks[0] == ranks[2] ||
+        ranks[1] == ranks[2];
+  }
+
+  bool get isAceHigh => cards.any((c) => c[0] == 'A');
+
+  bool get isBroadway {
+    const broadway = {'A', 'K', 'Q', 'J', 'T'};
+    return cards.where((c) => broadway.contains(c[0])).length >= 2;
+  }
+
+  String get texture {
+    final suits = cards.map((c) => c[1]).toSet();
+    if (suits.length == 1) return 'monotone';
+    if (suits.length == 2) return 'twoTone';
+    return 'rainbow';
+  }
+
+  List<String> get tags {
+    final list = <String>[texture];
+    list.add(isPaired ? 'paired' : 'unpaired');
+    if (isAceHigh) list.add('ace-high');
+    if (isBroadway) list.add('broadway');
+    return list;
+  }
+}
+
+class JamFoldOutcome {
+  final double jamEV;
+  final double foldEV;
+  final String decision; // 'jam' or 'fold'
+
+  JamFoldOutcome({required this.jamEV, required this.foldEV, required this.decision});
+
+  Map<String, dynamic> toJson() => {
+        'jamEV': jamEV,
+        'foldEV': foldEV,
+        'decision': decision,
+      };
+}
+
+class JamFoldEvaluator {
+  final Map<String, double> weights;
+
+  JamFoldEvaluator({Map<String, double>? weights})
+      : weights = weights ?? _defaultWeights;
+
+  factory JamFoldEvaluator.fromJson(String jsonStr) {
+    final decoded = json.decode(jsonStr) as Map<String, dynamic>;
+    return JamFoldEvaluator(
+      weights: decoded.map((k, v) => MapEntry(k, (v as num).toDouble())),
+    );
+  }
+
+  JamFoldOutcome evaluate({
+    required FlopBoard board,
+    required double spr,
+    Map<String, double>? priors,
+  }) {
+    final bucket = spr < 1
+        ? 'spr_low'
+        : spr < 2
+            ? 'spr_mid'
+            : 'spr_high';
+
+    double score = 0;
+    for (final tag in board.tags) {
+      score += weights[tag] ?? 0;
+    }
+    score += weights[bucket] ?? 0;
+
+    final jamPrior = priors?['jam'] ?? 0.5;
+    final foldPrior = priors?['fold'] ?? 0.5;
+
+    final jamEV = jamPrior + score;
+    final foldEV = foldPrior - score;
+    final decision = jamEV >= foldEV ? 'jam' : 'fold';
+
+    return JamFoldOutcome(jamEV: jamEV, foldEV: foldEV, decision: decision);
+  }
+}
+
+const Map<String, double> _defaultWeights = {
+  'paired': -0.2,
+  'unpaired': 0.2,
+  'monotone': -0.3,
+  'twoTone': 0.1,
+  'rainbow': 0.2,
+  'ace-high': 0.1,
+  'broadway': 0.05,
+  'spr_low': 0.3,
+  'spr_mid': 0.0,
+  'spr_high': -0.3,
+};
+

--- a/test/l3_evaluator_rules_test.dart
+++ b/test/l3_evaluator_rules_test.dart
@@ -1,0 +1,24 @@
+import 'package:poker_analyzer/l3/jam_fold_evaluator.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final evaluator = JamFoldEvaluator();
+
+  test('monotone broadway high SPR -> fold', () {
+    final board = FlopBoard.fromString('AsKsQs');
+    final out = evaluator.evaluate(board: board, spr: 2.5);
+    expect(out.decision, 'fold');
+  });
+
+  test('rainbow unpaired low SPR -> jam', () {
+    final board = FlopBoard.fromString('AsKd7c');
+    final out = evaluator.evaluate(board: board, spr: 0.8);
+    expect(out.decision, 'jam');
+  });
+
+  test('twoTone ace-high mid SPR -> jam', () {
+    final board = FlopBoard.fromString('AsKd9d');
+    final out = evaluator.evaluate(board: board, spr: 1.5);
+    expect(out.decision, 'jam');
+  });
+}

--- a/test/l3_packrun_cli_test.dart
+++ b/test/l3_packrun_cli_test.dart
@@ -1,0 +1,37 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+void main() {
+  test('pack run cli smoke', () async {
+    final outDir = 'build/tmp/l3_cli/111';
+    final gen = await Process.run('dart', [
+      'run',
+      'tool/autogen/l3_board_generator.dart',
+      '--preset',
+      'paired',
+      '--seed',
+      '111',
+      '--out',
+      outDir,
+    ]);
+    expect(gen.exitCode, 0, reason: gen.stderr.toString());
+    final reportFile = File('build/reports/l3_packrun_test.json');
+    final run = await Process.run('dart', [
+      'run',
+      'tool/l3/pack_run_cli.dart',
+      '--dir',
+      outDir,
+      '--out',
+      reportFile.path,
+    ]);
+    expect(run.exitCode, 0, reason: run.stderr.toString());
+    final report = json.decode(reportFile.readAsStringSync()) as Map<String, dynamic>;
+    final spots = report['spots'] as List<dynamic>;
+    expect(spots, isNotEmpty);
+    for (final spot in spots) {
+      expect(spot['decision'], isIn(['jam', 'fold']));
+    }
+  });
+}

--- a/tool/l3/pack_run_cli.dart
+++ b/tool/l3/pack_run_cli.dart
@@ -1,0 +1,74 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:args/args.dart';
+import 'package:yaml/yaml.dart';
+
+import 'package:poker_analyzer/l3/jam_fold_evaluator.dart';
+
+double _sprFromBoard(String board) {
+  final hash = board.codeUnits.fold<int>(0, (a, b) => a + b);
+  return 0.5 + (hash % 300) / 100.0; // 0.5 - 3.5
+}
+
+void main(List<String> args) {
+  final parser = ArgParser()
+    ..addOption('dir', defaultsTo: 'build/tmp/l3/111')
+    ..addOption('out', defaultsTo: 'build/reports/l3_packrun.json');
+  final res = parser.parse(args);
+  final dir = res['dir'] as String;
+  final outPath = res['out'] as String;
+
+  final evaluator = JamFoldEvaluator();
+  final outSpots = <Map<String, dynamic>>[];
+  final textureCounts = <String, int>{};
+  int jamCount = 0;
+
+  try {
+    final yamlFiles = Directory(dir)
+        .listSync(recursive: true)
+        .whereType<File>()
+        .where((f) => f.path.endsWith('.yaml'));
+    for (final file in yamlFiles) {
+      final doc = loadYaml(file.readAsStringSync()) as YamlMap;
+      final spots = doc['spots'] as YamlList?;
+      if (spots == null) continue;
+      for (final spot in spots) {
+        final s = spot as YamlMap;
+        final id = s['id'] as String;
+        final boardStr = s['board'] as String;
+        final tags = (s['tags'] as YamlList?)?.cast<String>() ?? <String>[];
+        final texture = tags.firstWhere(
+            (t) => t == 'monotone' || t == 'twoTone' || t == 'rainbow',
+            orElse: () => 'unknown');
+        textureCounts[texture] = (textureCounts[texture] ?? 0) + 1;
+        final spr = _sprFromBoard(boardStr);
+        final outcome = evaluator.evaluate(
+          board: FlopBoard.fromString(boardStr),
+          spr: spr,
+        );
+        if (outcome.decision == 'jam') jamCount++;
+        outSpots.add({
+          'id': id,
+          'board': boardStr,
+          'decision': outcome.decision,
+          'jamEV': outcome.jamEV,
+          'foldEV': outcome.foldEV,
+        });
+      }
+    }
+    final summary = {
+      'total': outSpots.length,
+      'avgJamRate': outSpots.isEmpty ? 0 : jamCount / outSpots.length,
+      'textureCounts': textureCounts,
+      'accuracy': {'jam': 0, 'fold': 0},
+    };
+    final report = {'spots': outSpots, 'summary': summary};
+    final outFile = File(outPath);
+    outFile.parent.createSync(recursive: true);
+    outFile.writeAsStringSync(jsonEncode(report));
+  } catch (e) {
+    stderr.writeln('Parse error: $e');
+    exit(1);
+  }
+}


### PR DESCRIPTION
## Summary
- add pure Dart jam/fold evaluator with texture and SPR heuristics
- introduce headless L3 pack run CLI and wire into CI
- cover evaluator and CLI with smoke tests

## Testing
- `dart test test/l3_*` *(fails: test/l3_autogen_distribution_test.dart: preset paired - did not complete; test/l3_packrun_cli_test.dart: pack run cli smoke - did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_689bdfbf8f8c832aaf39adbe2b87e8de