### PR TITLE
feat: add mobile CSV preview and haptics

### DIFF
--- a/lib/screens/l3_report_viewer_screen.dart
+++ b/lib/screens/l3_report_viewer_screen.dart
@@ -79,6 +79,7 @@ class L3ReportViewerScreen extends StatelessWidget {
           .create(recursive: true);
       final out = File('${dir.path}/report.csv');
       await out.writeAsString(buffer.toString());
+      HapticFeedback.selectionClick();
       if (!context.mounted) return;
       final messenger = ScaffoldMessenger.of(context);
       messenger.clearSnackBars();
@@ -90,10 +91,35 @@ class L3ReportViewerScreen extends StatelessWidget {
               TextButton(
                 onPressed: () {
                   Clipboard.setData(ClipboardData(text: out.path));
+                  HapticFeedback.selectionClick();
+                  messenger.clearSnackBars();
                   showToast(context, loc.copied);
                 },
                 child: Text(loc.copyPath),
               ),
+              if (!_isDesktop)
+                TextButton(
+                  onPressed: () async {
+                    final text = await out.readAsString();
+                    if (!context.mounted) return;
+                    messenger.clearSnackBars();
+                    await showDialog(
+                      context: context,
+                      builder: (_) => AlertDialog(
+                        content: SingleChildScrollView(
+                          child: SelectableText(text),
+                        ),
+                        actions: [
+                          TextButton(
+                            onPressed: () => Navigator.pop(context),
+                            child: Text(loc.ok),
+                          ),
+                        ],
+                      ),
+                    );
+                  },
+                  child: Text(loc.open),
+                ),
               if (_isDesktop)
                 TextButton(
                   onPressed: () => L3CliRunner.revealInFolder(out.path),

--- a/lib/screens/quickstart_l3_screen.dart
+++ b/lib/screens/quickstart_l3_screen.dart
@@ -504,6 +504,7 @@ class _QuickstartL3ScreenState extends State<QuickstartL3Screen> {
                                     onPressed: () {
                                       Clipboard.setData(
                                           ClipboardData(text: e.outPath));
+                                      HapticFeedback.selectionClick();
                                       showToast(context, loc.copied);
                                     },
                                     child: Text(loc.copyPath),


### PR DESCRIPTION
## Summary
- add haptic tick on CSV export and copy path actions
- add mobile CSV preview dialog directly from export snackbar
- trigger haptic on history row copy path

## Testing
- `flutter format lib/screens/l3_report_viewer_screen.dart lib/screens/quickstart_l3_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cc4de75f4832a85c8afdb01ce89b3