### PR TITLE
feat: add L3 demo sampler and packs

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -24,12 +24,16 @@ jobs:
             l2:
               - 'assets/packs/l2/**'
               - 'assets/packs/l3/**'
+              - 'assets/packs/l3/demo/**'
               - 'assets/theory/**'
               - 'tool/validators/**'
+              - 'tool/validators/l3_demo_validator.dart'
               - 'tool/metrics/**'
               - 'tool/autogen/**'
+              - 'tool/autogen/l3_demo_sampler.dart'
               - 'test/l2_*.dart'
               - 'test/l3_*.dart'
+              - 'test/l3_demo_*.dart'
               - 'pubspec.*'
 
       - name: Skip (no relevant L2 changes)
@@ -78,6 +82,12 @@ jobs:
       - name: Validate L3 distribution
         timeout-minutes: 5
         run: dart run tool/validators/l3_distribution_validator.dart --dir build/tmp/l3 --dedupe flop
+      - name: Generate L3 demo packs
+        run: dart run tool/autogen/l3_demo_sampler.dart --source build/tmp/l3/111 --preset all --out assets/packs/l3/demo --spots 100 --dedupe flop --seed 111
+      - name: Validate L3 demo packs
+        run: dart run tool/validators/l3_demo_validator.dart --dir assets/packs/l3/demo --dedupe flop
+      - name: Run L3 demo tests
+        run: dart test test/l3_demo_*
       - name: PackRun L3 (seed 111)
         run: dart run tool/l3/pack_run_cli.dart --dir build/tmp/l3/111 --out build/reports/l3_packrun_111.json
       - name: PackRun L3 (seed 222)

