### PR TITLE
chore: add precommit sanity script

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -60,6 +60,8 @@ jobs:
             pub-${{ runner.os }}-
 
       - run: flutter pub get
+      - name: Precommit sanity (dup checks)
+        run: bash tool/dev/precommit_sanity.sh
       - name: Check L2 theory snippet coverage
         run: dart run tool/validators/theory_snippet_coverage.dart --packs assets/packs/l2 --snippets assets/theory/l2/snippets.yaml --min 0.90
       - name: Generate L2 packs (seed 111)

--- a/tool/dev/precommit_sanity.sh
+++ b/tool/dev/precommit_sanity.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RED=$'\e[31m'; GRN=$'\e[32m'; NC=$'\e[0m'
+fail=0
+
+say_ok(){ echo "${GRN}OK${NC}  $1"; }
+say_bad(){ echo "${RED}FAIL${NC} $1"; fail=1; }
+
+# 1) Не должно быть дублей weightsPreset в парсере CLI
+if [[ $(grep -R "addOption('weightsPreset'" tool/l3/pack_run_cli.dart | wc -l) -gt 1 ]]; then
+  say_bad "duplicate addOption('weightsPreset') in tool/l3/pack_run_cli.dart"
+  grep -n "addOption('weightsPreset'" tool/l3/pack_run_cli.dart || true
+else
+  say_ok "weightsPreset parser deduped"
+fi
+
+# 2) Не более одного определения _renderSection в A/B диффе
+if [[ $(grep -R "void _renderSection\\(" tool/metrics/l3_ab_diff.dart | wc -l) -gt 1 ]]; then
+  say_bad "duplicate void _renderSection(...) in tool/metrics/l3_ab_diff.dart"
+  grep -n "void _renderSection\\(" tool/metrics/l3_ab_diff.dart || true
+else
+  say_ok "_renderSection defined once"
+fi
+
+# 3) Не должно быть «голых» строк тернарника (мусор типа '?  spr_mid')
+if grep -nE "^[[:space:]]*\\?[[:space:]]*'spr_(low|mid|high)'" tool/l3/pack_run_cli.dart >/dev/null; then
+  say_bad "stray ternary tail in tool/l3/pack_run_cli.dart"
+  grep -nE "^[[:space:]]*\\?[[:space:]]*'spr_(low|mid|high)'" tool/l3/pack_run_cli.dart || true
+else
+  say_ok "no stray ternary tails in CLI"
+fi
+
+# 4) Инициализация evaluator не должна повторяться «по дефолту»
+# (больше одного 'evaluator = JamFoldEvaluator();' подозрительно)
+if [[ $(grep -n "evaluator[[:space:]]*=[[:space:]]*JamFoldEvaluator\\(\\);" tool/l3/pack_run_cli.dart | wc -l) -gt 1 ]]; then
+  say_bad "multiple default evaluator initializations in CLI"
+  grep -n "evaluator[[:space:]]*=[[:space:]]*JamFoldEvaluator\\(\\);" tool/l3/pack_run_cli.dart || true
+else
+  say_ok "single default evaluator init"
+fi
+
+# 5) Быстрый формат-чек (не правит, только валит при расхождении)
+if dart format --set-exit-if-changed lib tool test >/dev/null 2>&1; then
+  say_ok "format clean"
+else
+  say_bad "formatting needed: run 'dart format lib tool test'"
+fi
+
+# 6) Быстрый анализ (если SDK на месте)
+if command -v dart >/dev/null 2>&1; then
+  if dart analyze >/dev/null 2>&1; then
+    say_ok "dart analyze"
+  else
+    say_bad "dart analyze has issues"
+  fi
+fi
+
+exit $fail


### PR DESCRIPTION
## Summary
- add `tool/dev/precommit_sanity.sh` script to detect CLI and metric duplicates, stray ternary tails, default evaluator duplication, formatting, and analysis issues
- run sanity script in CI workflow

## Testing
- `bash tool/dev/precommit_sanity.sh` *(fails: stray ternary tail in tool/l3/pack_run_cli.dart; formatting needed; dart analyze has issues)*

------
https://chatgpt.com/codex/tasks/task_e_689c14f71540832ab0e9fb9a852bc948