### PR TITLE
Make log-loading dialogs robust and format AB diff numbers

### DIFF
--- a/lib/screens/l3_ab_diff_screen.dart
+++ b/lib/screens/l3_ab_diff_screen.dart
@@ -70,6 +70,13 @@ class _L3AbDiffScreenState extends State<L3AbDiffScreen> {
     });
   }
 
+  String _f(num? v, {bool signed = false}) {
+    if (v == null) return '-';
+    final fmt =
+        NumberFormat(signed ? '+#,##0.####;-#,##0.####;0' : '#,##0.####');
+    return fmt.format(v);
+  }
+
   @override
   Widget build(BuildContext context) {
     final loc = AppLocalizations.of(context);
@@ -189,9 +196,9 @@ class _L3AbDiffScreenState extends State<L3AbDiffScreen> {
                 : k;
         rows.add(DataRow(cells: [
           DataCell(Text(label)),
-          DataCell(Text(a?.toString() ?? '-')),
-          DataCell(Text(b?.toString() ?? '-')),
-          DataCell(Text(delta?.toString() ?? '-')),
+          DataCell(Text(_f(a))),
+          DataCell(Text(_f(b))),
+          DataCell(Text(_f(delta, signed: true))),
         ]));
     }
     return rows;

--- a/lib/screens/l3_report_viewer_screen.dart
+++ b/lib/screens/l3_report_viewer_screen.dart
@@ -77,21 +77,31 @@ class L3ReportViewerScreen extends StatelessWidget {
               icon: const Icon(Icons.article),
               onPressed: () async {
                 if (_isDesktop) {
+                  final navigator = Navigator.of(context);
                   showDialog(
                     context: context,
                     barrierDismissible: false,
                     builder: (_) => const Center(child: CircularProgressIndicator()),
                   );
-                  final text = await File(logPath!).readAsString();
+                  String? text;
+                  Object? error;
+                  try {
+                    text = await File(logPath!).readAsString();
+                  } catch (e) {
+                    error = e;
+                  } finally {
+                    if (navigator.mounted) navigator.pop();
+                  }
                   if (!context.mounted) return;
-                  Navigator.pop(context);
                   await showDialog(
                     context: context,
                     builder: (_) => AlertDialog(
                       title: Text(loc.viewLogs),
-                      content: SingleChildScrollView(
-                        child: SelectableText(text),
-                      ),
+                      content: error == null
+                          ? SingleChildScrollView(
+                              child: SelectableText(text!),
+                            )
+                          : SelectableText(error.toString()),
                       actions: [
                         TextButton(
                           onPressed: () => Navigator.pop(context),

--- a/lib/screens/quickstart_l3_screen.dart
+++ b/lib/screens/quickstart_l3_screen.dart
@@ -159,19 +159,29 @@ class _QuickstartL3ScreenState extends State<QuickstartL3Screen> {
   }
 
   Future<void> _viewLogsFile(String path) async {
+    final navigator = Navigator.of(context);
     showDialog(
       context: context,
       barrierDismissible: false,
       builder: (_) => const Center(child: CircularProgressIndicator()),
     );
-    final text = await File(path).readAsString();
+    String? text;
+    Object? error;
+    try {
+      text = await File(path).readAsString();
+    } catch (e) {
+      error = e;
+    } finally {
+      if (navigator.mounted) navigator.pop();
+    }
     if (!mounted) return;
-    Navigator.pop(context);
     await showDialog(
       context: context,
       builder: (_) => AlertDialog(
         title: Text(AppLocalizations.of(context).viewLogs),
-        content: SingleChildScrollView(child: SelectableText(text)),
+        content: error == null
+            ? SingleChildScrollView(child: SelectableText(text!))
+            : SelectableText(error.toString()),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(context),


### PR DESCRIPTION
## Summary
- Ensure log spinner dialogs are always dismissed and show error messages on failure
- Add numeric formatter for A/B diff table with signed delta and grouping

## Testing
- `dart format lib/screens/quickstart_l3_screen.dart lib/screens/l3_report_viewer_screen.dart lib/screens/l3_ab_diff_screen.dart` *(command not found)*
- `flutter analyze` *(command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689c7d7533b8832a903a14cb906b1ed7