### PR TITLE
feat: improve L3 quickstart JSON UX

### DIFF
--- a/lib/utils/shared_prefs_keys.dart
+++ b/lib/utils/shared_prefs_keys.dart
@@ -57,4 +57,5 @@ class SharedPrefsKeys {
   static const String lastL3ReportPath = 'last_l3_report_path';
   static const String l3RunHistory = 'l3_run_history';
   static const String l3WeightsPreset = 'l3_weights_preset';
+  static const String l3WeightsJson = 'l3_weights_json';
 }


### PR DESCRIPTION
## Summary
- persist last L3 weights JSON in SharedPreferences
- add clear button and multiline input for weights JSON
- allow copying report paths from history

## Testing
- `dart format lib/screens/quickstart_l3_screen.dart lib/utils/shared_prefs_keys.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c84459e34832abb6c527e16cec013