### PR TITLE
fix: dedupe sprBucket init; harden precommit grep checks

### DIFF
--- a/tool/dev/precommit_sanity.sh
+++ b/tool/dev/precommit_sanity.sh
@@ -15,6 +15,14 @@ else
   say_ok "weightsPreset parser deduped"
 fi
 
+# 1b) Не должно быть дублей addOption('out')
+if [[ $(grep -RFn "addOption('out'" tool/l3/pack_run_cli.dart | wc -l) -gt 1 ]]; then
+  say_bad "duplicate addOption('out') in tool/l3/pack_run_cli.dart"
+  grep -n "addOption('out'" tool/l3/pack_run_cli.dart || true
+else
+  say_ok "single addOption('out')"
+fi
+
 # 2) Не более одного определения _renderSection в A/B диффе (fixed string)
 if [[ $(grep -RFn "void _renderSection(" tool/metrics/l3_ab_diff.dart | wc -l) -gt 1 ]]; then
   say_bad "duplicate void _renderSection(...) in tool/metrics/l3_ab_diff.dart"
@@ -29,6 +37,14 @@ if grep -nE "^[[:space:]]*[\?:][[:space:]]*'spr_(low|mid|high)'" tool/l3/pack_ru
   grep -nE "^[[:space:]]*[\?:][[:space:]]*'spr_(low|mid|high)'" tool/l3/pack_run_cli.dart || true
 else
   say_ok "no stray ternary tails in CLI"
+fi
+
+# 3b) Не более одного объявления sprBucket
+if [[ $(grep -nE '^[[:space:]]*final[[:space:]]+sprBucket[[:space:]]*=' tool/l3/pack_run_cli.dart | wc -l) -gt 1 ]]; then
+  say_bad "multiple 'final sprBucket =' initializations in CLI"
+  grep -nE '^[[:space:]]*final[[:space:]]+sprBucket[[:space:]]*=' tool/l3/pack_run_cli.dart || true
+else
+  say_ok "single sprBucket initialization"
 fi
 
 # 4) Инициализация evaluator по дефолту не должна повторяться


### PR DESCRIPTION
## Summary
- guard against duplicate CLI out option
- ensure single sprBucket initialization in CLI

## Testing
- `flutter pub get`
- `dart format lib tool test` *(fails: Expected to find '}' in lib/screens/achievements_catalog_screen.dart)*
- `bash tool/dev/precommit_sanity.sh` *(fails: formatting needed)*
- `dart analyze` *(fails: 464 issues)*
- `dart run tool/autogen/l3_board_generator.dart --preset paired --seed 111 --out build/tmp/l3/111 --maxAttemptsPerSpot 5000 --timeoutSec 90`
- `dart run tool/l3/pack_run_cli.dart --dir build/tmp/l3/111 --out build/reports/l3_packrun_111.json --weightsPreset default`
- `dart run tool/l3/pack_run_cli.dart --dir build/tmp/l3/111 --out build/reports/l3_packrun_aggro.json --weightsPreset aggro`
- `dart run tool/metrics/l3_ab_diff.dart --base build/reports/l3_packrun_111.json --challenger build/reports/l3_packrun_aggro.json --out build/reports/l3_ab_111.md`


------
https://chatgpt.com/codex/tasks/task_e_689c1d8c5e64832a99ea140c7e8a0654