--- a/assets/packs/l3/demo/l3-demo-ace-high.yaml
+++ b/assets/packs/l3/demo/l3-demo-ace-high.yaml
@@ -1,0 +1,869 @@
+id: l3-demo-ace-high
+stage:
+  id: L3
+subtype: postflop-jam
+street: flop
+tags:
+  - l3
+  - demo
+  - ace-high
+spots:
+  -
+    id: l3-demo-ace-high-s001
+    actionType: postflop-jam
+    board: Ac3d2s7h8d
+    tags:
+      - rainbow
+      - unpaired
+      - ace-high
+  -
+    id: l3-demo-ace-high-s002
+    actionType: postflop-jam
+    board: Ac3s2cJh3d
+    tags:
+      - twoTone
+      - unpaired
+      - ace-high
+  -
+    id: l3-demo-ace-high-s003
+    actionType: postflop-jam
+    board: Ac3s2sAhQh
+    tags:
+      - twoTone
+      - unpaired
+      - ace-high
+  -
+    id: l3-demo-ace-high-s004
+    actionType: postflop-jam
+    board: Ac5d4sTc4d
+    tags:
+      - rainbow
+      - unpaired
+      - ace-high
+  -
+    id: l3-demo-ace-high-s005
+    actionType: postflop-jam
+    board: Ac6s5sAs5c
+    tags:
+      - twoTone
+      - unpaired
+      - ace-high
+  -
+    id: l3-demo-ace-high-s006
+    actionType: postflop-jam
+    board: Ac7c5c6s6h
+    tags:
+      - monotone
+      - unpaired
+      - ace-high
+  -
+    id: l3-demo-ace-high-s007
+    actionType: postflop-jam
+    board: Ac8c2d6s5h
+    tags:
+      - twoTone
+      - unpaired
+      - ace-high
+  -
+    id: l3-demo-ace-high-s008
+    actionType: postflop-jam
+    board: Ac8s2cTsKh
+    tags:
+      - twoTone
+      - unpaired
+      - ace-high
+  -
+    id: l3-demo-ace-high-s009
+    actionType: postflop-jam
+    board: Ac8s3hKcQh
+    tags:
+      - rainbow
+      - unpaired
+      - ace-high
+  -
+    id: l3-demo-ace-high-s010
+    actionType: postflop-jam
+    board: Ac9c7hTdQd
+    tags:
+      - twoTone
+      - unpaired
+      - ace-high
+  -
+    id: l3-demo-ace-high-s011
+    actionType: postflop-jam
+    board: Ac9d8h7d3h
+    tags:
+      - rainbow
+      - unpaired
+      - ace-high
+  -
+    id: l3-demo-ace-high-s012
+    actionType: postflop-jam
+    board: Ac9h8s3sJs
+    tags:
+      - rainbow
+      - unpaired
+      - ace-high
+  -
+    id: l3-demo-ace-high-s013
+    actionType: postflop-jam
+    board: Ac9s2h5s4c
+    tags:
+      - rainbow
+      - unpaired
+      - ace-high
+  -
+    id: l3-demo-ace-high-s014
+    actionType: postflop-jam
+    board: AcJc2c4dJh
+    tags:
+      - monotone
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-ace-high-s015
+    actionType: postflop-jam
+    board: AcJc9c5d2c
+    tags:
+      - monotone
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-ace-high-s016
+    actionType: postflop-jam
+    board: AcJcTd7cKd
+    tags:
+      - twoTone
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-ace-high-s017
+    actionType: postflop-jam
+    board: AcJd8s6s2s
+    tags:
+      - rainbow
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-ace-high-s018
+    actionType: postflop-jam
+    board: AcJd9h3c3h
+    tags:
+      - rainbow
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-ace-high-s019
+    actionType: postflop-jam
+    board: AcJdJcKh7h
+    tags:
+      - twoTone
+      - paired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-ace-high-s020
+    actionType: postflop-jam
+    board: AcJh9sTs6h
+    tags:
+      - rainbow
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-ace-high-s021
+    actionType: postflop-jam
+    board: AcJs9c5hTd
+    tags:
+      - twoTone
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-ace-high-s022
+    actionType: postflop-jam
+    board: AcKcQcAh6h
+    tags:
+      - monotone
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-ace-high-s023
+    actionType: postflop-jam
+    board: AcKd3h9hAd
+    tags:
+      - rainbow
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-ace-high-s024
+    actionType: postflop-jam
+    board: AcKd7hQd7s
+    tags:
+      - rainbow
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-ace-high-s025
+    actionType: postflop-jam
+    board: AcQc5c4d9c
+    tags:
+      - monotone
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-ace-high-s026
+    actionType: postflop-jam
+    board: AcQc6c3cKs
+    tags:
+      - monotone
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-ace-high-s027
+    actionType: postflop-jam
+    board: AcTd4cJhQd
+    tags:
+      - twoTone
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-ace-high-s028
+    actionType: postflop-jam
+    board: AcTh5d6h7c
+    tags:
+      - rainbow
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-ace-high-s029
+    actionType: postflop-jam
+    board: AcTs6h8sKs
+    tags:
+      - rainbow
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-ace-high-s030
+    actionType: postflop-jam
+    board: Ad2s2c9d4d
+    tags:
+      - rainbow
+      - paired
+      - ace-high
+  -
+    id: l3-demo-ace-high-s031
+    actionType: postflop-jam
+    board: Ad4d2c4c6d
+    tags:
+      - twoTone
+      - unpaired
+      - ace-high
+  -
+    id: l3-demo-ace-high-s032
+    actionType: postflop-jam
+    board: Ad5c4d2s2h
+    tags:
+      - twoTone
+      - unpaired
+      - ace-high
+  -
+    id: l3-demo-ace-high-s033
+    actionType: postflop-jam
+    board: Ad6c3cQdTs
+    tags:
+      - twoTone
+      - unpaired
+      - ace-high
+  -
+    id: l3-demo-ace-high-s034
+    actionType: postflop-jam
+    board: Ad6h2sQhTc
+    tags:
+      - rainbow
+      - unpaired
+      - ace-high
+  -
+    id: l3-demo-ace-high-s035
+    actionType: postflop-jam
+    board: Ad8d6dKsJh
+    tags:
+      - monotone
+      - unpaired
+      - ace-high
+  -
+    id: l3-demo-ace-high-s036
+    actionType: postflop-jam
+    board: Ad8h8d2d3d
+    tags:
+      - twoTone
+      - paired
+      - ace-high
+  -
+    id: l3-demo-ace-high-s037
+    actionType: postflop-jam
+    board: Ad9c2h8c3d
+    tags:
+      - rainbow
+      - unpaired
+      - ace-high
+  -
+    id: l3-demo-ace-high-s038
+    actionType: postflop-jam
+    board: Ad9s5h6sJd
+    tags:
+      - rainbow
+      - unpaired
+      - ace-high
+  -
+    id: l3-demo-ace-high-s039
+    actionType: postflop-jam
+    board: AdJc2s5c9h
+    tags:
+      - rainbow
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-ace-high-s040
+    actionType: postflop-jam
+    board: AdJd5d5hAs
+    tags:
+      - monotone
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-ace-high-s041
+    actionType: postflop-jam
+    board: AdJs2d9dAh
+    tags:
+      - twoTone
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-ace-high-s042
+    actionType: postflop-jam
+    board: AdJsTc2sJc
+    tags:
+      - rainbow
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-ace-high-s043
+    actionType: postflop-jam
+    board: AdKh4cKdQs
+    tags:
+      - rainbow
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-ace-high-s044
+    actionType: postflop-jam
+    board: AdKhTc5cAs
+    tags:
+      - rainbow
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-ace-high-s045
+    actionType: postflop-jam
+    board: AdKs2dTcTh
+    tags:
+      - twoTone
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-ace-high-s046
+    actionType: postflop-jam
+    board: AdQc2s5h6c
+    tags:
+      - rainbow
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-ace-high-s047
+    actionType: postflop-jam
+    board: AdQh4cQd6s
+    tags:
+      - rainbow
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-ace-high-s048
+    actionType: postflop-jam
+    board: AdQh8cKc4h
+    tags:
+      - rainbow
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-ace-high-s049
+    actionType: postflop-jam
+    board: AdTd6dKdAc
+    tags:
+      - monotone
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-ace-high-s050
+    actionType: postflop-jam
+    board: AdTs4c6d6h
+    tags:
+      - rainbow
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-ace-high-s051
+    actionType: postflop-jam
+    board: AdTs5c7h8c
+    tags:
+      - rainbow
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-ace-high-s052
+    actionType: postflop-jam
+    board: Ah3d2c4dQd
+    tags:
+      - rainbow
+      - unpaired
+      - ace-high
+  -
+    id: l3-demo-ace-high-s053
+    actionType: postflop-jam
+    board: Ah4d2s9s2h
+    tags:
+      - rainbow
+      - unpaired
+      - ace-high
+  -
+    id: l3-demo-ace-high-s054
+    actionType: postflop-jam
+    board: Ah5d2s2hJd
+    tags:
+      - rainbow
+      - unpaired
+      - ace-high
+  -
+    id: l3-demo-ace-high-s055
+    actionType: postflop-jam
+    board: Ah6h2cJsJc
+    tags:
+      - twoTone
+      - unpaired
+      - ace-high
+  -
+    id: l3-demo-ace-high-s056
+    actionType: postflop-jam
+    board: Ah6h2h5s3h
+    tags:
+      - monotone
+      - unpaired
+      - ace-high
+  -
+    id: l3-demo-ace-high-s057
+    actionType: postflop-jam
+    board: Ah7s3d8d9c
+    tags:
+      - rainbow
+      - unpaired
+      - ace-high
+  -
+    id: l3-demo-ace-high-s058
+    actionType: postflop-jam
+    board: Ah8h6h3cTd
+    tags:
+      - monotone
+      - unpaired
+      - ace-high
+  -
+    id: l3-demo-ace-high-s059
+    actionType: postflop-jam
+    board: Ah9h3cTc9c
+    tags:
+      - twoTone
+      - unpaired
+      - ace-high
+  -
+    id: l3-demo-ace-high-s060
+    actionType: postflop-jam
+    board: Ah9s3h4dAd
+    tags:
+      - twoTone
+      - unpaired
+      - ace-high
+  -
+    id: l3-demo-ace-high-s061
+    actionType: postflop-jam
+    board: Ah9s6dJd3s
+    tags:
+      - rainbow
+      - unpaired
+      - ace-high
+  -
+    id: l3-demo-ace-high-s062
+    actionType: postflop-jam
+    board: Ah9s9c4cJs
+    tags:
+      - rainbow
+      - paired
+      - ace-high
+  -
+    id: l3-demo-ace-high-s063
+    actionType: postflop-jam
+    board: AhAd2hTs8s
+    tags:
+      - twoTone
+      - paired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-ace-high-s064
+    actionType: postflop-jam
+    board: AhJc7h2c5h
+    tags:
+      - twoTone
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-ace-high-s065
+    actionType: postflop-jam
+    board: AhJh7hQsTh
+    tags:
+      - monotone
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-ace-high-s066
+    actionType: postflop-jam
+    board: AhJh9hTd7d
+    tags:
+      - monotone
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-ace-high-s067
+    actionType: postflop-jam
+    board: AhJs6c6hJc
+    tags:
+      - rainbow
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-ace-high-s068
+    actionType: postflop-jam
+    board: AhKhJd5d3d
+    tags:
+      - twoTone
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-ace-high-s069
+    actionType: postflop-jam
+    board: AhKs2d4d3c
+    tags:
+      - rainbow
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-ace-high-s070
+    actionType: postflop-jam
+    board: AhKsKc8h5h
+    tags:
+      - rainbow
+      - paired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-ace-high-s071
+    actionType: postflop-jam
+    board: AhQc5h8s7h
+    tags:
+      - twoTone
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-ace-high-s072
+    actionType: postflop-jam
+    board: AhQc6s7d3h
+    tags:
+      - rainbow
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-ace-high-s073
+    actionType: postflop-jam
+    board: AhQd7s4cKs
+    tags:
+      - rainbow
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-ace-high-s074
+    actionType: postflop-jam
+    board: AhQdThQcQs
+    tags:
+      - twoTone
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-ace-high-s075
+    actionType: postflop-jam
+    board: AhQh9d3cAc
+    tags:
+      - twoTone
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-ace-high-s076
+    actionType: postflop-jam
+    board: AhQhTdJhTs
+    tags:
+      - twoTone
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-ace-high-s077
+    actionType: postflop-jam
+    board: AhTc5d3sKs
+    tags:
+      - rainbow
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-ace-high-s078
+    actionType: postflop-jam
+    board: AhTh2h8hAc
+    tags:
+      - monotone
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-ace-high-s079
+    actionType: postflop-jam
+    board: AhTs2d3c4d
+    tags:
+      - rainbow
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-ace-high-s080
+    actionType: postflop-jam
+    board: AhTs9c3h6d
+    tags:
+      - rainbow
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-ace-high-s081
+    actionType: postflop-jam
+    board: As3c2d5h8c
+    tags:
+      - rainbow
+      - unpaired
+      - ace-high
+  -
+    id: l3-demo-ace-high-s082
+    actionType: postflop-jam
+    board: As3d3c9s5h
+    tags:
+      - rainbow
+      - paired
+      - ace-high
+  -
+    id: l3-demo-ace-high-s083
+    actionType: postflop-jam
+    board: As6s3s3h7d
+    tags:
+      - monotone
+      - unpaired
+      - ace-high
+  -
+    id: l3-demo-ace-high-s084
+    actionType: postflop-jam
+    board: As8s4s9d4h
+    tags:
+      - monotone
+      - unpaired
+      - ace-high
+  -
+    id: l3-demo-ace-high-s085
+    actionType: postflop-jam
+    board: As9c4h8s7d
+    tags:
+      - rainbow
+      - unpaired
+      - ace-high
+  -
+    id: l3-demo-ace-high-s086
+    actionType: postflop-jam
+    board: As9c6c5s8d
+    tags:
+      - twoTone
+      - unpaired
+      - ace-high
+  -
+    id: l3-demo-ace-high-s087
+    actionType: postflop-jam
+    board: As9c6dThQc
+    tags:
+      - rainbow
+      - unpaired
+      - ace-high
+  -
+    id: l3-demo-ace-high-s088
+    actionType: postflop-jam
+    board: As9s2s7c5c
+    tags:
+      - monotone
+      - unpaired
+      - ace-high
+  -
+    id: l3-demo-ace-high-s089
+    actionType: postflop-jam
+    board: AsAc8d5c9c
+    tags:
+      - rainbow
+      - paired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-ace-high-s090
+    actionType: postflop-jam
+    board: AsAhQh9h8h
+    tags:
+      - twoTone
+      - paired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-ace-high-s091
+    actionType: postflop-jam
+    board: AsAhThAc6h
+    tags:
+      - twoTone
+      - paired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-ace-high-s092
+    actionType: postflop-jam
+    board: AsJd3c9s7h
+    tags:
+      - rainbow
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-ace-high-s093
+    actionType: postflop-jam
+    board: AsJh2c4d7h
+    tags:
+      - rainbow
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-ace-high-s094
+    actionType: postflop-jam
+    board: AsJs6s7c4c
+    tags:
+      - monotone
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-ace-high-s095
+    actionType: postflop-jam
+    board: AsKd8h2cQh
+    tags:
+      - rainbow
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-ace-high-s096
+    actionType: postflop-jam
+    board: AsKhKc7s6s
+    tags:
+      - rainbow
+      - paired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-ace-high-s097
+    actionType: postflop-jam
+    board: AsQs5s9s4s
+    tags:
+      - monotone
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-ace-high-s098
+    actionType: postflop-jam
+    board: AsTh7c8d4s
+    tags:
+      - rainbow
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-ace-high-s099
+    actionType: postflop-jam
+    board: AsTs4c2hKd
+    tags:
+      - twoTone
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-ace-high-s100
+    actionType: postflop-jam
+    board: AsTs5sAh5d
+    tags:
+      - monotone
+      - unpaired
+      - ace-high
+      - broadway

