### PR TITLE
ci: pin flutter 3.27 for l2 tests

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -39,8 +39,10 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
+          flutter-version: '3.27.0'
           cache: true
 
+      - run: flutter --version
       - run: dart --version
 
       - name: Cache pub


### PR DESCRIPTION
## Summary
- pin L2 Tests workflow to Flutter 3.27.0 (Dart ≥3.6) and report flutter version

## Testing
- `dart --version` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bf42f40f8832ab0a928baabfe12e3