### PR TITLE
Harden targetMix parsing and flop classifier

### DIFF
--- a/lib/services/autogen_stats.dart
+++ b/lib/services/autogen_stats.dart
@@ -6,10 +6,7 @@ class AutogenStats {
   final Map<String, int> textures;
   final int total;
 
-  AutogenStats({
-    required this.textures,
-    required this.total,
-  });
+  AutogenStats({required this.textures, required this.total});
 }
 
 AutogenStats? buildAutogenStats(String reportJson) {
@@ -25,17 +22,8 @@ AutogenStats? buildAutogenStats(String reportJson) {
     for (final spot in spots) {
       final board = (spot is Map<String, dynamic>) ? spot['board'] : null;
 
-      List<String>? cards;
-      if (board is String) {
-        cards = <String>[];
-        for (var i = 0; i + 1 < board.length && cards.length < 3; i += 2) {
-          cards.add(board.substring(i, i + 2));
-        }
-      } else if (board is List) {
-        cards = board.take(3).cast<String>().toList();
-      }
-
-      if (cards == null || cards.length < 3) continue;
+      final cards = parseBoard(board).take(3).toList();
+      if (cards.length < 3) continue;
 
       final texSet = classifyFlop(cards);
       for (final tex in texSet) {
@@ -50,4 +38,3 @@ AutogenStats? buildAutogenStats(String reportJson) {
     return null;
   }
 }
-

--- a/test/autogen_stats_test.dart
+++ b/test/autogen_stats_test.dart
@@ -1,0 +1,24 @@
+import 'dart:convert';
+
+import 'package:test/test.dart';
+import 'package:poker_analyzer/services/autogen_stats.dart';
+
+void main() {
+  test('buildAutogenStats tallies textures', () {
+    final report = json.encode({
+      'spots': [
+        {'board': 'AhKd2c'},
+        {
+          'board': ['Td', '9d', '8d'],
+        },
+      ],
+    });
+    final stats = buildAutogenStats(report);
+    expect(stats, isNotNull);
+    expect(stats!.total, 2);
+    expect(stats.textures['aceHigh'], 1);
+    expect(stats.textures['rainbow'], 1);
+    expect(stats.textures['broadwayHeavy'], 1);
+    expect(stats.textures['monotone'], 1);
+  });
+}

--- a/test/board_textures_test.dart
+++ b/test/board_textures_test.dart
@@ -1,0 +1,34 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/utils/board_textures.dart';
+
+void main() {
+  test('classifyFlop recognizes rainbow, aceHigh, broadwayHeavy', () {
+    final res = classifyFlop(['Ah', 'Kd', '2c']);
+    expect(res.contains(BoardTexture.rainbow), isTrue);
+    expect(res.contains(BoardTexture.aceHigh), isTrue);
+    expect(res.contains(BoardTexture.broadwayHeavy), isTrue);
+  });
+
+  test(
+    'classifyFlop handles twoTone, paired, broadwayHeavy with mixed ranks',
+    () {
+      final res = classifyFlop(['10h', 'Td', '2d']);
+      expect(res.contains(BoardTexture.twoTone), isTrue);
+      expect(res.contains(BoardTexture.paired), isTrue);
+      expect(res.contains(BoardTexture.broadwayHeavy), isTrue);
+    },
+  );
+
+  test('classifyFlop detects monotone and lowConnected', () {
+    final res = classifyFlop(['4c', '5c', '6c']);
+    expect(res.contains(BoardTexture.monotone), isTrue);
+    expect(res.contains(BoardTexture.lowConnected), isTrue);
+  });
+
+  test('parseBoard handles string boards with or without spaces', () {
+    final board1 = parseBoard('AhKd2c');
+    final board2 = parseBoard('Ah Kd 2c');
+    expect(board1, ['Ah', 'Kd', '2c']);
+    expect(board2, ['Ah', 'Kd', '2c']);
+  });
+}

--- a/test/l3_cli_runner_weights_parse_test.dart
+++ b/test/l3_cli_runner_weights_parse_test.dart
@@ -1,0 +1,21 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+import 'package:poker_analyzer/services/l3_cli_runner.dart';
+
+void main() {
+  test('extractTargetMix parses inline json', () {
+    final mix = extractTargetMix('{"targetMix":{"rainbow":0.2}}');
+    expect(mix, isNotNull);
+    expect(mix!['rainbow'], 0.2);
+  });
+
+  test('extractTargetMix parses file path', () {
+    final file = File('${Directory.systemTemp.path}/weights.json');
+    file.writeAsStringSync('{"targetMix":{"monotone":0.3}}');
+    final mix = extractTargetMix(file.path);
+    expect(mix, isNotNull);
+    expect(mix!['monotone'], 0.3);
+    file.deleteSync();
+  });
+}


### PR DESCRIPTION
## Summary
- Allow `L3CliRunner` to load `targetMix` from inline JSON or a file path
- Make flop card parsing rank/suit safe and accept flexible board strings
- Build autogen stats using the new board parser and add unit tests

## Testing
- `flutter test test/board_textures_test.dart test/autogen_stats_test.dart test/l3_cli_runner_weights_parse_test.dart`

------
https://chatgpt.com/codex/tasks/task_e_689cf431ef60832ab25d8565f4338d52