### PR TITLE
chore(cli): warn about conflicting weight flags

### DIFF
--- a/tool/dev/precommit_sanity.sh
+++ b/tool/dev/precommit_sanity.sh
@@ -23,6 +23,22 @@ else
   say_ok "single addOption('out')"
 fi
 
+# 1c) Не должно быть дублей addOption('weights')
+if [[ $(grep -RFn "addOption('weights'" tool/l3/pack_run_cli.dart | wc -l) -gt 1 ]]; then
+  say_bad "duplicate addOption('weights') in tool/l3/pack_run_cli.dart"
+  grep -n "addOption('weights'" tool/l3/pack_run_cli.dart || true
+else
+  say_ok "single addOption('weights')"
+fi
+
+# 1d) Не должно быть дублей addOption('priors')
+if [[ $(grep -RFn "addOption('priors'" tool/l3/pack_run_cli.dart | wc -l) -gt 1 ]]; then
+  say_bad "duplicate addOption('priors') in tool/l3/pack_run_cli.dart"
+  grep -n "addOption('priors'" tool/l3/pack_run_cli.dart || true
+else
+  say_ok "single addOption('priors')"
+fi
+
 # 2) Не более одного определения _renderSection в A/B диффе (fixed string)
 if [[ $(grep -RFn "void _renderSection(" tool/metrics/l3_ab_diff.dart | wc -l) -gt 1 ]]; then
   say_bad "duplicate void _renderSection(...) in tool/metrics/l3_ab_diff.dart"

--- a/tool/l3/pack_run_cli.dart
+++ b/tool/l3/pack_run_cli.dart
@@ -26,6 +26,11 @@ void main(List<String> args) {
   JamFoldEvaluator evaluator;
   final weightsOpt = res['weights'] as String?;
   final presetOpt = res['weightsPreset'] as String?;
+  if (weightsOpt != null && presetOpt != null) {
+    stderr.writeln(
+      "[pack_run_cli] both --weights and --weightsPreset provided; using --weights",
+    );
+  }
   if (weightsOpt != null) {
     final jsonStr = weightsOpt.trim().startsWith('{')
         ? weightsOpt
@@ -100,7 +105,14 @@ void main(List<String> args) {
         textureCounts[texture] = (textureCounts[texture] ?? 0) + 1;
         final spr = _sprFromBoard(boardStr);
         presetCounts[preset] = (presetCounts[preset] ?? 0) + 1;
-        final sprBucket = spr < 1.0 ? 'spr_low' : (spr < 2.0 ? 'spr_mid' : 'spr_high');
+        final sprBucket;
+        if (spr < 1.0) {
+          sprBucket = 'spr_low';
+        } else if (spr < 2.0) {
+          sprBucket = 'spr_mid';
+        } else {
+          sprBucket = 'spr_high';
+        }
         sprHistogram[sprBucket] = (sprHistogram[sprBucket] ?? 0) + 1;
         final outcome = evaluator.evaluate(
           board: FlopBoard.fromString(boardStr),


### PR DESCRIPTION
## Summary
- warn when both `--weights` and `--weightsPreset` are provided to `pack_run_cli`
- add precommit checks for duplicate `weights`/`priors` options

## Testing
- `bash tool/dev/precommit_sanity.sh` *(fails: formatting needed; dart analyze has issues)*
- `dart analyze` *(fails: 8842 issues found)*
- `dart run tool/autogen/l3_board_generator.dart --preset paired --seed 111 --out build/tmp/l3/111 --maxAttemptsPerSpot 5000 --timeoutSec 90` *(fails: Couldn't resolve the package 'args')*
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c207b3530832a9f38d08252799bf4