### PR TITLE
feat: add packs manifest generator

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -86,6 +86,20 @@ jobs:
         run: dart run tool/autogen/l3_demo_sampler.dart --source build/tmp/l3/111 --preset all --out assets/packs/l3/demo --spots 100 --dedupe flop --seed 111
       - name: Validate L3 demo packs
         run: dart run tool/validators/l3_demo_validator.dart --dir assets/packs/l3/demo --dedupe flop
+      - name: Generate packs manifest
+        run: dart run tool/metrics/packs_manifest.dart --roots assets/packs/l2,assets/packs/l3 --out build/reports/packs_manifest.json --mdOut build/reports/packs_manifest.md
+      - run: |
+          echo "::group::Packs Manifest"
+          cat build/reports/packs_manifest.md
+          echo "::endgroup::"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: packs_manifest
+          path: |
+            build/reports/packs_manifest.json
+            build/reports/packs_manifest.md
+      - name: Run packs manifest test
+        run: dart test test/packs_manifest_test.dart
       - name: Run L3 demo tests
         run: dart test test/l3_demo_*
       - name: PackRun L3 (seed 111)

--- a/test/packs_manifest_test.dart
+++ b/test/packs_manifest_test.dart
@@ -1,0 +1,50 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+void main() {
+  test('packs manifest generator', () async {
+    final proc = await Process.run('dart', [
+      'run',
+      'tool/metrics/packs_manifest.dart',
+      '--out',
+      'build/reports/packs_manifest.json',
+      '--mdOut',
+      'build/reports/packs_manifest.md',
+    ]);
+    expect(proc.exitCode, 0, reason: 'generator failed');
+
+    final file = File('build/reports/packs_manifest.json');
+    expect(file.existsSync(), true, reason: 'manifest not found');
+    final manifest = jsonDecode(await file.readAsString()) as Map;
+    final packs = List.from(manifest['packs'] as List? ?? []);
+
+    final demoIds = {'l3-demo-paired', 'l3-demo-unpaired', 'l3-demo-ace-high'};
+    for (final id in demoIds) {
+      final pack = packs.firstWhere((p) => p['id'] == id, orElse: () => null);
+      expect(pack != null, true, reason: 'missing demo pack $id');
+      final spotsCount = pack['spotsCount'] as int? ?? 0;
+      expect(spotsCount >= 80, true, reason: 'insufficient spots for $id');
+      final texture = Map<String, dynamic>.from(
+        pack['textureHistogram'] as Map? ?? {},
+      );
+      for (final key in ['monotone', 'twoTone', 'rainbow']) {
+        expect(texture.containsKey(key), true, reason: 'missing $key');
+      }
+    }
+
+    // basic schema check
+    for (final pack in packs) {
+      expect(pack.containsKey('id'), true);
+      expect(pack.containsKey('stage'), true);
+      expect((pack['stage'] as Map).containsKey('id'), true);
+      expect(pack.containsKey('subtype'), true);
+      expect(pack.containsKey('street'), true);
+      expect(pack.containsKey('file'), true);
+      expect(pack.containsKey('spotsCount'), true);
+      expect(pack.containsKey('tagsHistogram'), true);
+      expect(pack.containsKey('textureHistogram'), true);
+    }
+  });
+}

