### PR TITLE
Clean up stale temp directories before CSV exports

### DIFF
--- a/lib/screens/l3_ab_diff_screen.dart
+++ b/lib/screens/l3_ab_diff_screen.dart
@@ -11,6 +11,7 @@ import '../models/l3_run_history_entry.dart';
 import '../services/l3_cli_runner.dart';
 import '../utils/toast.dart';
 import '../utils/csv_io.dart';
+import '../utils/temp_cleanup.dart';
 
 String buildAbCsv(Map<String, dynamic> payload) {
   final Map<String, num> a = (payload['a'] as Map).cast<String, num>();
@@ -276,6 +277,7 @@ class _L3AbDiffScreenState extends State<L3AbDiffScreen> {
     };
     final csv = await compute(buildAbCsv, payload);
     if (navigator.mounted) navigator.pop();
+    await cleanupOldTempDirs(prefix: 'l3_ab');
     final dir = await Directory.systemTemp.createTemp('l3_ab');
     final file = File('${dir.path}/ab_diff.csv');
     await writeCsv(file, StringBuffer()..write(csv));

--- a/lib/screens/l3_report_viewer_screen.dart
+++ b/lib/screens/l3_report_viewer_screen.dart
@@ -10,6 +10,7 @@ import '../services/l3_cli_runner.dart';
 import '../utils/toast.dart';
 import '../utils/csv_io.dart';
 import '../utils/report_csv.dart';
+import '../utils/temp_cleanup.dart';
 import 'l3_ab_diff_screen.dart';
 
 class _ExportIntent extends Intent {
@@ -79,6 +80,7 @@ class L3ReportViewerScreen extends StatelessWidget {
         showToast(context, loc.invalidJson);
         return;
       }
+      await cleanupOldTempDirs(prefix: 'l3_report_');
       final dir = await Directory(
         '${Directory.systemTemp.path}/l3_report_${DateTime.now().millisecondsSinceEpoch}',
       ).create(recursive: true);

--- a/lib/screens/quickstart_l3_screen.dart
+++ b/lib/screens/quickstart_l3_screen.dart
@@ -15,6 +15,7 @@ import '../utils/toast.dart';
 import '../utils/csv_io.dart';
 import '../utils/history_csv.dart';
 import '../utils/report_csv.dart';
+import '../utils/temp_cleanup.dart';
 import 'l3_report_viewer_screen.dart';
 
 class QuickstartL3Screen extends StatefulWidget {
@@ -289,6 +290,7 @@ class _QuickstartL3ScreenState extends State<QuickstartL3Screen> {
       showToast(context, loc.invalidJson);
       return;
     }
+    await cleanupOldTempDirs(prefix: 'l3_report_');
     final dir = await Directory(
       '${Directory.systemTemp.path}/l3_report_${DateTime.now().millisecondsSinceEpoch}',
     ).create(recursive: true);
@@ -368,6 +370,7 @@ class _QuickstartL3ScreenState extends State<QuickstartL3Screen> {
         .toList();
     final csv = await compute(buildHistoryCsv, payload);
     if (navigator.mounted) navigator.pop();
+    await cleanupOldTempDirs(prefix: 'l3_history_');
     final dir = await Directory(
       '${Directory.systemTemp.path}/l3_history_${DateTime.now().millisecondsSinceEpoch}',
     ).create(recursive: true);

--- a/lib/utils/temp_cleanup.dart
+++ b/lib/utils/temp_cleanup.dart
@@ -1,0 +1,31 @@
+import 'dart:io';
+
+/// Deletes temp directories under [Directory.systemTemp] whose names start
+/// with [prefix] and whose last-modified time is older than [maxAge].
+Future<void> cleanupOldTempDirs({
+  required String prefix,
+  Duration maxAge = const Duration(days: 3),
+}) async {
+  final tmp = Directory.systemTemp;
+  final now = DateTime.now();
+  try {
+    await for (final ent in tmp.list(followLinks: false)) {
+      if (ent is! Directory) continue;
+      final base = ent.uri.pathSegments.isNotEmpty
+          ? ent.uri.pathSegments.last
+          : ent.path.split(Platform.pathSeparator).last;
+      if (!base.startsWith(prefix)) continue;
+      DateTime? mtime;
+      try {
+        final stat = await ent.stat();
+        mtime = stat.modified;
+      } catch (_) {}
+      if (mtime != null && now.difference(mtime) > maxAge) {
+        try {
+          await ent.delete(recursive: true);
+        } catch (_) {}
+      }
+    }
+  } catch (_) {}
+}
+


### PR DESCRIPTION
## Summary
- add temp dir cleanup helper
- purge outdated temp directories before L3 report, A/B diff, and quickstart CSV exports

## Testing
- `dart format lib/utils/temp_cleanup.dart lib/screens/l3_report_viewer_screen.dart lib/screens/l3_ab_diff_screen.dart lib/screens/quickstart_l3_screen.dart` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*
- `snap install flutter --classic` *(fails: cannot communicate with server)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ce3b7f000832ab2753f730cb8a8f8