### PR TITLE
fix: collapse sprBucket ternary; extend precommit check to catch ':' tails

### DIFF
--- a/tool/dev/precommit_sanity.sh
+++ b/tool/dev/precommit_sanity.sh
@@ -23,10 +23,10 @@ else
   say_ok "_renderSection defined once"
 fi
 
-# 3) Не должно быть «голых» строк тернарника (мусор типа '?  spr_mid')
-if grep -nE "^[[:space:]]*\\?[[:space:]]*'spr_(low|mid|high)'" tool/l3/pack_run_cli.dart >/dev/null; then
+# 3) Не должно быть «голых» строк тернарника (мусор '? spr_*' или ': spr_*')
+if grep -nE "^[[:space:]]*[?:].*'spr_(low|mid|high)'" tool/l3/pack_run_cli.dart >/dev/null; then
   say_bad "stray ternary tail in tool/l3/pack_run_cli.dart"
-  grep -nE "^[[:space:]]*\\?[[:space:]]*'spr_(low|mid|high)'" tool/l3/pack_run_cli.dart || true
+  grep -nE "^[[:space:]]*[?:].*'spr_(low|mid|high)'" tool/l3/pack_run_cli.dart || true
 else
   say_ok "no stray ternary tails in CLI"
 fi

--- a/tool/l3/pack_run_cli.dart
+++ b/tool/l3/pack_run_cli.dart
@@ -100,9 +100,8 @@ void main(List<String> args) {
         textureCounts[texture] = (textureCounts[texture] ?? 0) + 1;
         final spr = _sprFromBoard(boardStr);
         presetCounts[preset] = (presetCounts[preset] ?? 0) + 1;
-        final sprBucket = spr < 1.0
-            ? 'spr_low'
-            : (spr < 2.0 ? 'spr_mid' : 'spr_high');
+        final sprBucket =
+            spr < 1.0 ? 'spr_low' : (spr < 2.0 ? 'spr_mid' : 'spr_high');
         sprHistogram[sprBucket] = (sprHistogram[sprBucket] ?? 0) + 1;
         final outcome = evaluator.evaluate(
           board: FlopBoard.fromString(boardStr),


### PR DESCRIPTION
## Summary
- collapse `sprBucket` ternary into a single expression
- expand precommit sanity check to flag `:` ternary tails

## Testing
- `flutter pub get` *(fails: command not found)*
- `dart format lib tool test` *(fails: command not found)*
- `bash tool/dev/precommit_sanity.sh` *(fails: formatting needed; grep warning)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c18967ce0832abb63e6ae94335c59