### PR TITLE
feat: normalize L3 mix keys with tolerance override

### DIFF
--- a/lib/utils/mix_keys.dart
+++ b/lib/utils/mix_keys.dart
@@ -1,0 +1,23 @@
+String? canonicalMixKey(String raw) {
+  final key = raw.toLowerCase().replaceAll('_', '').replaceAll('-', '');
+  switch (key) {
+    case 'monotone':
+      return 'monotone';
+    case 'twotone':
+    case '2tone':
+      return 'twoTone';
+    case 'rainbow':
+      return 'rainbow';
+    case 'paired':
+      return 'paired';
+    case 'acehigh':
+      return 'aceHigh';
+    case 'lowconnected':
+      return 'lowConnected';
+    case 'broadway':
+    case 'broadwayheavy':
+      return 'broadwayHeavy';
+    default:
+      return null;
+  }
+}

--- a/test/l3_cli_runner_weights_parse_test.dart
+++ b/test/l3_cli_runner_weights_parse_test.dart
@@ -5,17 +5,30 @@ import 'package:poker_analyzer/services/l3_cli_runner.dart';
 
 void main() {
   test('extractTargetMix parses inline json', () {
-    final mix = extractTargetMix('{"targetMix":{"rainbow":0.2}}');
-    expect(mix, isNotNull);
-    expect(mix!['rainbow'], 0.2);
+    final res = extractTargetMix('{"targetMix":{"rainbow":0.2}}');
+    expect(res, isNotNull);
+    expect(res!.mix['rainbow'], 0.2);
+    expect(res.tolerance, 0.10);
   });
 
-  test('extractTargetMix parses file path', () {
+  test('extractTargetMix parses file path with tolerance', () {
     final file = File('${Directory.systemTemp.path}/weights.json');
-    file.writeAsStringSync('{"targetMix":{"monotone":0.3}}');
-    final mix = extractTargetMix(file.path);
-    expect(mix, isNotNull);
-    expect(mix!['monotone'], 0.3);
+    file.writeAsStringSync(
+      '{"targetMix":{"monotone":0.3},"mixTolerance":0.05}',
+    );
+    final res = extractTargetMix(file.path);
+    expect(res, isNotNull);
+    expect(res!.mix['monotone'], 0.3);
+    expect(res.tolerance, 0.05);
     file.deleteSync();
+  });
+
+  test('extractTargetMix normalizes keys', () {
+    final res = extractTargetMix(
+      '{"targetMix":{"two_tone":0.3,"broadway":0.25}}',
+    );
+    expect(res, isNotNull);
+    expect(res!.mix.containsKey('twoTone'), isTrue);
+    expect(res.mix.containsKey('broadwayHeavy'), isTrue);
   });
 }


### PR DESCRIPTION
## Summary
- allow l3_cli_runner to parse mixTolerance and normalize targetMix keys
- add canonical mix key utility
- cover key normalization and tolerance in tests

## Testing
- ✅ `/opt/dart-sdk/dart-sdk/bin/dart format lib/services/l3_cli_runner.dart lib/utils/mix_keys.dart test/l3_cli_runner_weights_parse_test.dart`
- ⚠️ `/opt/dart-sdk/dart-sdk/bin/dart analyze lib/services/l3_cli_runner.dart lib/utils/mix_keys.dart test/l3_cli_runner_weights_parse_test.dart` (missing Flutter SDK)
- ⚠️ `/opt/dart-sdk/dart-sdk/bin/dart test test/l3_cli_runner_weights_parse_test.dart` (Flutter SDK not available)


------
https://chatgpt.com/codex/tasks/task_e_689cf9944474832a99e215c3d7214559