### PR TITLE
fix: clean explain-mode merge artifacts (ArgParser, evaluator, reporter)

### DIFF
--- a/lib/l3/jam_fold_evaluator.dart
+++ b/lib/l3/jam_fold_evaluator.dart
@@ -59,20 +59,20 @@ class JamFoldOutcome {
   });
 
   Map<String, dynamic> toJson() => {
-        'jamEV': jamEV,
-        'foldEV': foldEV,
-        'decision': decision,
-        if (sprBucket != null) 'sprBucket': sprBucket,
-        if (tagsUsed != null) 'tagsUsed': tagsUsed,
-        if (contrib != null) 'contrib': contrib,
-      };
+    'jamEV': jamEV,
+    'foldEV': foldEV,
+    'decision': decision,
+    if (sprBucket != null) 'sprBucket': sprBucket,
+    if (tagsUsed != null) 'tagsUsed': tagsUsed,
+    if (contrib != null) 'contrib': contrib,
+  };
 }
 
 class JamFoldEvaluator {
   final Map<String, double> weights;
 
   JamFoldEvaluator({Map<String, double>? weights})
-      : weights = weights ?? _defaultWeights;
+    : weights = weights ?? _defaultWeights;
 
   factory JamFoldEvaluator.fromWeights(Map<String, double> w) {
     return JamFoldEvaluator(weights: {..._defaultWeights, ...w});
@@ -92,10 +92,10 @@ class JamFoldEvaluator {
     final bucket = spr < 1
         ? 'spr_low'
         : spr < 2
-            ? 'spr_mid'
-            : 'spr_high';
+        ? 'spr_mid'
+        : 'spr_high';
 
-    final tags = board.tags;
+    final tags = List<String>.from(board.tags)..sort();
     final contrib = <String, double>{};
     double score = 0;
     for (final tag in tags) {

--- a/tool/l3/pack_run_cli.dart
+++ b/tool/l3/pack_run_cli.dart
@@ -28,8 +28,9 @@ void main(List<String> args) {
     final jsonStr = weightsOpt.trim().startsWith('{')
         ? weightsOpt
         : File(weightsOpt).readAsStringSync();
-    final decoded = (json.decode(jsonStr) as Map<String, dynamic>)
-        .map((k, v) => MapEntry(k, (v as num).toDouble()));
+    final decoded = (json.decode(jsonStr) as Map<String, dynamic>).map(
+      (k, v) => MapEntry(k, (v as num).toDouble()),
+    );
     evaluator = JamFoldEvaluator.fromWeights(decoded);
   } else {
     evaluator = JamFoldEvaluator();
@@ -38,8 +39,12 @@ void main(List<String> args) {
   Map<String, double>? priors;
   final priorsOpt = res['priors'] as String?;
   if (priorsOpt != null) {
-    final decoded = (json.decode(priorsOpt) as Map<String, dynamic>)
-        .map((k, v) => MapEntry(k, (v as num).toDouble()));
+    final jsonStr = priorsOpt.trim().startsWith('{')
+        ? priorsOpt
+        : File(priorsOpt).readAsStringSync();
+    final decoded = (json.decode(jsonStr) as Map<String, dynamic>).map(
+      (k, v) => MapEntry(k, (v as num).toDouble()),
+    );
     priors = decoded;
   }
 
@@ -47,11 +52,7 @@ void main(List<String> args) {
   final outSpots = <Map<String, dynamic>>[];
   final textureCounts = <String, int>{};
   final presetCounts = <String, int>{};
-  final sprHistogram = <String, int>{
-    'spr_low': 0,
-    'spr_mid': 0,
-    'spr_high': 0,
-  };
+  final sprHistogram = <String, int>{'spr_low': 0, 'spr_mid': 0, 'spr_high': 0};
   int jamCount = 0;
 
   try {
@@ -89,8 +90,8 @@ void main(List<String> args) {
         final sprBucket = spr < 1.0
             ? 'spr_low'
             : spr < 2.0
-                ? 'spr_mid'
-                : 'spr_high';
+            ? 'spr_mid'
+            : 'spr_high';
         sprHistogram[sprBucket] = (sprHistogram[sprBucket] ?? 0) + 1;
         final outcome = evaluator.evaluate(
           board: FlopBoard.fromString(boardStr),


### PR DESCRIPTION
## Summary
- allow `--priors` to be loaded from JSON string or file path in `pack_run_cli`
- sort tags for deterministic `contrib` ordering in `jam_fold_evaluator`

## Testing
- `dart format tool/l3/pack_run_cli.dart lib/l3/jam_fold_evaluator.dart`
- `dart run tool/autogen/l3_board_generator.dart --preset paired --seed 111 --out build/tmp/l3/111 --maxAttemptsPerSpot 5000 --timeoutSec 90` *(fails: couldn't resolve package 'args')*
- `dart run tool/l3/pack_run_cli.dart --dir build/tmp/l3/111 --out build/reports/l3_packrun_111.json --explain` *(fails: couldn't resolve package 'args')*
- `dart run tool/metrics/l3_packrun_report.dart --reports build/reports/l3_packrun_111.json --out build/reports/l3_report.md`
- `dart run tool/validators/l3_distribution_validator.dart --dir build/tmp/l3 --dedupe flop` *(fails: couldn't resolve package 'args')*

## Risk/rollback
- revert patch

------
https://chatgpt.com/codex/tasks/task_e_689c07205960832ab095fcbae1bb5d47