### PR TITLE
Add preset and SPR stats to L3 pack run

### DIFF
--- a/test/l3_packrun_presetcounts_test.dart
+++ b/test/l3_packrun_presetcounts_test.dart
@@ -1,0 +1,51 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+void main() {
+  test('pack run summary contains preset and SPR stats', () async {
+    final outDir = 'build/tmp/l3_cli/222';
+    final gen = await Process.run('dart', [
+      'run',
+      'tool/autogen/l3_board_generator.dart',
+      '--preset',
+      'paired',
+      '--seed',
+      '222',
+      '--maxAttemptsPerSpot',
+      '5000',
+      '--timeoutSec',
+      '90',
+      '--out',
+      outDir,
+    ]);
+    expect(gen.exitCode, 0, reason: gen.stderr.toString());
+
+    final reportFile = File('build/reports/l3_packrun_preset.json');
+    final run = await Process.run('dart', [
+      'run',
+      'tool/l3/pack_run_cli.dart',
+      '--dir',
+      outDir,
+      '--out',
+      reportFile.path,
+    ]);
+    expect(run.exitCode, 0, reason: run.stderr.toString());
+
+    final report =
+        json.decode(reportFile.readAsStringSync()) as Map<String, dynamic>;
+    final summary = report['summary'] as Map<String, dynamic>;
+
+    final presetCounts = summary['presetCounts'] as Map<String, dynamic>?;
+    expect(presetCounts, isNotNull);
+    final presetKeys = presetCounts!.keys.where(
+      (k) => k == 'paired' || k == 'unpaired' || k == 'ace-high',
+    );
+    expect(presetKeys, isNotEmpty);
+
+    final sprHistogram = summary['sprHistogram'] as Map<String, dynamic>?;
+    expect(sprHistogram, isNotNull);
+    expect(sprHistogram!.keys, containsAll(['spr_low', 'spr_mid', 'spr_high']));
+  });
+}


### PR DESCRIPTION
## Summary
- extend pack_run_cli to capture preset counts, SPR histogram, and per-spot SPR
- aggregate and render SPR distribution in l3_packrun_report
- add regression test ensuring preset and SPR stats in summary

## Testing
- `flutter test test/l3_packrun_presetcounts_test.dart`
- `flutter test test/l3_packrun_cli_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_689bfd842708832a9be94c1a45dd35d0