### PR TITLE
fix: align L3 paired preset with feasible textures

### DIFF
--- a/test/l3_feasibility_test.dart
+++ b/test/l3_feasibility_test.dart
@@ -1,0 +1,55 @@
+import 'package:test/test.dart';
+
+const _ranks = [
+  'A',
+  'K',
+  'Q',
+  'J',
+  'T',
+  '9',
+  '8',
+  '7',
+  '6',
+  '5',
+  '4',
+  '3',
+  '2',
+];
+const _suits = ['s', 'h', 'd', 'c'];
+
+List<String> _buildDeck() {
+  return [
+    for (final r in _ranks)
+      for (final s in _suits) '$r$s',
+  ];
+}
+
+bool _isPaired(List<String> flop) {
+  final ranks = flop.map((c) => c[0]).toList();
+  return ranks[0] == ranks[1] || ranks[0] == ranks[2] || ranks[1] == ranks[2];
+}
+
+String _texture(List<String> flop) {
+  final suits = flop.map((c) => c[1]).toSet();
+  if (suits.length == 1) return 'monotone';
+  if (suits.length == 2) return 'twoTone';
+  return 'rainbow';
+}
+
+void main() {
+  test('paired & monotone flops are impossible', () {
+    final deck = _buildDeck();
+    var count = 0;
+    for (var i = 0; i < deck.length; i++) {
+      for (var j = i + 1; j < deck.length; j++) {
+        for (var k = j + 1; k < deck.length; k++) {
+          final flop = [deck[i], deck[j], deck[k]];
+          if (_isPaired(flop) && _texture(flop) == 'monotone') {
+            count++;
+          }
+        }
+      }
+    }
+    expect(count, 0);
+  });
+}

--- a/tool/autogen/l3_presets.dart
+++ b/tool/autogen/l3_presets.dart
@@ -18,7 +18,8 @@ bool _aceHigh(List<String> flop) => flop.any((c) => c[0] == 'A');
 const Map<String, L3Preset> l3Presets = {
   'paired': L3Preset(
     name: 'paired',
-    targetMix: {'monotone': 0.2, 'twoTone': 0.3, 'rainbow': 0.5},
+    // paired∧monotone impossible because a pair requires two suits
+    targetMix: {'monotone': 0.0, 'twoTone': 0.50, 'rainbow': 0.50},
     filter: _paired,
   ),
   'unpaired': L3Preset(


### PR DESCRIPTION
## Summary
- set L3 paired preset mix to 0% monotone, split evenly between two-tone and rainbow
- document that paired & monotone flops are impossible
- add feasibility test to ensure paired monotone flops never appear

## Testing
- `flutter test test/l3_feasibility_test.dart`
- `flutter test test/l3_autogen_distribution_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_689be62ba29c832a9d31ec6fce607ce5