### PR TITLE
Unfocus run input and clear stacked snackbars

### DIFF
--- a/lib/screens/l3_ab_diff_screen.dart
+++ b/lib/screens/l3_ab_diff_screen.dart
@@ -234,8 +234,10 @@ class _L3AbDiffScreenState extends State<L3AbDiffScreen> {
             TextButton(
               onPressed: () {
                 Clipboard.setData(ClipboardData(text: file.path));
-                messenger
-                    .showSnackBar(SnackBar(content: Text(loc.copied)));
+                messenger.clearSnackBars();
+                messenger.showSnackBar(
+                  SnackBar(content: Text(loc.copied)),
+                );
               },
               child: Text(loc.copyPath),
             ),

--- a/lib/screens/l3_report_viewer_screen.dart
+++ b/lib/screens/l3_report_viewer_screen.dart
@@ -48,9 +48,9 @@ class L3ReportViewerScreen extends StatelessWidget {
             onPressed: () {
               if (_isDesktop) {
                 Clipboard.setData(ClipboardData(text: path));
-                ScaffoldMessenger.of(
-                  context,
-                ).showSnackBar(
+                final messenger = ScaffoldMessenger.of(context);
+                messenger.clearSnackBars();
+                messenger.showSnackBar(
                   SnackBar(
                     content: Text(loc.copied),
                   ),

--- a/lib/screens/quickstart_l3_screen.dart
+++ b/lib/screens/quickstart_l3_screen.dart
@@ -105,6 +105,8 @@ class _QuickstartL3ScreenState extends State<QuickstartL3Screen> {
 
   Future<void> _run() async {
     await _formatWeightsJson();
+    FocusScope.of(context).unfocus();
+    final messenger = ScaffoldMessenger.of(context);
     setState(() {
       _running = true;
       _error = null;
@@ -119,7 +121,7 @@ class _QuickstartL3ScreenState extends State<QuickstartL3Screen> {
         if (decoded is! Map) throw const FormatException();
       } catch (_) {
         if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
+          messenger.showSnackBar(
             SnackBar(content: Text(AppLocalizations.of(context).invalidJson)),
           );
         }
@@ -169,8 +171,14 @@ class _QuickstartL3ScreenState extends State<QuickstartL3Screen> {
       }
     });
     if (collectedWarnings.isNotEmpty && mounted) {
+      messenger.clearSnackBars();
       for (final w in collectedWarnings) {
-        ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(w)));
+        messenger.showSnackBar(
+          SnackBar(
+            content: Text(w),
+            duration: const Duration(seconds: 2),
+          ),
+        );
       }
     }
   }
@@ -502,8 +510,10 @@ class _QuickstartL3ScreenState extends State<QuickstartL3Screen> {
                                     onPressed: () {
                                       Clipboard.setData(
                                           ClipboardData(text: e.outPath));
-                                      ScaffoldMessenger.of(context)
-                                          .showSnackBar(
+                                      final messenger =
+                                          ScaffoldMessenger.of(context);
+                                      messenger.clearSnackBars();
+                                      messenger.showSnackBar(
                                         SnackBar(
                                           content: Text(loc.copied),
                                         ),


### PR DESCRIPTION
## Summary
- Dismiss keyboard before running L3 to avoid focus issues
- Clear existing snackbars before showing warnings and copy-path toasts
- Ensure CSV export copy action replaces previous snackbars

## Testing
- `dart format lib/screens/quickstart_l3_screen.dart lib/screens/l3_report_viewer_screen.dart lib/screens/l3_ab_diff_screen.dart` *(command not found)*
- `flutter analyze` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c89ca7bbc832a8585af624c96a5d7