--- a/assets/packs/l3/demo/l3-demo-paired.yaml
+++ b/assets/packs/l3/demo/l3-demo-paired.yaml
@@ -1,0 +1,766 @@
+id: l3-demo-paired
+stage:
+  id: L3
+subtype: postflop-jam
+street: flop
+tags:
+  - l3
+  - demo
+  - paired
+spots:
+  -
+    id: l3-demo-paired-s001
+    actionType: postflop-jam
+    board: 3h3c2d8dJd
+    tags:
+      - rainbow
+      - paired
+  -
+    id: l3-demo-paired-s002
+    actionType: postflop-jam
+    board: 4d2s2c3c8d
+    tags:
+      - rainbow
+      - paired
+  -
+    id: l3-demo-paired-s003
+    actionType: postflop-jam
+    board: 4h2s2d3dTs
+    tags:
+      - rainbow
+      - paired
+  -
+    id: l3-demo-paired-s004
+    actionType: postflop-jam
+    board: 4h4d3s5s3d
+    tags:
+      - rainbow
+      - paired
+  -
+    id: l3-demo-paired-s005
+    actionType: postflop-jam
+    board: 4s2s2cAc7c
+    tags:
+      - twoTone
+      - paired
+  -
+    id: l3-demo-paired-s006
+    actionType: postflop-jam
+    board: 4s4c2d8sKs
+    tags:
+      - rainbow
+      - paired
+  -
+    id: l3-demo-paired-s007
+    actionType: postflop-jam
+    board: 5h5c2d8c4s
+    tags:
+      - rainbow
+      - paired
+  -
+    id: l3-demo-paired-s008
+    actionType: postflop-jam
+    board: 5h5c3c6hQh
+    tags:
+      - twoTone
+      - paired
+  -
+    id: l3-demo-paired-s009
+    actionType: postflop-jam
+    board: 5s5c4c2c3s
+    tags:
+      - twoTone
+      - paired
+  -
+    id: l3-demo-paired-s010
+    actionType: postflop-jam
+    board: 6d2s2cTc4c
+    tags:
+      - rainbow
+      - paired
+  -
+    id: l3-demo-paired-s011
+    actionType: postflop-jam
+    board: 6d6c2h4s6h
+    tags:
+      - rainbow
+      - paired
+  -
+    id: l3-demo-paired-s012
+    actionType: postflop-jam
+    board: 6d6c3d5c7s
+    tags:
+      - twoTone
+      - paired
+  -
+    id: l3-demo-paired-s013
+    actionType: postflop-jam
+    board: 6d6c3s5d6s
+    tags:
+      - rainbow
+      - paired
+  -
+    id: l3-demo-paired-s014
+    actionType: postflop-jam
+    board: 6h6c4cAhAc
+    tags:
+      - twoTone
+      - paired
+  -
+    id: l3-demo-paired-s015
+    actionType: postflop-jam
+    board: 6s4h4d2h6h
+    tags:
+      - rainbow
+      - paired
+  -
+    id: l3-demo-paired-s016
+    actionType: postflop-jam
+    board: 7c5h5c8h9d
+    tags:
+      - twoTone
+      - paired
+  -
+    id: l3-demo-paired-s017
+    actionType: postflop-jam
+    board: 7d2d2c4d8h
+    tags:
+      - twoTone
+      - paired
+  -
+    id: l3-demo-paired-s018
+    actionType: postflop-jam
+    board: 7d5h5c8c3h
+    tags:
+      - rainbow
+      - paired
+  -
+    id: l3-demo-paired-s019
+    actionType: postflop-jam
+    board: 7h2h2dAs3d
+    tags:
+      - twoTone
+      - paired
+  -
+    id: l3-demo-paired-s020
+    actionType: postflop-jam
+    board: 7h3s3c5c4c
+    tags:
+      - rainbow
+      - paired
+  -
+    id: l3-demo-paired-s021
+    actionType: postflop-jam
+    board: 7h7c3sTdJs
+    tags:
+      - rainbow
+      - paired
+  -
+    id: l3-demo-paired-s022
+    actionType: postflop-jam
+    board: 7s3s3c5sAs
+    tags:
+      - twoTone
+      - paired
+  -
+    id: l3-demo-paired-s023
+    actionType: postflop-jam
+    board: 7s7c2cAd5c
+    tags:
+      - twoTone
+      - paired
+  -
+    id: l3-demo-paired-s024
+    actionType: postflop-jam
+    board: 8d4d4c6cJc
+    tags:
+      - twoTone
+      - paired
+  -
+    id: l3-demo-paired-s025
+    actionType: postflop-jam
+    board: 8h2h2cAs8s
+    tags:
+      - twoTone
+      - paired
+  -
+    id: l3-demo-paired-s026
+    actionType: postflop-jam
+    board: 8h4s4d7h3h
+    tags:
+      - rainbow
+      - paired
+  -
+    id: l3-demo-paired-s027
+    actionType: postflop-jam
+    board: 8h6d6c4s2h
+    tags:
+      - rainbow
+      - paired
+  -
+    id: l3-demo-paired-s028
+    actionType: postflop-jam
+    board: 8s8c2hTc2s
+    tags:
+      - rainbow
+      - paired
+  -
+    id: l3-demo-paired-s029
+    actionType: postflop-jam
+    board: 8s8d6hAsJh
+    tags:
+      - rainbow
+      - paired
+  -
+    id: l3-demo-paired-s030
+    actionType: postflop-jam
+    board: 9c4d4cJc5h
+    tags:
+      - twoTone
+      - paired
+  -
+    id: l3-demo-paired-s031
+    actionType: postflop-jam
+    board: 9d5d5cTdQh
+    tags:
+      - twoTone
+      - paired
+  -
+    id: l3-demo-paired-s032
+    actionType: postflop-jam
+    board: 9h2h2dTd8h
+    tags:
+      - twoTone
+      - paired
+  -
+    id: l3-demo-paired-s033
+    actionType: postflop-jam
+    board: 9h9c6d7h9s
+    tags:
+      - rainbow
+      - paired
+  -
+    id: l3-demo-paired-s034
+    actionType: postflop-jam
+    board: 9s2s2cTs9c
+    tags:
+      - twoTone
+      - paired
+  -
+    id: l3-demo-paired-s035
+    actionType: postflop-jam
+    board: 9s9h8sAcQc
+    tags:
+      - twoTone
+      - paired
+  -
+    id: l3-demo-paired-s036
+    actionType: postflop-jam
+    board: Ac2h2d8sTh
+    tags:
+      - rainbow
+      - paired
+      - ace-high
+  -
+    id: l3-demo-paired-s037
+    actionType: postflop-jam
+    board: AcQsQc9d6c
+    tags:
+      - twoTone
+      - paired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-paired-s038
+    actionType: postflop-jam
+    board: AdAc7hKdQc
+    tags:
+      - rainbow
+      - paired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-paired-s039
+    actionType: postflop-jam
+    board: AdAcQdAhJs
+    tags:
+      - twoTone
+      - paired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-paired-s040
+    actionType: postflop-jam
+    board: AdJhJcKcKd
+    tags:
+      - rainbow
+      - paired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-paired-s041
+    actionType: postflop-jam
+    board: AdKhKcQsAs
+    tags:
+      - rainbow
+      - paired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-paired-s042
+    actionType: postflop-jam
+    board: AdKsKd6d2d
+    tags:
+      - twoTone
+      - paired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-paired-s043
+    actionType: postflop-jam
+    board: AhAdQh7h7d
+    tags:
+      - twoTone
+      - paired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-paired-s044
+    actionType: postflop-jam
+    board: AhTsTh3d7s
+    tags:
+      - twoTone
+      - paired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-paired-s045
+    actionType: postflop-jam
+    board: As6h6dQc4c
+    tags:
+      - rainbow
+      - paired
+      - ace-high
+  -
+    id: l3-demo-paired-s046
+    actionType: postflop-jam
+    board: As8s8c5cJs
+    tags:
+      - twoTone
+      - paired
+      - ace-high
+  -
+    id: l3-demo-paired-s047
+    actionType: postflop-jam
+    board: AsAc2sQdJd
+    tags:
+      - twoTone
+      - paired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-paired-s048
+    actionType: postflop-jam
+    board: AsAc6s2h6d
+    tags:
+      - twoTone
+      - paired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-paired-s049
+    actionType: postflop-jam
+    board: AsAd3cAhQc
+    tags:
+      - rainbow
+      - paired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-paired-s050
+    actionType: postflop-jam
+    board: AsAd5dTdQc
+    tags:
+      - twoTone
+      - paired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-paired-s051
+    actionType: postflop-jam
+    board: AsAd6h6sQd
+    tags:
+      - rainbow
+      - paired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-paired-s052
+    actionType: postflop-jam
+    board: Jc3s3hJhKh
+    tags:
+      - rainbow
+      - paired
+  -
+    id: l3-demo-paired-s053
+    actionType: postflop-jam
+    board: Jc5d5c5hKc
+    tags:
+      - twoTone
+      - paired
+  -
+    id: l3-demo-paired-s054
+    actionType: postflop-jam
+    board: Jc6d6cAh8d
+    tags:
+      - twoTone
+      - paired
+  -
+    id: l3-demo-paired-s055
+    actionType: postflop-jam
+    board: Jd3s3h5h8d
+    tags:
+      - rainbow
+      - paired
+  -
+    id: l3-demo-paired-s056
+    actionType: postflop-jam
+    board: Jd5d5c5h9s
+    tags:
+      - twoTone
+      - paired
+  -
+    id: l3-demo-paired-s057
+    actionType: postflop-jam
+    board: Jh7d7cQsQc
+    tags:
+      - rainbow
+      - paired
+  -
+    id: l3-demo-paired-s058
+    actionType: postflop-jam
+    board: Jh9d9c3c5s
+    tags:
+      - rainbow
+      - paired
+  -
+    id: l3-demo-paired-s059
+    actionType: postflop-jam
+    board: JhJc8s8hTd
+    tags:
+      - rainbow
+      - paired
+      - broadway
+  -
+    id: l3-demo-paired-s060
+    actionType: postflop-jam
+    board: JhJc9h7sQd
+    tags:
+      - twoTone
+      - paired
+      - broadway
+  -
+    id: l3-demo-paired-s061
+    actionType: postflop-jam
+    board: JhJd5d9s3c
+    tags:
+      - twoTone
+      - paired
+      - broadway
+  -
+    id: l3-demo-paired-s062
+    actionType: postflop-jam
+    board: JhJdTcKh9s
+    tags:
+      - rainbow
+      - paired
+      - broadway
+  -
+    id: l3-demo-paired-s063
+    actionType: postflop-jam
+    board: JsJc7hKcKh
+    tags:
+      - rainbow
+      - paired
+      - broadway
+  -
+    id: l3-demo-paired-s064
+    actionType: postflop-jam
+    board: JsJh4sAhTs
+    tags:
+      - twoTone
+      - paired
+      - broadway
+  -
+    id: l3-demo-paired-s065
+    actionType: postflop-jam
+    board: JsJh7dQd3s
+    tags:
+      - rainbow
+      - paired
+      - broadway
+  -
+    id: l3-demo-paired-s066
+    actionType: postflop-jam
+    board: Kd2s2hQd4s
+    tags:
+      - rainbow
+      - paired
+  -
+    id: l3-demo-paired-s067
+    actionType: postflop-jam
+    board: Kd9s9hAcJh
+    tags:
+      - rainbow
+      - paired
+  -
+    id: l3-demo-paired-s068
+    actionType: postflop-jam
+    board: KdKc9h4hQd
+    tags:
+      - rainbow
+      - paired
+      - broadway
+  -
+    id: l3-demo-paired-s069
+    actionType: postflop-jam
+    board: KhKc2s2h8s
+    tags:
+      - rainbow
+      - paired
+      - broadway
+  -
+    id: l3-demo-paired-s070
+    actionType: postflop-jam
+    board: KhKd6d8hAh
+    tags:
+      - twoTone
+      - paired
+      - broadway
+  -
+    id: l3-demo-paired-s071
+    actionType: postflop-jam
+    board: KhKd8c7c9c
+    tags:
+      - rainbow
+      - paired
+      - broadway
+  -
+    id: l3-demo-paired-s072
+    actionType: postflop-jam
+    board: KhKd8d3s9s
+    tags:
+      - twoTone
+      - paired
+      - broadway
+  -
+    id: l3-demo-paired-s073
+    actionType: postflop-jam
+    board: Ks6s6dAc2h
+    tags:
+      - twoTone
+      - paired
+  -
+    id: l3-demo-paired-s074
+    actionType: postflop-jam
+    board: KsJhJd9h7h
+    tags:
+      - rainbow
+      - paired
+      - broadway
+  -
+    id: l3-demo-paired-s075
+    actionType: postflop-jam
+    board: KsKc5d5c8s
+    tags:
+      - rainbow
+      - paired
+      - broadway
+  -
+    id: l3-demo-paired-s076
+    actionType: postflop-jam
+    board: KsKc6h7h4c
+    tags:
+      - rainbow
+      - paired
+      - broadway
+  -
+    id: l3-demo-paired-s077
+    actionType: postflop-jam
+    board: KsKc7s7hAs
+    tags:
+      - twoTone
+      - paired
+      - broadway
+  -
+    id: l3-demo-paired-s078
+    actionType: postflop-jam
+    board: KsKcQhKhQd
+    tags:
+      - rainbow
+      - paired
+      - broadway
+  -
+    id: l3-demo-paired-s079
+    actionType: postflop-jam
+    board: KsKd2d3s6s
+    tags:
+      - twoTone
+      - paired
+      - broadway
+  -
+    id: l3-demo-paired-s080
+    actionType: postflop-jam
+    board: Qc2s2c9c9h
+    tags:
+      - twoTone
+      - paired
+  -
+    id: l3-demo-paired-s081
+    actionType: postflop-jam
+    board: Qc2s2dQs4s
+    tags:
+      - rainbow
+      - paired
+  -
+    id: l3-demo-paired-s082
+    actionType: postflop-jam
+    board: Qc4h4c5dQh
+    tags:
+      - twoTone
+      - paired
+  -
+    id: l3-demo-paired-s083
+    actionType: postflop-jam
+    board: Qc7s7hJhTc
+    tags:
+      - rainbow
+      - paired
+  -
+    id: l3-demo-paired-s084
+    actionType: postflop-jam
+    board: Qc9h9cAh5d
+    tags:
+      - twoTone
+      - paired
+  -
+    id: l3-demo-paired-s085
+    actionType: postflop-jam
+    board: QcJsJd9cQs
+    tags:
+      - rainbow
+      - paired
+      - broadway
+  -
+    id: l3-demo-paired-s086
+    actionType: postflop-jam
+    board: Qd6s6cQs5s
+    tags:
+      - rainbow
+      - paired
+  -
+    id: l3-demo-paired-s087
+    actionType: postflop-jam
+    board: QdQcTdQs2s
+    tags:
+      - twoTone
+      - paired
+      - broadway
+  -
+    id: l3-demo-paired-s088
+    actionType: postflop-jam
+    board: Qh7h7c9cAc
+    tags:
+      - twoTone
+      - paired
+  -
+    id: l3-demo-paired-s089
+    actionType: postflop-jam
+    board: Qh9s9h7d3h
+    tags:
+      - twoTone
+      - paired
+  -
+    id: l3-demo-paired-s090
+    actionType: postflop-jam
+    board: QhQcJcAcTc
+    tags:
+      - twoTone
+      - paired
+      - broadway
+  -
+    id: l3-demo-paired-s091
+    actionType: postflop-jam
+    board: QhQd9h2d7h
+    tags:
+      - twoTone
+      - paired
+      - broadway
+  -
+    id: l3-demo-paired-s092
+    actionType: postflop-jam
+    board: Qs5d5c6s7c
+    tags:
+      - rainbow
+      - paired
+  -
+    id: l3-demo-paired-s093
+    actionType: postflop-jam
+    board: Qs8s8hAs3s
+    tags:
+      - twoTone
+      - paired
+  -
+    id: l3-demo-paired-s094
+    actionType: postflop-jam
+    board: QsQc4sKhAc
+    tags:
+      - twoTone
+      - paired
+      - broadway
+  -
+    id: l3-demo-paired-s095
+    actionType: postflop-jam
+    board: QsQd5d7sAs
+    tags:
+      - twoTone
+      - paired
+      - broadway
+  -
+    id: l3-demo-paired-s096
+    actionType: postflop-jam
+    board: QsQh7hKs3c
+    tags:
+      - twoTone
+      - paired
+      - broadway
+  -
+    id: l3-demo-paired-s097
+    actionType: postflop-jam
+    board: QsQh8cJh2c
+    tags:
+      - rainbow
+      - paired
+      - broadway
+  -
+    id: l3-demo-paired-s098
+    actionType: postflop-jam
+    board: Tc2s2c8c2d
+    tags:
+      - twoTone
+      - paired
+  -
+    id: l3-demo-paired-s099
+    actionType: postflop-jam
+    board: Ts2h2d9sQd
+    tags:
+      - rainbow
+      - paired
+  -
+    id: l3-demo-paired-s100
+    actionType: postflop-jam
+    board: TsTc3hJdJh
+    tags:
+      - rainbow
+      - paired
+      - broadway

