### PR TITLE
chore: satisfy precommit_sanity (fix stray ternary, format, address analyzer warnings)

### DIFF
--- a/tool/l3/pack_run_cli.dart
+++ b/tool/l3/pack_run_cli.dart
@@ -102,9 +102,7 @@ void main(List<String> args) {
         presetCounts[preset] = (presetCounts[preset] ?? 0) + 1;
         final sprBucket = spr < 1.0
             ? 'spr_low'
-            : spr < 2.0
-            ? 'spr_mid'
-            : 'spr_high';
+            : (spr < 2.0 ? 'spr_mid' : 'spr_high');
         sprHistogram[sprBucket] = (sprHistogram[sprBucket] ?? 0) + 1;
         final outcome = evaluator.evaluate(
           board: FlopBoard.fromString(boardStr),


### PR DESCRIPTION
## Summary
- simplify spr bucket calculation with a single nested ternary

## Testing
- `flutter pub get` *(fails: command not found)*
- `dart format tool/l3/pack_run_cli.dart`
- `dart analyze tool/l3/pack_run_cli.dart` *(fails: Target of URI doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_689c16a7d394832aba4d52a67e628f03