### PR TITLE
Localize copy toast and restore rootKeys metric

### DIFF
--- a/lib/screens/l3_ab_diff_screen.dart
+++ b/lib/screens/l3_ab_diff_screen.dart
@@ -46,12 +46,13 @@ class _L3AbDiffScreenState extends State<L3AbDiffScreen> {
     final decoded = jsonDecode(content);
     final result = <String, num>{};
     if (decoded is Map) {
+      result['rootKeys'] = decoded.length;
       decoded.forEach((key, value) {
-          if (value is num) {
-            result[key] = value;
-          } else if (value is List) {
-            result['array:$key'] = value.length;
-          }
+        if (value is num) {
+          result[key] = value;
+        } else if (value is List) {
+          result['array:$key'] = value.length;
+        }
       });
     }
     return result;

--- a/lib/screens/l3_report_viewer_screen.dart
+++ b/lib/screens/l3_report_viewer_screen.dart
@@ -50,7 +50,11 @@ class L3ReportViewerScreen extends StatelessWidget {
                 Clipboard.setData(ClipboardData(text: path));
                 ScaffoldMessenger.of(
                   context,
-                ).showSnackBar(const SnackBar(content: Text('Copied')));
+                ).showSnackBar(
+                  SnackBar(
+                    content: Text(loc.copied),
+                  ),
+                );
               } else {
                 showDialog(
                   context: context,


### PR DESCRIPTION
## Summary
- localize "Copied" toast using `loc.copied`
- track `rootKeys` in A/B diff stats

## Testing
- `dart format lib/screens/l3_report_viewer_screen.dart lib/screens/l3_ab_diff_screen.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c791c9440832a83f56c4f19d08b30