--- a/assets/packs/l3/demo/l3-demo-unpaired.yaml
+++ b/assets/packs/l3/demo/l3-demo-unpaired.yaml
@@ -1,0 +1,775 @@
+id: l3-demo-unpaired
+stage:
+  id: L3
+subtype: postflop-jam
+street: flop
+tags:
+  - l3
+  - demo
+  - unpaired
+spots:
+  -
+    id: l3-demo-unpaired-s001
+    actionType: postflop-jam
+    board: 5s4c2d8dKh
+    tags:
+      - rainbow
+      - unpaired
+  -
+    id: l3-demo-unpaired-s002
+    actionType: postflop-jam
+    board: 6h5h4c5s2d
+    tags:
+      - twoTone
+      - unpaired
+  -
+    id: l3-demo-unpaired-s003
+    actionType: postflop-jam
+    board: 7d4d2dAsTd
+    tags:
+      - monotone
+      - unpaired
+  -
+    id: l3-demo-unpaired-s004
+    actionType: postflop-jam
+    board: 7h5s4hAhJc
+    tags:
+      - twoTone
+      - unpaired
+  -
+    id: l3-demo-unpaired-s005
+    actionType: postflop-jam
+    board: 7h6c2sTs4s
+    tags:
+      - rainbow
+      - unpaired
+  -
+    id: l3-demo-unpaired-s006
+    actionType: postflop-jam
+    board: 8c5h2s6h3s
+    tags:
+      - rainbow
+      - unpaired
+  -
+    id: l3-demo-unpaired-s007
+    actionType: postflop-jam
+    board: 8d4d3d7sAs
+    tags:
+      - monotone
+      - unpaired
+  -
+    id: l3-demo-unpaired-s008
+    actionType: postflop-jam
+    board: 8d6d4hAd3h
+    tags:
+      - twoTone
+      - unpaired
+  -
+    id: l3-demo-unpaired-s009
+    actionType: postflop-jam
+    board: 8h5d2s7hAs
+    tags:
+      - rainbow
+      - unpaired
+  -
+    id: l3-demo-unpaired-s010
+    actionType: postflop-jam
+    board: 8s6h3hTc2s
+    tags:
+      - twoTone
+      - unpaired
+  -
+    id: l3-demo-unpaired-s011
+    actionType: postflop-jam
+    board: 8s7s2h9d3c
+    tags:
+      - twoTone
+      - unpaired
+  -
+    id: l3-demo-unpaired-s012
+    actionType: postflop-jam
+    board: 9h7h4s3d7c
+    tags:
+      - twoTone
+      - unpaired
+  -
+    id: l3-demo-unpaired-s013
+    actionType: postflop-jam
+    board: 9h7s5dKs9c
+    tags:
+      - rainbow
+      - unpaired
+  -
+    id: l3-demo-unpaired-s014
+    actionType: postflop-jam
+    board: 9h8h2cQc4h
+    tags:
+      - twoTone
+      - unpaired
+  -
+    id: l3-demo-unpaired-s015
+    actionType: postflop-jam
+    board: 9s7d4cJcQs
+    tags:
+      - rainbow
+      - unpaired
+  -
+    id: l3-demo-unpaired-s016
+    actionType: postflop-jam
+    board: Ac5d4s8hJs
+    tags:
+      - rainbow
+      - unpaired
+      - ace-high
+  -
+    id: l3-demo-unpaired-s017
+    actionType: postflop-jam
+    board: Ac9h5d2s5s
+    tags:
+      - rainbow
+      - unpaired
+      - ace-high
+  -
+    id: l3-demo-unpaired-s018
+    actionType: postflop-jam
+    board: Ac9s8c2hJd
+    tags:
+      - twoTone
+      - unpaired
+      - ace-high
+  -
+    id: l3-demo-unpaired-s019
+    actionType: postflop-jam
+    board: AcKc4c6sJd
+    tags:
+      - monotone
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-unpaired-s020
+    actionType: postflop-jam
+    board: Ad4d2dJs7c
+    tags:
+      - monotone
+      - unpaired
+      - ace-high
+  -
+    id: l3-demo-unpaired-s021
+    actionType: postflop-jam
+    board: AdQcTc8hAh
+    tags:
+      - twoTone
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-unpaired-s022
+    actionType: postflop-jam
+    board: AdQh6h9c7h
+    tags:
+      - twoTone
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-unpaired-s023
+    actionType: postflop-jam
+    board: AdQh9c2dQc
+    tags:
+      - rainbow
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-unpaired-s024
+    actionType: postflop-jam
+    board: Ah3h2hJs8d
+    tags:
+      - monotone
+      - unpaired
+      - ace-high
+  -
+    id: l3-demo-unpaired-s025
+    actionType: postflop-jam
+    board: Ah6c3s3d5c
+    tags:
+      - rainbow
+      - unpaired
+      - ace-high
+  -
+    id: l3-demo-unpaired-s026
+    actionType: postflop-jam
+    board: Ah7c4sAd3s
+    tags:
+      - rainbow
+      - unpaired
+      - ace-high
+  -
+    id: l3-demo-unpaired-s027
+    actionType: postflop-jam
+    board: Ah8c6c4sQh
+    tags:
+      - twoTone
+      - unpaired
+      - ace-high
+  -
+    id: l3-demo-unpaired-s028
+    actionType: postflop-jam
+    board: Ah8d2s7d5c
+    tags:
+      - rainbow
+      - unpaired
+      - ace-high
+  -
+    id: l3-demo-unpaired-s029
+    actionType: postflop-jam
+    board: AhJc4dAd2d
+    tags:
+      - rainbow
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-unpaired-s030
+    actionType: postflop-jam
+    board: AhKc5dJs7d
+    tags:
+      - rainbow
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-unpaired-s031
+    actionType: postflop-jam
+    board: AhKh8h4c3c
+    tags:
+      - monotone
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-unpaired-s032
+    actionType: postflop-jam
+    board: AhKs8s8hJh
+    tags:
+      - twoTone
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-unpaired-s033
+    actionType: postflop-jam
+    board: AhQhJh3s2h
+    tags:
+      - monotone
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-unpaired-s034
+    actionType: postflop-jam
+    board: AhTd2s2h7h
+    tags:
+      - rainbow
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-unpaired-s035
+    actionType: postflop-jam
+    board: AhTs3d4h6c
+    tags:
+      - rainbow
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-unpaired-s036
+    actionType: postflop-jam
+    board: AhTs5c6s3h
+    tags:
+      - rainbow
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-unpaired-s037
+    actionType: postflop-jam
+    board: As5s3s7cJh
+    tags:
+      - monotone
+      - unpaired
+      - ace-high
+  -
+    id: l3-demo-unpaired-s038
+    actionType: postflop-jam
+    board: AsJh9c2dKd
+    tags:
+      - rainbow
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-unpaired-s039
+    actionType: postflop-jam
+    board: AsKs9c7s2s
+    tags:
+      - twoTone
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-unpaired-s040
+    actionType: postflop-jam
+    board: AsQc9s4cJd
+    tags:
+      - twoTone
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-unpaired-s041
+    actionType: postflop-jam
+    board: AsTc5dTs3d
+    tags:
+      - rainbow
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-unpaired-s042
+    actionType: postflop-jam
+    board: AsTh4d5hAd
+    tags:
+      - rainbow
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-unpaired-s043
+    actionType: postflop-jam
+    board: AsTs9s9h8h
+    tags:
+      - monotone
+      - unpaired
+      - ace-high
+      - broadway
+  -
+    id: l3-demo-unpaired-s044
+    actionType: postflop-jam
+    board: Jc5d4hTh2s
+    tags:
+      - rainbow
+      - unpaired
+  -
+    id: l3-demo-unpaired-s045
+    actionType: postflop-jam
+    board: JcTc4cQc7s
+    tags:
+      - monotone
+      - unpaired
+      - broadway
+  -
+    id: l3-demo-unpaired-s046
+    actionType: postflop-jam
+    board: Jd9d3d3h8c
+    tags:
+      - monotone
+      - unpaired
+  -
+    id: l3-demo-unpaired-s047
+    actionType: postflop-jam
+    board: JdTc7sJsTs
+    tags:
+      - rainbow
+      - unpaired
+      - broadway
+  -
+    id: l3-demo-unpaired-s048
+    actionType: postflop-jam
+    board: JdTc8h9d6s
+    tags:
+      - rainbow
+      - unpaired
+      - broadway
+  -
+    id: l3-demo-unpaired-s049
+    actionType: postflop-jam
+    board: JdTd4d6hTc
+    tags:
+      - monotone
+      - unpaired
+      - broadway
+  -
+    id: l3-demo-unpaired-s050
+    actionType: postflop-jam
+    board: JhTc9d4c9c
+    tags:
+      - rainbow
+      - unpaired
+      - broadway
+  -
+    id: l3-demo-unpaired-s051
+    actionType: postflop-jam
+    board: JhTh3sQhTc
+    tags:
+      - twoTone
+      - unpaired
+      - broadway
+  -
+    id: l3-demo-unpaired-s052
+    actionType: postflop-jam
+    board: Js5s3sAd2s
+    tags:
+      - monotone
+      - unpaired
+  -
+    id: l3-demo-unpaired-s053
+    actionType: postflop-jam
+    board: Js5s4sAcQc
+    tags:
+      - monotone
+      - unpaired
+  -
+    id: l3-demo-unpaired-s054
+    actionType: postflop-jam
+    board: Js8d7c4cAs
+    tags:
+      - rainbow
+      - unpaired
+  -
+    id: l3-demo-unpaired-s055
+    actionType: postflop-jam
+    board: Kc6h3sKd7c
+    tags:
+      - rainbow
+      - unpaired
+  -
+    id: l3-demo-unpaired-s056
+    actionType: postflop-jam
+    board: Kc9c5cKd6h
+    tags:
+      - monotone
+      - unpaired
+  -
+    id: l3-demo-unpaired-s057
+    actionType: postflop-jam
+    board: Kc9d6h9cJd
+    tags:
+      - rainbow
+      - unpaired
+  -
+    id: l3-demo-unpaired-s058
+    actionType: postflop-jam
+    board: KcJhTs8s5d
+    tags:
+      - rainbow
+      - unpaired
+      - broadway
+  -
+    id: l3-demo-unpaired-s059
+    actionType: postflop-jam
+    board: Kd4d3d6hQh
+    tags:
+      - monotone
+      - unpaired
+  -
+    id: l3-demo-unpaired-s060
+    actionType: postflop-jam
+    board: Kd4h3s5s2d
+    tags:
+      - rainbow
+      - unpaired
+  -
+    id: l3-demo-unpaired-s061
+    actionType: postflop-jam
+    board: Kd5d2d9dQd
+    tags:
+      - monotone
+      - unpaired
+  -
+    id: l3-demo-unpaired-s062
+    actionType: postflop-jam
+    board: Kd5d3sTcQd
+    tags:
+      - twoTone
+      - unpaired
+  -
+    id: l3-demo-unpaired-s063
+    actionType: postflop-jam
+    board: Kd6h4hQdJc
+    tags:
+      - twoTone
+      - unpaired
+  -
+    id: l3-demo-unpaired-s064
+    actionType: postflop-jam
+    board: Kd7s3s8dQd
+    tags:
+      - twoTone
+      - unpaired
+  -
+    id: l3-demo-unpaired-s065
+    actionType: postflop-jam
+    board: KdJh7dTc6h
+    tags:
+      - twoTone
+      - unpaired
+      - broadway
+  -
+    id: l3-demo-unpaired-s066
+    actionType: postflop-jam
+    board: KdQd4dAdQc
+    tags:
+      - monotone
+      - unpaired
+      - broadway
+  -
+    id: l3-demo-unpaired-s067
+    actionType: postflop-jam
+    board: KdQhTsAc6c
+    tags:
+      - rainbow
+      - unpaired
+      - broadway
+  -
+    id: l3-demo-unpaired-s068
+    actionType: postflop-jam
+    board: Kh6c5sAcQc
+    tags:
+      - rainbow
+      - unpaired
+  -
+    id: l3-demo-unpaired-s069
+    actionType: postflop-jam
+    board: Kh6h3hAcQh
+    tags:
+      - monotone
+      - unpaired
+  -
+    id: l3-demo-unpaired-s070
+    actionType: postflop-jam
+    board: Kh8h5dAc8s
+    tags:
+      - twoTone
+      - unpaired
+  -
+    id: l3-demo-unpaired-s071
+    actionType: postflop-jam
+    board: KhJs9c3c5d
+    tags:
+      - rainbow
+      - unpaired
+      - broadway
+  -
+    id: l3-demo-unpaired-s072
+    actionType: postflop-jam
+    board: KhQs2s6cJh
+    tags:
+      - twoTone
+      - unpaired
+      - broadway
+  -
+    id: l3-demo-unpaired-s073
+    actionType: postflop-jam
+    board: Ks9d5d2c6d
+    tags:
+      - twoTone
+      - unpaired
+  -
+    id: l3-demo-unpaired-s074
+    actionType: postflop-jam
+    board: KsQs2hAcKc
+    tags:
+      - twoTone
+      - unpaired
+      - broadway
+  -
+    id: l3-demo-unpaired-s075
+    actionType: postflop-jam
+    board: KsQsJd5dJs
+    tags:
+      - twoTone
+      - unpaired
+      - broadway
+  -
+    id: l3-demo-unpaired-s076
+    actionType: postflop-jam
+    board: Qc9d7hKhJc
+    tags:
+      - rainbow
+      - unpaired
+  -
+    id: l3-demo-unpaired-s077
+    actionType: postflop-jam
+    board: QcJd4dAc7d
+    tags:
+      - twoTone
+      - unpaired
+      - broadway
+  -
+    id: l3-demo-unpaired-s078
+    actionType: postflop-jam
+    board: QcTh3d2s4d
+    tags:
+      - rainbow
+      - unpaired
+      - broadway
+  -
+    id: l3-demo-unpaired-s079
+    actionType: postflop-jam
+    board: Qd5c2hKs8s
+    tags:
+      - rainbow
+      - unpaired
+  -
+    id: l3-demo-unpaired-s080
+    actionType: postflop-jam
+    board: Qd6h3hTd4s
+    tags:
+      - twoTone
+      - unpaired
+  -
+    id: l3-demo-unpaired-s081
+    actionType: postflop-jam
+    board: Qh5c3sJd7h
+    tags:
+      - rainbow
+      - unpaired
+  -
+    id: l3-demo-unpaired-s082
+    actionType: postflop-jam
+    board: Qh7d2d2c9h
+    tags:
+      - twoTone
+      - unpaired
+  -
+    id: l3-demo-unpaired-s083
+    actionType: postflop-jam
+    board: Qh9d4c6dTd
+    tags:
+      - rainbow
+      - unpaired
+  -
+    id: l3-demo-unpaired-s084
+    actionType: postflop-jam
+    board: QhJd2h7s7h
+    tags:
+      - twoTone
+      - unpaired
+      - broadway
+  -
+    id: l3-demo-unpaired-s085
+    actionType: postflop-jam
+    board: Qs5h4dTs4h
+    tags:
+      - rainbow
+      - unpaired
+  -
+    id: l3-demo-unpaired-s086
+    actionType: postflop-jam
+    board: QsJh6c2c3d
+    tags:
+      - rainbow
+      - unpaired
+      - broadway
+  -
+    id: l3-demo-unpaired-s087
+    actionType: postflop-jam
+    board: QsTd9c3c9d
+    tags:
+      - rainbow
+      - unpaired
+      - broadway
+  -
+    id: l3-demo-unpaired-s088
+    actionType: postflop-jam
+    board: Tc6s4h5s7d
+    tags:
+      - rainbow
+      - unpaired
+  -
+    id: l3-demo-unpaired-s089
+    actionType: postflop-jam
+    board: Tc7d4s4dTs
+    tags:
+      - rainbow
+      - unpaired
+  -
+    id: l3-demo-unpaired-s090
+    actionType: postflop-jam
+    board: Tc7s4d2dTs
+    tags:
+      - rainbow
+      - unpaired
+  -
+    id: l3-demo-unpaired-s091
+    actionType: postflop-jam
+    board: Tc8h7dAcQs
+    tags:
+      - rainbow
+      - unpaired
+  -
+    id: l3-demo-unpaired-s092
+    actionType: postflop-jam
+    board: Tc8s6hAc7c
+    tags:
+      - rainbow
+      - unpaired
+  -
+    id: l3-demo-unpaired-s093
+    actionType: postflop-jam
+    board: Tc9c8d7d3d
+    tags:
+      - twoTone
+      - unpaired
+  -
+    id: l3-demo-unpaired-s094
+    actionType: postflop-jam
+    board: Tc9h7sQh9c
+    tags:
+      - rainbow
+      - unpaired
+  -
+    id: l3-demo-unpaired-s095
+    actionType: postflop-jam
+    board: Tc9s2dKc3s
+    tags:
+      - rainbow
+      - unpaired
+  -
+    id: l3-demo-unpaired-s096
+    actionType: postflop-jam
+    board: Td4s2c7h6s
+    tags:
+      - rainbow
+      - unpaired
+  -
+    id: l3-demo-unpaired-s097
+    actionType: postflop-jam
+    board: Th4h3hQd2s
+    tags:
+      - monotone
+      - unpaired
+  -
+    id: l3-demo-unpaired-s098
+    actionType: postflop-jam
+    board: Th7c3sQdQh
+    tags:
+      - rainbow
+      - unpaired
+  -
+    id: l3-demo-unpaired-s099
+    actionType: postflop-jam
+    board: Th8c6c4hKh
+    tags:
+      - twoTone
+      - unpaired
+  -
+    id: l3-demo-unpaired-s100
+    actionType: postflop-jam
+    board: Ts6d5cAdQd
+    tags:
+      - rainbow
+      - unpaired

