### PR TITLE
Refactor csv writer for platform injection and add tests

### DIFF
--- a/lib/utils/csv_io.dart
+++ b/lib/utils/csv_io.dart
@@ -1,8 +1,9 @@
 import 'dart:io';
 
-Future<void> writeCsv(File file, StringBuffer buffer) async {
+Future<void> writeCsv(File file, StringBuffer buffer, {bool? isWindows}) async {
   var csv = buffer.toString();
-  if (Platform.isWindows) {
+  final win = isWindows ?? Platform.isWindows;
+  if (win) {
     csv = '\uFEFF' + csv.replaceAll('\n', '\r\n');
   }
   await file.writeAsString(csv);

--- a/test/csv_io_test.dart
+++ b/test/csv_io_test.dart
@@ -1,0 +1,41 @@
+import 'dart:io';
+
+import 'package:poker_analyzer/utils/csv_io.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('writeCsv', () {
+    test('writes BOM and CRLF on Windows', () async {
+      final dir = await Directory.systemTemp.createTemp('csv_io_test_');
+      final file = File('${dir.path}/out.csv');
+      final buffer = StringBuffer()
+        ..writeln('a,b')
+        ..write('c,d');
+
+      await writeCsv(file, buffer, isWindows: true);
+      final contents = await file.readAsString();
+
+      expect(contents.startsWith('\uFEFF'), isTrue);
+      expect(contents, '\uFEFFa,b\r\nc,d');
+
+      await dir.delete(recursive: true);
+    });
+
+    test('writes LF without BOM on non-Windows', () async {
+      final dir = await Directory.systemTemp.createTemp('csv_io_test_');
+      final file = File('${dir.path}/out.csv');
+      final buffer = StringBuffer()
+        ..writeln('a,b')
+        ..write('c,d');
+
+      await writeCsv(file, buffer, isWindows: false);
+      final contents = await file.readAsString();
+
+      expect(contents.startsWith('\uFEFF'), isFalse);
+      expect(contents, 'a,b\nc,d');
+
+      await dir.delete(recursive: true);
+    });
+  });
+}
+


### PR DESCRIPTION
## Summary
- allow csv writer to inject target platform for testing
- add tests verifying BOM and newline handling on different platforms

## Testing
- `dart format lib/utils/csv_io.dart test/csv_io_test.dart` *(fails: command not found)*
- `dart test test/csv_io_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cefedce2c832abc23dea1fe4d8270