### PR TITLE
Make log viewing async and escape CSV fields

### DIFF
--- a/lib/screens/l3_ab_diff_screen.dart
+++ b/lib/screens/l3_ab_diff_screen.dart
@@ -197,6 +197,8 @@ class _L3AbDiffScreenState extends State<L3AbDiffScreen> {
     return rows;
   }
 
+  String _csv(String v) => '"${v.replaceAll('"', '""')}"';
+
   Future<void> _exportCsv() async {
     final statsA = _statsA;
     final statsB = _statsB;
@@ -204,12 +206,13 @@ class _L3AbDiffScreenState extends State<L3AbDiffScreen> {
     final keys = <String>{...statsA.keys, ...statsB.keys}.toList()..sort();
     final buffer = StringBuffer();
     buffer.writeln('metric,a,b,delta');
-    buffer.writeln('args,"${_a?.argsSummary}","${_b?.argsSummary}",');
+    buffer.writeln(
+        '${_csv('args')},${_csv(_a?.argsSummary ?? '-')},${_csv(_b?.argsSummary ?? '-')},');
     for (final k in keys) {
       final a = statsA[k];
       final b = statsB[k];
       final delta = (b ?? 0) - (a ?? 0);
-      buffer.writeln('$k,$a,$b,$delta');
+      buffer.writeln('${_csv(k)},$a,$b,$delta');
     }
     final dir = await Directory.systemTemp.createTemp('l3_ab');
     final file = File('${dir.path}/ab_diff.csv');

--- a/lib/screens/l3_report_viewer_screen.dart
+++ b/lib/screens/l3_report_viewer_screen.dart
@@ -75,10 +75,17 @@ class L3ReportViewerScreen extends StatelessWidget {
             IconButton(
               tooltip: loc.logs,
               icon: const Icon(Icons.article),
-              onPressed: () {
+              onPressed: () async {
                 if (_isDesktop) {
-                  final text = File(logPath!).readAsStringSync();
                   showDialog(
+                    context: context,
+                    barrierDismissible: false,
+                    builder: (_) => const Center(child: CircularProgressIndicator()),
+                  );
+                  final text = await File(logPath!).readAsString();
+                  if (!context.mounted) return;
+                  Navigator.pop(context);
+                  await showDialog(
                     context: context,
                     builder: (_) => AlertDialog(
                       title: Text(loc.viewLogs),

--- a/lib/screens/quickstart_l3_screen.dart
+++ b/lib/screens/quickstart_l3_screen.dart
@@ -152,15 +152,22 @@ class _QuickstartL3ScreenState extends State<QuickstartL3Screen> {
     );
   }
 
-  void _viewLogs() {
+  Future<void> _viewLogs() async {
     final path = _result?.logPath;
     if (path == null) return;
-    _viewLogsFile(path);
+    await _viewLogsFile(path);
   }
 
-  void _viewLogsFile(String path) {
-    final text = File(path).readAsStringSync();
+  Future<void> _viewLogsFile(String path) async {
     showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (_) => const Center(child: CircularProgressIndicator()),
+    );
+    final text = await File(path).readAsString();
+    if (!mounted) return;
+    Navigator.pop(context);
+    await showDialog(
       context: context,
       builder: (_) => AlertDialog(
         title: Text(AppLocalizations.of(context).viewLogs),
@@ -261,7 +268,11 @@ class _QuickstartL3ScreenState extends State<QuickstartL3Screen> {
                 Row(
                   mainAxisAlignment: MainAxisAlignment.end,
                   children: [
-                    TextButton(onPressed: _viewLogs, child: Text(loc.viewLogs)),
+                    TextButton(
+                        onPressed: () async {
+                          await _viewLogs();
+                        },
+                        child: Text(loc.viewLogs)),
                     TextButton(onPressed: _retry, child: Text(loc.retry)),
                   ],
                 ),
@@ -363,7 +374,9 @@ class _QuickstartL3ScreenState extends State<QuickstartL3Screen> {
                                     child: Text(loc.open),
                                   ),
                                   TextButton(
-                                    onPressed: () => _viewLogsFile(e.logPath),
+                                    onPressed: () async {
+                                      await _viewLogsFile(e.logPath);
+                                    },
                                     child: Text(loc.logs),
                                   ),
                                   if (_isDesktop)


### PR DESCRIPTION
## Summary
- async log reading with loading indicator in quickstart and report viewer
- quote CSV metric and args fields for safer export

## Testing
- `dart format lib/screens/quickstart_l3_screen.dart lib/screens/l3_report_viewer_screen.dart lib/screens/l3_ab_diff_screen.dart` *(command failed: dart not found)*
- `flutter analyze` *(command failed: flutter not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c7a763c58832a864b5f551c0585b5