--- a/tool/metrics/packs_manifest.dart
+++ b/tool/metrics/packs_manifest.dart
@@ -1,0 +1,184 @@
+import 'dart:convert';
+import 'dart:io';
+
+class _Counts {
+  int packs = 0;
+  int spots = 0;
+  void add(int spotCount) {
+    packs += 1;
+    spots += spotCount;
+  }
+}
+
+Map<String, String> _parseArgs(List<String> args) {
+  final map = <String, String>{};
+  for (var i = 0; i < args.length; i++) {
+    final arg = args[i];
+    if (arg.startsWith('--') && i + 1 < args.length) {
+      map[arg.substring(2)] = args[++i];
+    }
+  }
+  return map;
+}
+
+Future<void> main(List<String> args) async {
+  final argMap = _parseArgs(args);
+  final rootsArg = argMap['roots'] ?? 'assets/packs/l2,assets/packs/l3';
+  final roots = rootsArg.split(',').where((e) => e.isNotEmpty).toList();
+  final outFile = File(argMap['out'] ?? 'build/reports/packs_manifest.json');
+  final mdOutPath = argMap['mdOut'];
+  final entries = <Map<String, Object>>[];
+  final stageSubtypeStats = <String, Map<String, _Counts>>{};
+  var totalSpots = 0;
+
+  final tagLineReg = RegExp(r'-\s*(\S+)');
+  final packTagSectionReg = RegExp(
+    r'^tags:\n((?:\s+-\s*\S+\n)+)',
+    multiLine: true,
+  );
+  final spotReg = RegExp(r'^\s{2}-\n((?:\s{4}.+\n)+)', multiLine: true);
+  final spotTagsReg = RegExp(
+    r'^\s{4}tags:\n((?:\s{6}-\s*\S+\n)+)',
+    multiLine: true,
+  );
+
+  for (final root in roots) {
+    final dir = Directory(root);
+    if (!dir.existsSync()) continue;
+    final files = dir
+        .listSync(recursive: true)
+        .whereType<File>()
+        .where((f) => f.path.endsWith('.yaml'));
+    for (final file in files) {
+      final raw = await file.readAsString();
+      if (!raw.contains('\nspots:')) continue;
+      final id =
+          RegExp(r'^id:\s*(\S+)', multiLine: true).firstMatch(raw)?.group(1) ??
+          '';
+      final stageId =
+          RegExp(
+            r'^stage:\n\s+id:\s*(\S+)',
+            multiLine: true,
+          ).firstMatch(raw)?.group(1) ??
+          'unknown';
+      final subtype =
+          RegExp(
+            r'^subtype:\s*(\S+)',
+            multiLine: true,
+          ).firstMatch(raw)?.group(1) ??
+          'unknown';
+      final street =
+          RegExp(
+            r'^street:\s*(\S+)',
+            multiLine: true,
+          ).firstMatch(raw)?.group(1) ??
+          'unknown';
+
+      final tagsHistogram = <String, int>{};
+      final textureHistogram = <String, int>{
+        'monotone': 0,
+        'twoTone': 0,
+        'rainbow': 0,
+      };
+
+      final packTagSection = packTagSectionReg.firstMatch(raw);
+      if (packTagSection != null) {
+        final lines = packTagSection.group(1)!.trim().split('\n');
+        for (final line in lines) {
+          final tag = tagLineReg.firstMatch(line)?.group(1);
+          if (tag != null) {
+            tagsHistogram[tag] = (tagsHistogram[tag] ?? 0) + 1;
+            if (textureHistogram.containsKey(tag)) {
+              textureHistogram[tag] = textureHistogram[tag]! + 1;
+            }
+          }
+        }
+      }
+
+      final spotMatches = spotReg.allMatches(raw).toList();
+      final spotsCount = spotMatches.length;
+      for (final match in spotMatches) {
+        final spotContent = match.group(1)!;
+        final tagSection = spotTagsReg.firstMatch(spotContent);
+        if (tagSection != null) {
+          final lines = tagSection.group(1)!.trim().split('\n');
+          for (final line in lines) {
+            final tag = tagLineReg.firstMatch(line)?.group(1);
+            if (tag != null) {
+              tagsHistogram[tag] = (tagsHistogram[tag] ?? 0) + 1;
+              if (textureHistogram.containsKey(tag)) {
+                textureHistogram[tag] = textureHistogram[tag]! + 1;
+              }
+            }
+          }
+        }
+      }
+
+      totalSpots += spotsCount;
+      entries.add({
+        'id': id,
+        'stage': {'id': stageId},
+        'subtype': subtype,
+        'street': street,
+        'file': file.path,
+        'spotsCount': spotsCount,
+        'tagsHistogram': tagsHistogram,
+        'textureHistogram': textureHistogram,
+      });
+      final stageMap = stageSubtypeStats.putIfAbsent(
+        stageId,
+        () => <String, _Counts>{},
+      );
+      stageMap.putIfAbsent(subtype, () => _Counts()).add(spotsCount);
+    }
+  }
+
+  entries.sort((a, b) {
+    final s = (a['stage'] as Map)['id'].toString().compareTo(
+      (b['stage'] as Map)['id'].toString(),
+    );
+    if (s != 0) return s;
+    final st = a['subtype'].toString().compareTo(b['subtype'].toString());
+    if (st != 0) return st;
+    return a['id'].toString().compareTo(b['id'].toString());
+  });
+
+  if (!outFile.parent.existsSync()) {
+    outFile.parent.createSync(recursive: true);
+  }
+  final manifest = {
+    'totalPacks': entries.length,
+    'totalSpots': totalSpots,
+    'packs': entries,
+  };
+  await outFile.writeAsString(
+    const JsonEncoder.withIndent('  ').convert(manifest),
+  );
+
+  if (mdOutPath != null) {
+    final mdFile = File(mdOutPath);
+    if (!mdFile.parent.existsSync()) {
+      mdFile.parent.createSync(recursive: true);
+    }
+    final buffer = StringBuffer();
+    buffer.writeln('# Packs Manifest');
+    buffer.writeln();
+    buffer.writeln('- total packs: ${entries.length}');
+    buffer.writeln('- total spots: $totalSpots');
+    buffer.writeln();
+    buffer.writeln('## By stage/subtype');
+    final stageKeys = stageSubtypeStats.keys.toList()..sort();
+    for (final stage in stageKeys) {
+      buffer.writeln('- $stage');
+      final sub = stageSubtypeStats[stage]!;
+      final subKeys = sub.keys.toList()..sort();
+      for (final st in subKeys) {
+        final c = sub[st]!;
+        buffer.writeln('  - $st: ${c.packs} packs, ${c.spots} spots');
+      }
+    }
+    await mdFile.writeAsString(buffer.toString());
+  }
+
+  print('packs: ${entries.length}, spots: $totalSpots');
+}


### PR DESCRIPTION
## Summary
- add packs manifest CLI to summarize L2/L3 packs and produce JSON/Markdown reports
- test demo packs and manifest schema
- wire generator, logs, artifacts, and test into CI workflow

## Testing
- `dart run tool/metrics/packs_manifest.dart --out build/reports/packs_manifest.json --mdOut build/reports/packs_manifest.md`
- `dart test test/packs_manifest_test.dart` *(fails: test did not complete)*


------
https://chatgpt.com/codex/tasks/task_e_689bfaa8f7c0832abc51cb1359d60261