### PR TITLE
feat: add weights preset alias and l3 A/B diff

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -26,6 +26,7 @@ jobs:
               - 'assets/packs/l3/**'
               - 'assets/packs/l3/demo/**'
               - 'assets/theory/**'
+              - 'tool/config/weights/**'
               - 'tool/validators/**'
               - 'tool/validators/l3_demo_validator.dart'
               - 'tool/metrics/**'
@@ -104,6 +105,18 @@ jobs:
         run: dart test test/l3_demo_*
       - name: PackRun L3 (seed 111)
         run: dart run tool/l3/pack_run_cli.dart --dir build/tmp/l3/111 --out build/reports/l3_packrun_111.json
+      - name: PackRun L3 aggro (seed 111)
+        run: dart run tool/l3/pack_run_cli.dart --dir build/tmp/l3/111 --out build/reports/l3_packrun_aggro.json --weightsPreset aggro
+      - name: L3 A/B diff 111
+        run: dart run tool/metrics/l3_ab_diff.dart --base build/reports/l3_packrun_111.json --challenger build/reports/l3_packrun_aggro.json --out build/reports/l3_ab_111.md
+      - run: |
+          echo "::group::L3 A/B diff 111"
+          cat build/reports/l3_ab_111.md
+          echo "::endgroup::"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: l3_ab_111.md
+          path: build/reports/l3_ab_111.md
       - name: PackRun L3 (seed 222)
         run: dart run tool/l3/pack_run_cli.dart --dir build/tmp/l3/222 --out build/reports/l3_packrun_222.json
       - name: PackRun L3 (seed 333)

--- a/tool/config/weights/default.json
+++ b/tool/config/weights/default.json
@@ -1,0 +1,1 @@
+{"paired":-0.2,"unpaired":0.2,"monotone":-0.3,"twoTone":0.1,"rainbow":0.2,"ace-high":0.1,"broadway":0.05,"spr_low":0.3,"spr_mid":0.0,"spr_high":-0.3}

--- a/tool/metrics/l3_ab_diff.dart
+++ b/tool/metrics/l3_ab_diff.dart
@@ -1,0 +1,83 @@
+import 'dart:convert';
+import 'dart:io';
+
+Map<String, String> _parseArgs(List<String> args) {
+  final map = <String, String>{};
+  for (var i = 0; i < args.length; i++) {
+    final arg = args[i];
+    if (arg.startsWith('--') && i + 1 < args.length) {
+      map[arg.substring(2)] = args[++i];
+    }
+  }
+  return map;
+}
+
+void _renderSection(StringBuffer buf, String title, Map<String, dynamic> base,
+    Map<String, dynamic> challenger) {
+  buf.writeln('\n### $title');
+  buf.writeln('| key | base | challenger | Δ |');
+  buf.writeln('| --- | --- | --- | --- |');
+  final keys = {
+    ...base.keys.cast<String>(),
+    ...challenger.keys.cast<String>(),
+  }.toList()
+    ..sort();
+  for (final k in keys) {
+    final b = (base[k] as num? ?? 0).toInt();
+    final c = (challenger[k] as num? ?? 0).toInt();
+    final d = c - b;
+    final delta = d >= 0 ? '+$d' : '$d';
+    buf.writeln('| $k | $b | $c | $delta |');
+  }
+}
+
+void main(List<String> args) async {
+  final argMap = _parseArgs(args);
+  final basePath = argMap['base'];
+  final challPath = argMap['challenger'];
+  final outPath = argMap['out'];
+  final buffer = StringBuffer();
+  try {
+    final baseJson = jsonDecode(await File(basePath ?? '').readAsString())
+        as Map<String, dynamic>;
+    final challJson = jsonDecode(await File(challPath ?? '').readAsString())
+        as Map<String, dynamic>;
+    final baseSummary =
+        (baseJson['summary'] as Map<String, dynamic>?) ?? <String, dynamic>{};
+    final challSummary =
+        (challJson['summary'] as Map<String, dynamic>?) ?? <String, dynamic>{};
+
+    final baseJam = (baseSummary['avgJamRate'] as num? ?? 0).toDouble();
+    final challJam = (challSummary['avgJamRate'] as num? ?? 0).toDouble();
+    buffer.writeln('| metric | base | challenger | Δ |');
+    buffer.writeln('| --- | --- | --- | --- |');
+    buffer.writeln(
+        '| jamRate | ${baseJam.toStringAsFixed(3)} | ${challJam.toStringAsFixed(3)} | ${(challJam - baseJam).toStringAsFixed(3)} |');
+
+    _renderSection(
+        buffer,
+        'Textures',
+        (baseSummary['textureCounts'] as Map<String, dynamic>?) ?? {},
+        (challSummary['textureCounts'] as Map<String, dynamic>?) ?? {});
+    _renderSection(
+        buffer,
+        'Presets',
+        (baseSummary['presetCounts'] as Map<String, dynamic>?) ?? {},
+        (challSummary['presetCounts'] as Map<String, dynamic>?) ?? {});
+    _renderSection(
+        buffer,
+        'SPR',
+        (baseSummary['sprHistogram'] as Map<String, dynamic>?) ?? {},
+        (challSummary['sprHistogram'] as Map<String, dynamic>?) ?? {});
+
+    if (outPath != null) {
+      final outFile = File(outPath);
+      outFile.parent.createSync(recursive: true);
+      await outFile.writeAsString(buffer.toString());
+    } else {
+      print(buffer.toString());
+    }
+  } catch (e) {
+    stderr.writeln('l3_ab_diff error: $e');
+  }
+}


### PR DESCRIPTION
## Summary
- support `--weightsPreset` in `pack_run_cli` for aggro/nitty/default weight aliases
- report PackRun A/B differences with new `l3_ab_diff` tool
- run aggro PackRun and diff in CI; trigger on weight config changes

## Testing
- `flutter pub get`
- `dart run tool/l3/pack_run_cli.dart --dir build/tmp/l3/111 --out build/reports/l3_packrun_111.json`
- `dart run tool/l3/pack_run_cli.dart --dir build/tmp/l3/111 --out build/reports/l3_packrun_aggro.json --weightsPreset aggro`
- `dart run tool/metrics/l3_ab_diff.dart --base build/reports/l3_packrun_111.json --challenger build/reports/l3_packrun_aggro.json --out build/reports/l3_ab_111.md`


------
https://chatgpt.com/codex/tasks/task_e_689c0c8e689c832a9e036fab07bde479