### PR TITLE
refactor: add toast helper and clear snackbars

### DIFF
--- a/lib/screens/l3_ab_diff_screen.dart
+++ b/lib/screens/l3_ab_diff_screen.dart
@@ -10,6 +10,12 @@ import '../l10n/app_localizations.dart';
 import '../models/l3_run_history_entry.dart';
 import '../services/l3_cli_runner.dart';
 
+void _toast(BuildContext ctx, String msg, {Duration d = const Duration(seconds: 2)}) {
+  final m = ScaffoldMessenger.of(ctx);
+  m.clearSnackBars();
+  m.showSnackBar(SnackBar(content: Text(msg), duration: d));
+}
+
 class L3AbDiffScreen extends StatefulWidget {
   const L3AbDiffScreen({super.key});
 
@@ -226,6 +232,7 @@ class _L3AbDiffScreenState extends State<L3AbDiffScreen> {
     await file.writeAsString(buffer.toString());
     if (!mounted) return;
     final messenger = ScaffoldMessenger.of(context);
+    messenger.clearSnackBars();
     messenger.showSnackBar(
       SnackBar(
         content: Row(
@@ -234,10 +241,7 @@ class _L3AbDiffScreenState extends State<L3AbDiffScreen> {
             TextButton(
               onPressed: () {
                 Clipboard.setData(ClipboardData(text: file.path));
-                messenger.clearSnackBars();
-                messenger.showSnackBar(
-                  SnackBar(content: Text(loc.copied)),
-                );
+                _toast(context, loc.copied);
               },
               child: Text(loc.copyPath),
             ),

--- a/lib/screens/l3_report_viewer_screen.dart
+++ b/lib/screens/l3_report_viewer_screen.dart
@@ -9,6 +9,12 @@ import '../l10n/app_localizations.dart';
 import '../services/l3_cli_runner.dart';
 import 'l3_ab_diff_screen.dart';
 
+void _toast(BuildContext ctx, String msg, {Duration d = const Duration(seconds: 2)}) {
+  final m = ScaffoldMessenger.of(ctx);
+  m.clearSnackBars();
+  m.showSnackBar(SnackBar(content: Text(msg), duration: d));
+}
+
 class L3ReportViewerScreen extends StatelessWidget {
   final String path;
   final String? logPath;
@@ -48,13 +54,7 @@ class L3ReportViewerScreen extends StatelessWidget {
             onPressed: () {
               if (_isDesktop) {
                 Clipboard.setData(ClipboardData(text: path));
-                final messenger = ScaffoldMessenger.of(context);
-                messenger.clearSnackBars();
-                messenger.showSnackBar(
-                  SnackBar(
-                    content: Text(loc.copied),
-                  ),
-                );
+                _toast(context, loc.copied);
               } else {
                 showDialog(
                   context: context,

--- a/lib/screens/quickstart_l3_screen.dart
+++ b/lib/screens/quickstart_l3_screen.dart
@@ -12,6 +12,12 @@ import '../utils/shared_prefs_keys.dart';
 import '../models/l3_run_history_entry.dart';
 import 'l3_report_viewer_screen.dart';
 
+void _toast(BuildContext ctx, String msg, {Duration d = const Duration(seconds: 2)}) {
+  final m = ScaffoldMessenger.of(ctx);
+  m.clearSnackBars();
+  m.showSnackBar(SnackBar(content: Text(msg), duration: d));
+}
+
 class QuickstartL3Screen extends StatefulWidget {
   const QuickstartL3Screen({super.key});
 
@@ -121,9 +127,7 @@ class _QuickstartL3ScreenState extends State<QuickstartL3Screen> {
         if (decoded is! Map) throw const FormatException();
       } catch (_) {
         if (mounted) {
-          messenger.showSnackBar(
-            SnackBar(content: Text(AppLocalizations.of(context).invalidJson)),
-          );
+          _toast(context, AppLocalizations.of(context).invalidJson);
         }
         setState(() {
           _running = false;
@@ -198,9 +202,7 @@ class _QuickstartL3ScreenState extends State<QuickstartL3Screen> {
     if (!exists || (await file.readAsString()).trim().isEmpty) {
       if (mounted) {
         final loc = AppLocalizations.of(context);
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(SnackBar(content: Text(loc.reportEmpty)));
+        _toast(context, loc.reportEmpty);
       }
       return;
     }
@@ -307,8 +309,7 @@ class _QuickstartL3ScreenState extends State<QuickstartL3Screen> {
         _lastReportPath = null;
       });
       if (mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(SnackBar(content: Text(loc.deleted)));
+        _toast(context, loc.deleted);
       }
     }
   }
@@ -486,14 +487,12 @@ class _QuickstartL3ScreenState extends State<QuickstartL3Screen> {
                                 }
                                 setState(() {});
                                 if (mounted) {
-                                  ScaffoldMessenger.of(context).showSnackBar(
-                                    SnackBar(content: Text(loc.deleted)),
-                                  );
+                                  _toast(context, loc.deleted);
                                 }
                               },
-                            child: ListTile(
-                              title: Text('$ts ${e.argsSummary}'),
-                              trailing: Wrap(
+                              child: ListTile(
+                                title: Text('$ts ${e.argsSummary}'),
+                                trailing: Wrap(
                                 spacing: 4,
                                 children: [
                                   TextButton(
@@ -510,14 +509,7 @@ class _QuickstartL3ScreenState extends State<QuickstartL3Screen> {
                                     onPressed: () {
                                       Clipboard.setData(
                                           ClipboardData(text: e.outPath));
-                                      final messenger =
-                                          ScaffoldMessenger.of(context);
-                                      messenger.clearSnackBars();
-                                      messenger.showSnackBar(
-                                        SnackBar(
-                                          content: Text(loc.copied),
-                                        ),
-                                      );
+                                      _toast(context, loc.copied);
                                     },
                                     child: Text(loc.copyPath),
                                   ),


### PR DESCRIPTION
## Summary
- add toast helper to centralize snackbar logic across L3 screens
- clear existing snackbars before showing CSV export notification

## Testing
- `dart format lib/screens/l3_ab_diff_screen.dart lib/screens/l3_report_viewer_screen.dart lib/screens/quickstart_l3_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c8b13c9e4832a924a133104e962f2