--- a/test/l3_demo_sampler_test.dart
+++ b/test/l3_demo_sampler_test.dart
@@ -1,0 +1,77 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+import 'package:yaml/yaml.dart';
+
+void main() {
+  test('l3 demo sampler produces valid packs', () async {
+    final gen = await Process.run('dart', [
+      'run',
+      'tool/autogen/l3_board_generator.dart',
+      '--preset',
+      'all',
+      '--seed',
+      '111',
+      '--out',
+      'build/tmp/l3/111',
+      '--maxAttemptsPerSpot',
+      '5000',
+      '--timeoutSec',
+      '90',
+    ]);
+    if (gen.exitCode != 0) {
+      fail('generator failed\nstdout: ${gen.stdout}\nstderr: ${gen.stderr}');
+    }
+
+    final sampler = await Process.run('dart', [
+      'run',
+      'tool/autogen/l3_demo_sampler.dart',
+      '--source',
+      'build/tmp/l3/111',
+      '--preset',
+      'all',
+      '--out',
+      'assets/packs/l3/demo',
+      '--spots',
+      '100',
+      '--dedupe',
+      'flop',
+      '--seed',
+      '111',
+    ]);
+    if (sampler.exitCode != 0) {
+      fail('sampler failed\nstdout: ${sampler.stdout}\nstderr: ${sampler.stderr}');
+    }
+
+    final validator = await Process.run('dart', [
+      'run',
+      'tool/validators/l3_demo_validator.dart',
+      '--dir',
+      'assets/packs/l3/demo',
+      '--dedupe',
+      'flop',
+    ]);
+    if (validator.exitCode != 0) {
+      fail('validator failed\nstdout: ${validator.stdout}\nstderr: ${validator.stderr}');
+    }
+
+    final dir = Directory('assets/packs/l3/demo');
+    final files = dir
+        .listSync()
+        .whereType<File>()
+        .where((f) => f.path.endsWith('.yaml'));
+    expect(files, isNotEmpty);
+    for (final file in files) {
+      final content = loadYaml(file.readAsStringSync()) as Map;
+      final spots = List.from(content['spots'] as List? ?? []);
+      expect(spots.length >= 80, true, reason: 'insufficient spots');
+      for (final spot in spots) {
+        final tags = List.from((spot as Map)['tags'] as List? ?? []);
+        final hasTexture = tags.contains('monotone') ||
+            tags.contains('twoTone') ||
+            tags.contains('rainbow');
+        expect(hasTexture, true, reason: 'missing texture tag');
+      }
+    }
+  });
+}

