### PR TITLE
refactor: deduplicate toast helper

### DIFF
--- a/lib/screens/l3_ab_diff_screen.dart
+++ b/lib/screens/l3_ab_diff_screen.dart
@@ -9,12 +9,7 @@ import 'package:intl/intl.dart';
 import '../l10n/app_localizations.dart';
 import '../models/l3_run_history_entry.dart';
 import '../services/l3_cli_runner.dart';
-
-void _toast(BuildContext ctx, String msg, {Duration d = const Duration(seconds: 2)}) {
-  final m = ScaffoldMessenger.of(ctx);
-  m.clearSnackBars();
-  m.showSnackBar(SnackBar(content: Text(msg), duration: d));
-}
+import '../utils/toast.dart';
 
 class L3AbDiffScreen extends StatefulWidget {
   const L3AbDiffScreen({super.key});
@@ -241,7 +236,7 @@ class _L3AbDiffScreenState extends State<L3AbDiffScreen> {
             TextButton(
               onPressed: () {
                 Clipboard.setData(ClipboardData(text: file.path));
-                _toast(context, loc.copied);
+                showToast(context, loc.copied);
               },
               child: Text(loc.copyPath),
             ),

--- a/lib/screens/l3_report_viewer_screen.dart
+++ b/lib/screens/l3_report_viewer_screen.dart
@@ -7,13 +7,8 @@ import 'package:flutter/services.dart';
 
 import '../l10n/app_localizations.dart';
 import '../services/l3_cli_runner.dart';
+import '../utils/toast.dart';
 import 'l3_ab_diff_screen.dart';
-
-void _toast(BuildContext ctx, String msg, {Duration d = const Duration(seconds: 2)}) {
-  final m = ScaffoldMessenger.of(ctx);
-  m.clearSnackBars();
-  m.showSnackBar(SnackBar(content: Text(msg), duration: d));
-}
 
 class L3ReportViewerScreen extends StatelessWidget {
   final String path;
@@ -54,7 +49,7 @@ class L3ReportViewerScreen extends StatelessWidget {
             onPressed: () {
               if (_isDesktop) {
                 Clipboard.setData(ClipboardData(text: path));
-                _toast(context, loc.copied);
+                showToast(context, loc.copied);
               } else {
                 showDialog(
                   context: context,

--- a/lib/screens/quickstart_l3_screen.dart
+++ b/lib/screens/quickstart_l3_screen.dart
@@ -10,13 +10,8 @@ import '../l10n/app_localizations.dart';
 import '../services/l3_cli_runner.dart';
 import '../utils/shared_prefs_keys.dart';
 import '../models/l3_run_history_entry.dart';
+import '../utils/toast.dart';
 import 'l3_report_viewer_screen.dart';
-
-void _toast(BuildContext ctx, String msg, {Duration d = const Duration(seconds: 2)}) {
-  final m = ScaffoldMessenger.of(ctx);
-  m.clearSnackBars();
-  m.showSnackBar(SnackBar(content: Text(msg), duration: d));
-}
 
 class QuickstartL3Screen extends StatefulWidget {
   const QuickstartL3Screen({super.key});
@@ -127,7 +122,7 @@ class _QuickstartL3ScreenState extends State<QuickstartL3Screen> {
         if (decoded is! Map) throw const FormatException();
       } catch (_) {
         if (mounted) {
-          _toast(context, AppLocalizations.of(context).invalidJson);
+          showToast(context, AppLocalizations.of(context).invalidJson);
         }
         setState(() {
           _running = false;
@@ -202,7 +197,7 @@ class _QuickstartL3ScreenState extends State<QuickstartL3Screen> {
     if (!exists || (await file.readAsString()).trim().isEmpty) {
       if (mounted) {
         final loc = AppLocalizations.of(context);
-        _toast(context, loc.reportEmpty);
+        showToast(context, loc.reportEmpty);
       }
       return;
     }
@@ -309,7 +304,7 @@ class _QuickstartL3ScreenState extends State<QuickstartL3Screen> {
         _lastReportPath = null;
       });
       if (mounted) {
-        _toast(context, loc.deleted);
+        showToast(context, loc.deleted);
       }
     }
   }
@@ -487,7 +482,7 @@ class _QuickstartL3ScreenState extends State<QuickstartL3Screen> {
                                 }
                                 setState(() {});
                                 if (mounted) {
-                                  _toast(context, loc.deleted);
+                                  showToast(context, loc.deleted);
                                 }
                               },
                               child: ListTile(
@@ -509,7 +504,7 @@ class _QuickstartL3ScreenState extends State<QuickstartL3Screen> {
                                     onPressed: () {
                                       Clipboard.setData(
                                           ClipboardData(text: e.outPath));
-                                      _toast(context, loc.copied);
+                                      showToast(context, loc.copied);
                                     },
                                     child: Text(loc.copyPath),
                                   ),

--- a/lib/utils/toast.dart
+++ b/lib/utils/toast.dart
@@ -1,0 +1,7 @@
+import 'package:flutter/material.dart';
+
+void showToast(BuildContext context, String msg, {Duration duration = const Duration(seconds: 2)}) {
+  final m = ScaffoldMessenger.of(context);
+  m.clearSnackBars();
+  m.showSnackBar(SnackBar(content: Text(msg), duration: duration));
+}


### PR DESCRIPTION
## Summary
- factor out repeated `_toast` into shared `showToast` helper
- use `showToast` across L3 screens for consistent snackbars

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cb9606eb4832a94f7f0e9b5b86ee1