### PR TITLE
fix: tidy weightsPreset branch, ensure CI catches l3 changes

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -26,6 +26,7 @@ jobs:
               - 'assets/packs/l3/**'
               - 'assets/packs/l3/demo/**'
               - 'assets/theory/**'
+              - 'tool/l3/**'
               - 'tool/config/weights/**'
               - 'tool/validators/**'
               - 'tool/validators/l3_demo_validator.dart'

--- a/tool/l3/pack_run_cli.dart
+++ b/tool/l3/pack_run_cli.dart
@@ -16,10 +16,7 @@ void main(List<String> args) {
     ..addOption('dir', defaultsTo: 'build/tmp/l3/111')
     ..addOption('out', defaultsTo: 'build/reports/l3_packrun.json')
     ..addOption('weights')
-    ..addOption(
-      'weightsPreset',
-      allowed: ['aggro', 'nitty', 'default'],
-    )
+    ..addOption('weightsPreset', allowed: ['aggro', 'nitty', 'default'])
     ..addOption('priors')
     ..addFlag('explain', negatable: false);
   final res = parser.parse(args);
@@ -28,6 +25,7 @@ void main(List<String> args) {
 
   JamFoldEvaluator evaluator;
   final weightsOpt = res['weights'] as String?;
+  final presetOpt = res['weightsPreset'] as String?;
   if (weightsOpt != null) {
     final jsonStr = weightsOpt.trim().startsWith('{')
         ? weightsOpt
@@ -36,22 +34,19 @@ void main(List<String> args) {
       (k, v) => MapEntry(k, (v as num).toDouble()),
     );
     evaluator = JamFoldEvaluator.fromWeights(decoded);
+  } else if (presetOpt != null) {
+    final presetPath = {
+      'aggro': 'tool/config/weights/aggro.json',
+      'nitty': 'tool/config/weights/nitty.json',
+      'default': 'tool/config/weights/default.json',
+    }[presetOpt]!;
+    final jsonStr = File(presetPath).readAsStringSync();
+    final decoded = (json.decode(jsonStr) as Map<String, dynamic>).map(
+      (k, v) => MapEntry(k, (v as num).toDouble()),
+    );
+    evaluator = JamFoldEvaluator.fromWeights(decoded);
   } else {
-    final presetOpt = res['weightsPreset'] as String?;
-    if (presetOpt != null) {
-      final presetPath = {
-        'aggro': 'tool/config/weights/aggro.json',
-        'nitty': 'tool/config/weights/nitty.json',
-        'default': 'tool/config/weights/default.json',
-      }[presetOpt]!;
-      final jsonStr = File(presetPath).readAsStringSync();
-      final decoded = (json.decode(jsonStr) as Map<String, dynamic>).map(
-        (k, v) => MapEntry(k, (v as num).toDouble()),
-      );
-      evaluator = JamFoldEvaluator.fromWeights(decoded);
-    } else {
-      evaluator = JamFoldEvaluator();
-    }
+    evaluator = JamFoldEvaluator();
   }
 
   Map<String, double>? priors;
@@ -108,8 +103,8 @@ void main(List<String> args) {
         final sprBucket = spr < 1.0
             ? 'spr_low'
             : spr < 2.0
-                ? 'spr_mid'
-                : 'spr_high';
+            ? 'spr_mid'
+            : 'spr_high';
         sprHistogram[sprBucket] = (sprHistogram[sprBucket] ?? 0) + 1;
         final outcome = evaluator.evaluate(
           board: FlopBoard.fromString(boardStr),

--- a/tool/metrics/l3_ab_diff.dart
+++ b/tool/metrics/l3_ab_diff.dart
@@ -12,16 +12,19 @@ Map<String, String> _parseArgs(List<String> args) {
   return map;
 }
 
-void _renderSection(StringBuffer buf, String title, Map<String, dynamic> base,
-    Map<String, dynamic> challenger) {
+void _renderSection(
+  StringBuffer buf,
+  String title,
+  Map<String, dynamic> base,
+  Map<String, dynamic> challenger,
+) {
   buf.writeln('\n### $title');
   buf.writeln('| key | base | challenger | Δ |');
   buf.writeln('| --- | --- | --- | --- |');
   final keys = {
     ...base.keys.cast<String>(),
     ...challenger.keys.cast<String>(),
-  }.toList()
-    ..sort();
+  }.toList()..sort();
   for (final k in keys) {
     final b = (base[k] as num? ?? 0).toInt();
     final c = (challenger[k] as num? ?? 0).toInt();
@@ -38,10 +41,14 @@ void main(List<String> args) async {
   final outPath = argMap['out'];
   final buffer = StringBuffer();
   try {
-    final baseJson = jsonDecode(await File(basePath ?? '').readAsString())
-        as Map<String, dynamic>;
-    final challJson = jsonDecode(await File(challPath ?? '').readAsString())
-        as Map<String, dynamic>;
+    buffer.writeln('# L3 A/B diff');
+    buffer.writeln();
+    final baseJson =
+        jsonDecode(await File(basePath ?? '').readAsString())
+            as Map<String, dynamic>;
+    final challJson =
+        jsonDecode(await File(challPath ?? '').readAsString())
+            as Map<String, dynamic>;
     final baseSummary =
         (baseJson['summary'] as Map<String, dynamic>?) ?? <String, dynamic>{};
     final challSummary =
@@ -52,23 +59,27 @@ void main(List<String> args) async {
     buffer.writeln('| metric | base | challenger | Δ |');
     buffer.writeln('| --- | --- | --- | --- |');
     buffer.writeln(
-        '| jamRate | ${baseJam.toStringAsFixed(3)} | ${challJam.toStringAsFixed(3)} | ${(challJam - baseJam).toStringAsFixed(3)} |');
+      '| jamRate | ${baseJam.toStringAsFixed(3)} | ${challJam.toStringAsFixed(3)} | ${(challJam - baseJam).toStringAsFixed(3)} |',
+    );
 
     _renderSection(
-        buffer,
-        'Textures',
-        (baseSummary['textureCounts'] as Map<String, dynamic>?) ?? {},
-        (challSummary['textureCounts'] as Map<String, dynamic>?) ?? {});
+      buffer,
+      'Textures',
+      (baseSummary['textureCounts'] as Map<String, dynamic>?) ?? {},
+      (challSummary['textureCounts'] as Map<String, dynamic>?) ?? {},
+    );
     _renderSection(
-        buffer,
-        'Presets',
-        (baseSummary['presetCounts'] as Map<String, dynamic>?) ?? {},
-        (challSummary['presetCounts'] as Map<String, dynamic>?) ?? {});
+      buffer,
+      'Presets',
+      (baseSummary['presetCounts'] as Map<String, dynamic>?) ?? {},
+      (challSummary['presetCounts'] as Map<String, dynamic>?) ?? {},
+    );
     _renderSection(
-        buffer,
-        'SPR',
-        (baseSummary['sprHistogram'] as Map<String, dynamic>?) ?? {},
-        (challSummary['sprHistogram'] as Map<String, dynamic>?) ?? {});
+      buffer,
+      'SPR',
+      (baseSummary['sprHistogram'] as Map<String, dynamic>?) ?? {},
+      (challSummary['sprHistogram'] as Map<String, dynamic>?) ?? {},
+    );
 
     if (outPath != null) {
       final outFile = File(outPath);


### PR DESCRIPTION
## Summary
- simplify weight selection order and clean stray ternary in `pack_run_cli.dart`
- add `tool/l3/**` to CI paths filter
- add header line to `l3_ab_diff` report

## Testing
- `dart format tool/l3/pack_run_cli.dart tool/metrics/l3_ab_diff.dart`
- `flutter pub get` *(fails: command not found)*
- `dart analyze`
- `dart run tool/l3/pack_run_cli.dart --dir build/tmp/l3/111 --out build/reports/l3_packrun_111.json` *(fails: package resolution)*
- `dart run tool/l3/pack_run_cli.dart --dir build/tmp/l3/111 --out build/reports/l3_packrun_aggro.json --weightsPreset aggro` *(fails: package resolution)*
- `dart run tool/metrics/l3_ab_diff.dart --base build/reports/l3_packrun_111.json --challenger build/reports/l3_packrun_aggro.json --out build/reports/l3_ab_111.md` *(fails: missing input file)*


------
https://chatgpt.com/codex/tasks/task_e_689c0f17453c832a80912ca2dad865de