### PR TITLE
test: cover CLI weights preset conflict

### DIFF
--- a/test/l3_cli_weights_conflict_warning_test.dart
+++ b/test/l3_cli_weights_conflict_warning_test.dart
@@ -18,14 +18,52 @@ void main() {
         '--weightsPreset',
         'aggro',
       ]);
-      // CLI должен не падать…
       expect(res.exitCode, 0, reason: res.stderr.toString());
-      // …и печатать предупреждение в stderr
-      expect(
-        res.stderr.toString(),
-        contains('both --weights and --weightsPreset'),
-      );
-      // и сформировать JSON-репорт (пусть и пустой)
+      expect(res.stderr.toString(), contains('both --weights and --weightsPreset'));
+      expect(File(outPath).existsSync(), isTrue);
+    } finally {
+      tmp.deleteSync(recursive: true);
+    }
+  });
+
+  test('CLI does not warn when only --weights is set', () async {
+    final tmp = Directory.systemTemp.createTempSync('l3_cli_weights_only_');
+    try {
+      final outPath = '${tmp.path}/out.json';
+      final res = await Process.run('dart', [
+        'run',
+        'tool/l3/pack_run_cli.dart',
+        '--dir',
+        tmp.path,
+        '--out',
+        outPath,
+        '--weights',
+        '{"spr_low":0.1}',
+      ]);
+      expect(res.exitCode, 0, reason: res.stderr.toString());
+      expect(res.stderr.toString(), isNot(contains('both --weights and --weightsPreset')));
+      expect(File(outPath).existsSync(), isTrue);
+    } finally {
+      tmp.deleteSync(recursive: true);
+    }
+  });
+
+  test('CLI does not warn when only --weightsPreset is set', () async {
+    final tmp = Directory.systemTemp.createTempSync('l3_cli_preset_only_');
+    try {
+      final outPath = '${tmp.path}/out.json';
+      final res = await Process.run('dart', [
+        'run',
+        'tool/l3/pack_run_cli.dart',
+        '--dir',
+        tmp.path,
+        '--out',
+        outPath,
+        '--weightsPreset',
+        'aggro',
+      ]);
+      expect(res.exitCode, 0, reason: res.stderr.toString());
+      expect(res.stderr.toString(), isNot(contains('both --weights and --weightsPreset')));
       expect(File(outPath).existsSync(), isTrue);
     } finally {
       tmp.deleteSync(recursive: true);


### PR DESCRIPTION
## Summary
- hermetic temp directory for CLI weights conflict warning
- add regression tests for single flag usage

## Testing
- `dart format test/l3_cli_weights_conflict_warning_test.dart` *(fails: command not found)*
- `bash tool/dev/precommit_sanity.sh` *(fails: formatting needed)*
- `dart test test/l3_cli_weights_conflict_warning_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c2c8bc2e0832ab6f0cd821b5612ce