--- a/tool/autogen/l3_demo_sampler.dart
+++ b/tool/autogen/l3_demo_sampler.dart
@@ -1,0 +1,126 @@
+import 'dart:io';
+import 'dart:math';
+
+import 'package:args/args.dart';
+import 'package:path/path.dart' as p;
+import 'package:yaml/yaml.dart';
+
+void main(List<String> args) {
+  final parser = ArgParser()
+    ..addOption('source', defaultsTo: 'build/tmp/l3')
+    ..addOption('preset', defaultsTo: 'all', allowed: ['paired', 'unpaired', 'ace-high', 'all'])
+    ..addOption('out', defaultsTo: 'assets/packs/l3/demo')
+    ..addOption('spots', defaultsTo: '100')
+    ..addOption('dedupe', defaultsTo: 'flop', allowed: ['flop', 'board'])
+    ..addOption('seed', defaultsTo: '111');
+  final res = parser.parse(args);
+  final sourceArg = res['source'] as String;
+  final presetArg = res['preset'] as String;
+  final outDir = res['out'] as String;
+  final spotCount = int.parse(res['spots'] as String);
+  final dedupe = res['dedupe'] as String;
+  final seed = int.parse(res['seed'] as String);
+
+  final source = _resolveSource(sourceArg);
+  final presets = presetArg == 'all'
+      ? ['paired', 'unpaired', 'ace-high']
+      : [presetArg];
+
+  final out = Directory(outDir);
+  out.createSync(recursive: true);
+
+  var hasError = false;
+  for (final preset in presets) {
+    final file = File(p.join(source.path, 'postflop-jam', preset, 'l3-postflop-jam-$preset.yaml'));
+    if (!file.existsSync()) {
+      stderr.writeln('Missing source pack for preset $preset at ${file.path}');
+      hasError = true;
+      continue;
+    }
+    final content = loadYaml(file.readAsStringSync()) as Map;
+    final spots = List.from(content['spots'] as List? ?? []);
+    if (spots.isEmpty) {
+      stderr.writeln('Source pack ${file.path} has no spots');
+      hasError = true;
+      continue;
+    }
+    spots.shuffle(Random(seed));
+    final selected = spots.take(spotCount).toList();
+    selected.sort((a, b) {
+      final boardA = a['board'] as String? ?? '';
+      final boardB = b['board'] as String? ?? '';
+      return boardA.compareTo(boardB);
+    });
+
+    final seenFlops = <String>{};
+    final seenBoards = <String>{};
+    final sb = StringBuffer();
+    final packId = 'l3-demo-$preset';
+    sb.writeln('id: $packId');
+    sb.writeln('stage:');
+    sb.writeln('  id: L3');
+    sb.writeln('subtype: postflop-jam');
+    sb.writeln('street: flop');
+    sb.writeln('tags:');
+    sb.writeln('  - l3');
+    sb.writeln('  - demo');
+    sb.writeln('  - $preset');
+    sb.writeln('spots:');
+    for (var i = 0; i < selected.length; i++) {
+      final spot = selected[i] as Map;
+      final board = spot['board'] as String?;
+      final actionType = spot['actionType'] as String?;
+      final tags = List.from(spot['tags'] as List? ?? []);
+      tags.removeWhere((t) => t == 'l3');
+      if (board == null || actionType != 'postflop-jam' || tags.isEmpty) {
+        stderr.writeln('Invalid spot in ${file.path}: $spot');
+        hasError = true;
+        continue;
+      }
+      final flop = board.substring(0, 6);
+      if (dedupe == 'flop') {
+        if (!seenFlops.add(flop)) {
+          stderr.writeln('Duplicate flop $flop in preset $preset');
+          hasError = true;
+        }
+      } else {
+        if (!seenBoards.add(board)) {
+          stderr.writeln('Duplicate board $board in preset $preset');
+          hasError = true;
+        }
+      }
+      final spotId = '${packId}-s${(i + 1).toString().padLeft(3, '0')}';
+      sb.writeln('  -');
+      sb.writeln('    id: $spotId');
+      sb.writeln('    actionType: postflop-jam');
+      sb.writeln('    board: $board');
+      sb.writeln('    tags:');
+      for (final t in tags) {
+        sb.writeln('      - $t');
+      }
+    }
+    final outFile = File(p.join(out.path, '$packId.yaml'));
+    outFile.writeAsStringSync(sb.toString());
+    if (selected.isEmpty) {
+      stderr.writeln('No spots selected for preset $preset');
+      hasError = true;
+    }
+  }
+  if (hasError) exit(1);
+}
+
+Directory _resolveSource(String sourceArg) {
+  final dir = Directory(sourceArg);
+  if (!dir.existsSync()) {
+    stderr.writeln('Source directory not found: ${dir.path}');
+    exit(1);
+  }
+  final seeds = dir
+      .listSync()
+      .whereType<Directory>()
+      .where((d) => int.tryParse(p.basename(d.path)) != null)
+      .toList();
+  if (seeds.isEmpty) return dir;
+  seeds.sort((a, b) => p.basename(a.path).compareTo(p.basename(b.path)));
+  return seeds.last;
+}

