### PR TITLE
Add CSV builder and temp cleanup tests

### DIFF
--- a/lib/utils/temp_cleanup.dart
+++ b/lib/utils/temp_cleanup.dart
@@ -5,9 +5,10 @@ import 'dart:io';
 Future<void> cleanupOldTempDirs({
   required String prefix,
   Duration maxAge = const Duration(days: 3),
+  DateTime? now,
 }) async {
   final tmp = Directory.systemTemp;
-  final now = DateTime.now();
+  final clock = now ?? DateTime.now();
   try {
     await for (final ent in tmp.list(followLinks: false)) {
       if (ent is! Directory) continue;
@@ -20,7 +21,7 @@ Future<void> cleanupOldTempDirs({
         final stat = await ent.stat();
         mtime = stat.modified;
       } catch (_) {}
-      if (mtime != null && now.difference(mtime) > maxAge) {
+      if (mtime != null && clock.difference(mtime) > maxAge) {
         try {
           await ent.delete(recursive: true);
         } catch (_) {}
@@ -28,4 +29,3 @@ Future<void> cleanupOldTempDirs({
     }
   } catch (_) {}
 }
-

--- a/test/history_csv_test.dart
+++ b/test/history_csv_test.dart
@@ -1,0 +1,22 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/utils/history_csv.dart';
+
+void main() {
+  test('buildHistoryCsv formats rows correctly', () {
+    final rows = [
+      {'ts': 't1', 'args': '--flag', 'out': '/tmp/out1', 'log': '/tmp/log1'},
+      {
+        'ts': 't2',
+        'args': '"quoted" arg',
+        'out': '/tmp/out2',
+        'log': '/tmp/log2',
+      },
+    ];
+    final csv = buildHistoryCsv(rows);
+    final lines = csv.trim().split('\n');
+    expect(lines.first, 'timestamp,args,outPath,logPath');
+    expect(lines[1], '"t1","--flag","/tmp/out1","/tmp/log1"');
+    expect(lines[2], '"t2","""quoted"" arg","/tmp/out2","/tmp/log2"');
+    expect(lines.length, 3);
+  });
+}

--- a/test/report_csv_test.dart
+++ b/test/report_csv_test.dart
@@ -1,0 +1,24 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/utils/report_csv.dart';
+
+void main() {
+  group('buildReportCsv', () {
+    test('produces expected metrics', () {
+      final json = '{"b":2,"a":[1,2,3],"c":"ignore"}';
+      final csv = buildReportCsv(json);
+      expect(csv, isNotNull);
+      final lines = csv!.trim().split('\n');
+      expect(lines.first, 'metric,value');
+      expect(lines[1], '"rootKeys",3');
+      expect(lines[2], '"array:a",3');
+      expect(lines[3], '"b",2');
+      expect(lines.length, 4);
+    });
+
+    test('invalid or empty json returns null', () {
+      expect(buildReportCsv(''), isNull);
+      expect(buildReportCsv('not json'), isNull);
+      expect(buildReportCsv('[]'), isNull);
+    });
+  });
+}

--- a/test/temp_cleanup_test.dart
+++ b/test/temp_cleanup_test.dart
@@ -1,0 +1,22 @@
+import 'dart:io';
+import 'package:test/test.dart';
+import 'package:poker_analyzer/utils/temp_cleanup.dart';
+
+void main() {
+  test('cleanupOldTempDirs removes only old directories', () async {
+    final now = DateTime(2023, 1, 10);
+    final oldDir = await Directory.systemTemp.createTemp('l3_report_');
+    final recentDir = await Directory.systemTemp.createTemp('l3_history_');
+    await oldDir.setLastModified(now.subtract(const Duration(days: 4)));
+    await recentDir.setLastModified(now);
+
+    await cleanupOldTempDirs(prefix: 'l3_report_', now: now);
+    expect(await oldDir.exists(), isFalse);
+    expect(await recentDir.exists(), isTrue);
+
+    await cleanupOldTempDirs(prefix: 'l3_history_', now: now);
+    expect(await recentDir.exists(), isTrue);
+
+    await recentDir.delete(recursive: true);
+  });
+}


### PR DESCRIPTION
## Summary
- test CSV report builder for headers, root key count, numeric and array metrics
- test history CSV builder quoting and ordering
- add `now` parameter for deterministic temp cleanup and cover old dir deletion

## Testing
- `dart test test/report_csv_test.dart test/history_csv_test.dart test/temp_cleanup_test.dart` *(fails: flutter_test from sdk which doesn't exist)*


------
https://chatgpt.com/codex/tasks/task_e_689cec154c90832ab503d86c4b0f38dc