### PR TITLE
feat: add desktop reveal shortcuts

### DIFF
--- a/lib/screens/l3_report_viewer_screen.dart
+++ b/lib/screens/l3_report_viewer_screen.dart
@@ -24,6 +24,10 @@ class _OpenLogsIntent extends Intent {
   const _OpenLogsIntent();
 }
 
+class _RevealIntent extends Intent {
+  const _RevealIntent();
+}
+
 class L3ReportViewerScreen extends StatelessWidget {
   final String path;
   final String? logPath;
@@ -182,6 +186,12 @@ class L3ReportViewerScreen extends StatelessWidget {
             const _CopyPathIntent(),
         const SingleActivator(LogicalKeyboardKey.keyC, meta: true):
             const _CopyPathIntent(),
+        const SingleActivator(LogicalKeyboardKey.keyR,
+                control: true, shift: true):
+            const _RevealIntent(),
+        const SingleActivator(LogicalKeyboardKey.keyR,
+                meta: true, shift: true):
+            const _RevealIntent(),
         if (logPath != null)
           const SingleActivator(LogicalKeyboardKey.keyL, control: true):
               const _OpenLogsIntent(),
@@ -240,6 +250,13 @@ class L3ReportViewerScreen extends StatelessWidget {
                   ],
                 ),
               );
+              return null;
+            },
+          ),
+          _RevealIntent: CallbackAction<_RevealIntent>(
+            onInvoke: (_) {
+              if (!_isDesktop) return null;
+              L3CliRunner.revealInFolder(path);
               return null;
             },
           ),

--- a/lib/screens/quickstart_l3_screen.dart
+++ b/lib/screens/quickstart_l3_screen.dart
@@ -44,6 +44,10 @@ class _OpenLastLogsIntent extends Intent {
   const _OpenLastLogsIntent();
 }
 
+class _RevealLastIntent extends Intent {
+  const _RevealLastIntent();
+}
+
 class _QuickstartL3ScreenState extends State<QuickstartL3Screen> {
   final _weightsController = TextEditingController();
   String? _weightsPreset;
@@ -792,6 +796,13 @@ class _QuickstartL3ScreenState extends State<QuickstartL3Screen> {
             const _OpenLastLogsIntent(),
         const SingleActivator(LogicalKeyboardKey.keyL, meta: true):
             const _OpenLastLogsIntent(),
+        // Reveal last report in folder
+        const SingleActivator(LogicalKeyboardKey.keyR,
+                control: true, shift: true):
+            const _RevealLastIntent(),
+        const SingleActivator(LogicalKeyboardKey.keyR,
+                meta: true, shift: true):
+            const _RevealLastIntent(),
       },
       child: Actions(
         actions: {
@@ -829,6 +840,13 @@ class _QuickstartL3ScreenState extends State<QuickstartL3Screen> {
             onInvoke: (_) {
               if (!(_isDesktop && _lastReportPath != null)) return null;
               _openLastLogs();
+              return null;
+            },
+          ),
+          _RevealLastIntent: CallbackAction<_RevealLastIntent>(
+            onInvoke: (_) {
+              if (!(_isDesktop && _lastReportPath != null)) return null;
+              L3CliRunner.revealInFolder(_lastReportPath!);
               return null;
             },
           ),


### PR DESCRIPTION
## Summary
- add desktop reveal shortcut to report viewer screen
- support revealing last report from quickstart screen

## Testing
- `flutter format lib/screens/l3_report_viewer_screen.dart lib/screens/quickstart_l3_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ce05dfde0832a816fd9447191ff12