### PR TITLE
feat: guard L3 quickstart run and localize dialogs

### DIFF
--- a/lib/screens/l3_report_viewer_screen.dart
+++ b/lib/screens/l3_report_viewer_screen.dart
@@ -63,7 +63,7 @@ class L3ReportViewerScreen extends StatelessWidget {
                     actions: [
                       TextButton(
                         onPressed: () => Navigator.pop(context),
-                        child: const Text('OK'),
+                        child: Text(loc.ok),
                       ),
                     ],
                   ),
@@ -105,7 +105,7 @@ class L3ReportViewerScreen extends StatelessWidget {
                       actions: [
                         TextButton(
                           onPressed: () => Navigator.pop(context),
-                          child: const Text('OK'),
+                          child: Text(loc.ok),
                         ),
                       ],
                     ),
@@ -118,7 +118,7 @@ class L3ReportViewerScreen extends StatelessWidget {
                       actions: [
                         TextButton(
                           onPressed: () => Navigator.pop(context),
-                          child: const Text('OK'),
+                          child: Text(loc.ok),
                         ),
                       ],
                     ),
@@ -140,7 +140,7 @@ class L3ReportViewerScreen extends StatelessWidget {
                     actions: [
                       TextButton(
                         onPressed: () => Navigator.pop(context),
-                        child: const Text('OK'),
+                        child: Text(loc.ok),
                       ),
                     ],
                   ),

--- a/lib/screens/quickstart_l3_screen.dart
+++ b/lib/screens/quickstart_l3_screen.dart
@@ -45,7 +45,7 @@ class _QuickstartL3ScreenState extends State<QuickstartL3Screen> {
             actions: [
               TextButton(
                 onPressed: () => Navigator.pop(context),
-                child: const Text('OK'),
+                child: Text(AppLocalizations.of(context).ok),
               ),
             ],
           ),
@@ -185,7 +185,7 @@ class _QuickstartL3ScreenState extends State<QuickstartL3Screen> {
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(context),
-            child: const Text('OK'),
+            child: Text(AppLocalizations.of(context).ok),
           ),
         ],
       ),
@@ -299,6 +299,7 @@ class _QuickstartL3ScreenState extends State<QuickstartL3Screen> {
             TextField(
               controller: _weightsController,
               decoration: InputDecoration(labelText: loc.weightsJson),
+              onChanged: (_) => setState(() {}),
             ),
             const SizedBox(height: 8),
             DropdownButton<String>(
@@ -315,10 +316,13 @@ class _QuickstartL3ScreenState extends State<QuickstartL3Screen> {
             if (_weightsController.text.isNotEmpty && _weightsPreset != null)
               Padding(
                 padding: const EdgeInsets.only(top: 8),
-                child: Text(_inlineWarning ?? ''),
+                child: Text(loc.presetWillBeUsed),
               ),
             const SizedBox(height: 16),
-            ElevatedButton(onPressed: _run, child: Text(loc.run)),
+            ElevatedButton(
+              onPressed: _running ? null : _run,
+              child: Text(loc.run),
+            ),
             if (_lastReportPath != null)
               TextButton(onPressed: _openReport, child: Text(loc.openReport)),
             const SizedBox(height: 16),


### PR DESCRIPTION
## Summary
- disable Quickstart run button while a job is executing
- show preset/weights conflict hint pre-run
- localize lingering OK buttons in Quickstart and L3 report viewer dialogs

## Testing
- `dart format lib/screens/quickstart_l3_screen.dart lib/screens/l3_report_viewer_screen.dart` *(fails: dart not installed)*
- `apt-get install -y dart` *(fails: unable to locate package)*
- `apt-get install -y flutter` *(fails: unable to locate package)*
- `flutter analyze` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_689c7f14e17c832ab82e7b70c5053765