### PR TITLE
feat: add L3 PackRun metrics reporter

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -82,6 +82,16 @@ jobs:
         run: dart run tool/l3/pack_run_cli.dart --dir build/tmp/l3/222 --out build/reports/l3_packrun_222.json
       - name: PackRun L3 (seed 333)
         run: dart run tool/l3/pack_run_cli.dart --dir build/tmp/l3/333 --out build/reports/l3_packrun_333.json
+      - name: L3 PackRun metrics
+        run: dart run tool/metrics/l3_packrun_report.dart --reports build/reports/l3_packrun_111.json,build/reports/l3_packrun_222.json,build/reports/l3_packrun_333.json --out build/reports/l3_report.md
+      - run: |
+          echo "::group::L3 Metrics"
+          cat build/reports/l3_report.md
+          echo "::endgroup::"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: l3_report.md
+          path: build/reports/l3_report.md
       - name: Upload L3 PackRun reports
         uses: actions/upload-artifact@v4
         with:

--- a/test/l3_metrics_smoke_test.dart
+++ b/test/l3_metrics_smoke_test.dart
@@ -1,0 +1,54 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+void main() {
+  test('l3 metrics smoke', () async {
+    const jsonPath = 'build/reports/l3_packrun_test.json';
+    final jsonFile = File(jsonPath);
+    if (!jsonFile.existsSync()) {
+      final dir = Directory('build/tmp/l3/test');
+      dir.createSync(recursive: true);
+      final yaml = '''
+spots:
+  - id: a
+    board: AhKhQh
+    tags: [monotone]
+  - id: b
+    board: AhKdQc
+    tags: [twoTone]
+  - id: c
+    board: AhKdQs
+    tags: [rainbow]
+''';
+      File('${dir.path}/test.yaml').writeAsStringSync(yaml);
+      final gen = await Process.run('dart', [
+        'run',
+        'tool/l3/pack_run_cli.dart',
+        '--dir',
+        dir.path,
+        '--out',
+        jsonPath,
+      ]);
+      if (gen.exitCode != 0) {
+        throw Exception('pack run failed: ${gen.stderr}');
+      }
+    }
+
+    final res = await Process.run('dart', [
+      'run',
+      'tool/metrics/l3_packrun_report.dart',
+      '--reports',
+      jsonPath,
+      '--out',
+      'build/reports/l3_report_test.md',
+    ]);
+    final stdout = (res.stdout as String).toLowerCase();
+    expect(stdout, contains('jam rate'));
+    final md =
+        File('build/reports/l3_report_test.md').readAsStringSync().toLowerCase();
+    expect(md, contains('monotone'));
+    expect(md, contains('twotone'));
+    expect(md, contains('rainbow'));
+  });
+}

--- a/tool/metrics/l3_packrun_report.dart
+++ b/tool/metrics/l3_packrun_report.dart
@@ -1,0 +1,90 @@
+import 'dart:convert';
+import 'dart:io';
+
+Map<String, String> _parseArgs(List<String> args) {
+  final map = <String, String>{};
+  for (var i = 0; i < args.length; i++) {
+    final arg = args[i];
+    if (arg.startsWith('--') && i + 1 < args.length) {
+      map[arg.substring(2)] = args[++i];
+    }
+  }
+  return map;
+}
+
+String _renderHistogram(Map<String, int> counts) {
+  if (counts.isEmpty) return '';
+  final maxCount = counts.values.fold<int>(0, (a, b) => a > b ? a : b);
+  final buffer = StringBuffer();
+  final keys = counts.keys.toList()..sort();
+  for (final key in keys) {
+    final count = counts[key]!;
+    final barLen = maxCount == 0 ? 0 : ((count / maxCount) * 20).round();
+    final bar = ''.padRight(barLen, '#');
+    buffer.writeln('- $key: $count $bar');
+  }
+  return buffer.toString();
+}
+
+void main(List<String> args) async {
+  try {
+    final argMap = _parseArgs(args);
+    final reportsArg = argMap['reports'];
+    if (reportsArg == null || reportsArg.isEmpty) {
+      print('l3 metrics: no reports provided');
+      return;
+    }
+    final outFile = File(argMap['out'] ?? 'build/reports/l3_report.md');
+    final reportPaths = reportsArg.split(',').map((s) => s.trim()).where((s) => s.isNotEmpty);
+
+    var totalSpots = 0;
+    var jamCount = 0.0;
+    final textureCounts = <String, int>{};
+    final presetCounts = <String, int>{};
+
+    for (final path in reportPaths) {
+      final file = File(path);
+      if (!file.existsSync()) continue;
+      final json = jsonDecode(await file.readAsString()) as Map<String, dynamic>;
+      final summary = (json['summary'] as Map<String, dynamic>?) ?? {};
+      final total = (summary['total'] as num?)?.toInt() ?? 0;
+      final avgJam = (summary['avgJamRate'] as num?)?.toDouble() ?? 0;
+      final textures = (summary['textureCounts'] as Map<String, dynamic>?) ?? {};
+      final presets = (summary['presetCounts'] as Map<String, dynamic>?) ?? {};
+
+      totalSpots += total;
+      jamCount += avgJam * total;
+      textures.forEach((k, v) {
+        textureCounts[k] = (textureCounts[k] ?? 0) + (v as num).toInt();
+      });
+      presets.forEach((k, v) {
+        presetCounts[k] = (presetCounts[k] ?? 0) + (v as num).toInt();
+      });
+    }
+
+    final jamRate = totalSpots == 0 ? 0 : jamCount / totalSpots;
+
+    final buffer = StringBuffer();
+    buffer.writeln('# L3 PackRun Metrics');
+    buffer.writeln();
+    buffer.writeln('- total spots: $totalSpots');
+    buffer.writeln('- jam rate: ${(jamRate * 100).toStringAsFixed(1)}%');
+    buffer.writeln();
+    buffer.writeln('## Texture Distribution');
+    buffer.write(_renderHistogram(textureCounts));
+    if (presetCounts.isNotEmpty) {
+      buffer.writeln('## Presets');
+      buffer.write(_renderHistogram(presetCounts));
+    }
+
+    if (!outFile.parent.existsSync()) {
+      outFile.parent.createSync(recursive: true);
+    }
+    await outFile.writeAsString(buffer.toString());
+
+    print('l3 metrics: total $totalSpots, jam rate ${(jamRate * 100).toStringAsFixed(1)}%');
+    print(buffer.toString());
+  } catch (e) {
+    stderr.writeln('l3 metrics error: $e');
+  }
+}


### PR DESCRIPTION
## Summary
- add Dart tool to aggregate L3 PackRun JSONs and emit Markdown metrics
- wire L3 metrics reporter into CI workflow and upload report artifact
- cover reporter with smoke test

## Testing
- `dart test test/l3_metrics_smoke_test.dart` *(fails: Because poker_analyzer depends on flutter_test from sdk which doesn't exist)*
- `flutter pub get` *(fails: lottie 3.3.1 requires SDK version ^3.6.0)*
- `dart run tool/metrics/l3_packrun_report.dart --reports build/reports/l3_packrun_test.json --out build/reports/l3_report_test.md`


------
https://chatgpt.com/codex/tasks/task_e_689bf13fd860832aa18e3eb523401183