--- a/tool/validators/l3_demo_validator.dart
+++ b/tool/validators/l3_demo_validator.dart
@@ -1,0 +1,72 @@
+import 'dart:io';
+
+import 'package:args/args.dart';
+import 'package:yaml/yaml.dart';
+
+void main(List<String> args) {
+  final parser = ArgParser()
+    ..addOption('dir', defaultsTo: 'assets/packs/l3/demo')
+    ..addOption('dedupe', defaultsTo: 'flop', allowed: ['flop', 'board']);
+  final res = parser.parse(args);
+  final dirPath = res['dir'] as String;
+  final dedupe = res['dedupe'] as String;
+
+  final dir = Directory(dirPath);
+  if (!dir.existsSync()) {
+    stderr.writeln('Directory not found: $dirPath');
+    exit(1);
+  }
+
+  var hasError = false;
+  for (final file
+      in dir.listSync().whereType<File>().where((f) => f.path.endsWith('.yaml'))) {
+    final content = loadYaml(file.readAsStringSync()) as Map;
+    final subtype = content['subtype'];
+    final street = content['street'];
+    if (subtype != 'postflop-jam' || street != 'flop') {
+      stderr.writeln('::error::${file.path} has invalid subtype/street');
+      hasError = true;
+    }
+    final spots = List.from(content['spots'] as List? ?? []);
+    if (spots.length < 80 || spots.length > 120) {
+      stderr.writeln('::error::${file.path} has ${spots.length} spots');
+      hasError = true;
+    }
+    final seenFlops = <String>{};
+    final seenBoards = <String>{};
+    for (final s in spots) {
+      final spot = s as Map;
+      final actionType = spot['actionType'];
+      final board = spot['board'] as String?;
+      final tags = List.from(spot['tags'] as List? ?? []);
+      if (actionType != 'postflop-jam' || board == null || tags.isEmpty) {
+        stderr.writeln('::error::${file.path} has invalid spot');
+        hasError = true;
+        continue;
+      }
+      if (!tags.contains('monotone') &&
+          !tags.contains('twoTone') &&
+          !tags.contains('rainbow')) {
+        stderr.writeln('::error::${file.path} spot $board missing texture tag');
+        hasError = true;
+      }
+      if (tags.any((t) => (t as String).isEmpty)) {
+        stderr.writeln('::error::${file.path} spot $board has empty tag');
+        hasError = true;
+      }
+      final flop = board.substring(0, 6);
+      if (dedupe == 'flop') {
+        if (!seenFlops.add(flop)) {
+          stderr.writeln('::error::${file.path} duplicate flop $flop');
+          hasError = true;
+        }
+      } else {
+        if (!seenBoards.add(board)) {
+          stderr.writeln('::error::${file.path} duplicate board $board');
+          hasError = true;
+        }
+      }
+    }
+  }
+  if (hasError) exit(1);
+}


### PR DESCRIPTION
## Summary
- add deterministic L3 demo sampler and validator
- ship seed-stable L3 demo packs
- wire demo sampler, validator and tests into CI

## Testing
- `flutter pub get`
- `dart run tool/autogen/l3_board_generator.dart --preset all --seed 111 --out build/tmp/l3/111 --maxAttemptsPerSpot 5000 --timeoutSec 90`
- `dart run tool/autogen/l3_demo_sampler.dart --source build/tmp/l3/111 --preset all --out assets/packs/l3/demo --spots 100 --dedupe flop --seed 111`
- `dart run tool/validators/l3_demo_validator.dart --dir assets/packs/l3/demo --dedupe flop`
- `dart test test/l3_demo_sampler_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_689bf677fa8c832abb45ec1310746ecb