### PR TITLE
Add default weight presets & A/B jam-rate check (tooling-only)

### DIFF
--- a/test/l3_weights_presets_test.dart
+++ b/test/l3_weights_presets_test.dart
@@ -1,0 +1,66 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+void main() {
+  test('weight presets influence jam rate', () async {
+    const outDir = 'build/tmp/l3/222';
+    final gen = await Process.run('dart', [
+      'run',
+      'tool/autogen/l3_board_generator.dart',
+      '--preset',
+      'paired',
+      '--seed',
+      '222',
+      '--maxAttemptsPerSpot',
+      '5000',
+      '--timeoutSec',
+      '90',
+      '--out',
+      outDir,
+    ]);
+    expect(gen.exitCode, 0, reason: gen.stderr.toString());
+
+    Future<Map<String, dynamic>> runPack(String out, [String? weights]) async {
+      final args = [
+        'run',
+        'tool/l3/pack_run_cli.dart',
+        '--dir',
+        outDir,
+        '--out',
+        out,
+      ];
+      if (weights != null) {
+        args.addAll(['--weights', weights]);
+      }
+      final res = await Process.run('dart', args);
+      expect(res.exitCode, 0, reason: res.stderr.toString());
+      return json.decode(File(out).readAsStringSync()) as Map<String, dynamic>;
+    }
+
+    final defaultReport = await runPack(
+      'build/reports/l3_packrun_default.json',
+    );
+    final aggroReport = await runPack(
+      'build/reports/l3_packrun_aggro.json',
+      'tool/config/weights/aggro.json',
+    );
+    final nittyReport = await runPack(
+      'build/reports/l3_packrun_nitty.json',
+      'tool/config/weights/nitty.json',
+    );
+
+    double jamRate(Map<String, dynamic> report) {
+      final summary = report['summary'] as Map<String, dynamic>;
+      return (summary['avgJamRate'] as num).toDouble();
+    }
+
+    final defaultJam = jamRate(defaultReport);
+    final aggroJam = jamRate(aggroReport);
+    final nittyJam = jamRate(nittyReport);
+
+    expect(aggroJam, greaterThan(defaultJam));
+    expect(defaultJam, greaterThan(nittyJam));
+  });
+}

--- a/tool/config/weights/aggro.json
+++ b/tool/config/weights/aggro.json
@@ -1,0 +1,1 @@
+{"paired":-0.1,"unpaired":0.3,"monotone":-0.2,"twoTone":0.15,"rainbow":0.25,"ace-high":0.15,"broadway":0.1,"spr_low":0.4,"spr_mid":0.05,"spr_high":-0.35}

--- a/tool/config/weights/nitty.json
+++ b/tool/config/weights/nitty.json
@@ -1,0 +1,1 @@
+{"paired":-0.25,"unpaired":0.1,"monotone":-0.35,"twoTone":0.05,"rainbow":0.1,"ace-high":0.0,"broadway":0.0,"spr_low":0.1,"spr_mid":0.0,"spr_high":-0.4}


### PR DESCRIPTION
## Summary
- add aggro and nitty weight presets for L3 pack runs
- test that verifies weight presets alter jam rate

## Testing
- `dart pub get` *(fails: Because poker_analyzer depends on flutter_test from sdk which doesn't exist (the Flutter SDK is not available))*
- `dart run tool/autogen/l3_board_generator.dart --preset paired --seed 222 --out build/tmp/l3/222 --maxAttemptsPerSpot 5000 --timeoutSec 90` *(fails: Error: Not found: 'package:path/path.dart')*


------
https://chatgpt.com/codex/tasks/task_e_689c08e0e654832aa6a765da9066e878