### PR TITLE
refactor: centralize csv writer for report exports

### DIFF
--- a/lib/screens/l3_ab_diff_screen.dart
+++ b/lib/screens/l3_ab_diff_screen.dart
@@ -10,6 +10,7 @@ import '../l10n/app_localizations.dart';
 import '../models/l3_run_history_entry.dart';
 import '../services/l3_cli_runner.dart';
 import '../utils/toast.dart';
+import '../utils/csv_io.dart';
 
 class _ExportIntent extends Intent {
   const _ExportIntent();
@@ -257,11 +258,7 @@ class _L3AbDiffScreenState extends State<L3AbDiffScreen> {
     }
     final dir = await Directory.systemTemp.createTemp('l3_ab');
     final file = File('${dir.path}/ab_diff.csv');
-    var csv = buffer.toString();
-    if (Platform.isWindows) {
-      csv = '\uFEFF' + csv.replaceAll('\n', '\r\n');
-    }
-    await file.writeAsString(csv);
+    await writeCsv(file, buffer);
     if (!_isDesktop) HapticFeedback.selectionClick();
     if (!mounted) return;
     final messenger = ScaffoldMessenger.of(context);

--- a/lib/screens/l3_report_viewer_screen.dart
+++ b/lib/screens/l3_report_viewer_screen.dart
@@ -8,6 +8,7 @@ import 'package:flutter/services.dart';
 import '../l10n/app_localizations.dart';
 import '../services/l3_cli_runner.dart';
 import '../utils/toast.dart';
+import '../utils/csv_io.dart';
 import 'l3_ab_diff_screen.dart';
 
 class _ExportIntent extends Intent {
@@ -86,11 +87,7 @@ class L3ReportViewerScreen extends StatelessWidget {
         '${Directory.systemTemp.path}/l3_report_${DateTime.now().millisecondsSinceEpoch}',
       ).create(recursive: true);
       final out = File('${dir.path}/report.csv');
-      var csv = buffer.toString();
-      if (Platform.isWindows) {
-        csv = '\uFEFF' + csv.replaceAll('\n', '\r\n');
-      }
-      await out.writeAsString(csv);
+      await writeCsv(out, buffer);
       if (!_isDesktop) HapticFeedback.selectionClick();
       if (!context.mounted) return;
       final messenger = ScaffoldMessenger.of(context);

--- a/lib/utils/csv_io.dart
+++ b/lib/utils/csv_io.dart
@@ -1,0 +1,9 @@
+import 'dart:io';
+
+Future<void> writeCsv(File file, StringBuffer buffer) async {
+  var csv = buffer.toString();
+  if (Platform.isWindows) {
+    csv = '\uFEFF' + csv.replaceAll('\n', '\r\n');
+  }
+  await file.writeAsString(csv);
+}


### PR DESCRIPTION
## Summary
- add `writeCsv` helper to handle BOM/CRLF for CSV files
- reuse helper in L3 report viewer and L3 A/B diff exports

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cd0918448832aa9b35b1115855704