### PR TITLE
fix(cli): remove duplicate sprBucket init via late-final if/else; precommit supports both decl styles

### DIFF
--- a/tool/dev/precommit_sanity.sh
+++ b/tool/dev/precommit_sanity.sh
@@ -55,12 +55,15 @@ else
   say_ok "no stray ternary tails in CLI"
 fi
 
-# 3b) Не более одного объявления sprBucket
-if [[ $(grep -nE '^[[:space:]]*final[[:space:]]+sprBucket[[:space:]]*=' tool/l3/pack_run_cli.dart | wc -l) -gt 1 ]]; then
-  say_bad "multiple 'final sprBucket =' initializations in CLI"
-  grep -nE '^[[:space:]]*final[[:space:]]+sprBucket[[:space:]]*=' tool/l3/pack_run_cli.dart || true
+# 3b) Не более одного объявления sprBucket (поддерживаем оба стиля)
+count_eq=$(grep -nE '^[[:space:]]*final[[:space:]]+sprBucket[[:space:]]*=' tool/l3/pack_run_cli.dart | wc -l || true)
+count_late=$(grep -nE '^[[:space:]]*late[[:space:]]+final[[:space:]]+String[[:space:]]+sprBucket[[:space:]]*;' tool/l3/pack_run_cli.dart | wc -l || true)
+total=$((count_eq + count_late))
+if [[ $total -gt 1 ]]; then
+  say_bad "multiple sprBucket declarations in CLI (found $total)"
+  grep -nE '^[[:space:]]*(final[[:space:]]+sprBucket[[:space:]]*=|late[[:space:]]+final[[:space:]]+String[[:space:]]+sprBucket[[:space:]]*;)' tool/l3/pack_run_cli.dart || true
 else
-  say_ok "single sprBucket initialization"
+  say_ok "sprBucket declared once or less"
 fi
 
 # 4) Инициализация evaluator по дефолту не должна повторяться

--- a/tool/l3/pack_run_cli.dart
+++ b/tool/l3/pack_run_cli.dart
@@ -105,7 +105,7 @@ void main(List<String> args) {
         textureCounts[texture] = (textureCounts[texture] ?? 0) + 1;
         final spr = _sprFromBoard(boardStr);
         presetCounts[preset] = (presetCounts[preset] ?? 0) + 1;
-        final sprBucket;
+        late final String sprBucket;
         if (spr < 1.0) {
           sprBucket = 'spr_low';
         } else if (spr < 2.0) {


### PR DESCRIPTION
## Summary
- replace duplicate sprBucket initialization with late-final if/else
- extend precommit sanity check to count both `final` and `late final` sprBucket declarations

## Testing
- `flutter pub get` *(fails: command not found: flutter)*
- `dart format lib tool test` *(fails: command not found: dart)*
- `bash tool/dev/precommit_sanity.sh` *(FAIL formatting needed: run 'dart format lib tool test')*
- `dart analyze` *(fails: command not found: dart)*
- `dart run tool/autogen/l3_board_generator.dart --preset paired --seed 111 --out build/tmp/l3/111 --maxAttemptsPerSpot 5000 --timeoutSec 90` *(fails: command not found: dart)*
- `dart run tool/l3/pack_run_cli.dart --dir build/tmp/l3/111 --out build/reports/l3_packrun_111.json --weightsPreset default` *(fails: command not found: dart)*
- `dart run tool/l3/pack_run_cli.dart --dir build/tmp/l3/111 --out build/reports/l3_packrun_aggro.json --weightsPreset aggro` *(fails: command not found: dart)*
- `dart run tool/metrics/l3_ab_diff.dart --base build/reports/l3_packrun_111.json --challenger build/reports/l3_packrun_aggro.json --out build/reports/l3_ab_111.md` *(fails: command not found: dart)*

------
https://chatgpt.com/codex/tasks/task_e_689c23bcd7fc832ab39a052c24c7063c