### PR TITLE
feat: add per-key mix tolerance with min sample guard

### DIFF
--- a/test/l3_cli_runner_weights_parse_test.dart
+++ b/test/l3_cli_runner_weights_parse_test.dart
@@ -5,39 +5,35 @@ import 'package:poker_analyzer/services/l3_cli_runner.dart';
 
 void main() {
   test(
-    'extractTargetMix parses inline json',
-    () {
-      final res = extractTargetMix('{"targetMix":{"rainbow":0.2}}');
-      expect(res, isNotNull);
-      expect(res!.mix['rainbow'], 0.2);
-      expect(res.tolerance, 0.10);
-    },
-  );
-
-  test(
-    'extractTargetMix parses file path with tolerance',
-    () {
-      final file = File('${Directory.systemTemp.path}/weights.json');
-      file.writeAsStringSync(
-        '{"targetMix":{"monotone":0.3},"mixTolerance":0.05}',
-      );
-      final res = extractTargetMix(file.path);
-      expect(res, isNotNull);
-      expect(res!.mix['monotone'], 0.3);
-      expect(res.tolerance, 0.05);
-      file.deleteSync();
-    },
-  );
-
-  test(
-    'extractTargetMix normalizes keys',
+    'extractTargetMix parses inline json with map tolerance and min total',
     () {
       final res = extractTargetMix(
-        '{"targetMix":{"two_tone":0.3,"broadway":0.25}}',
+        '{"targetMix":{"two_tone":0.3,"broadway":0.25},"mixTolerance":{"two_tone":0.04},"mixMinTotal":75}',
       );
       expect(res, isNotNull);
       expect(res!.mix.containsKey('twoTone'), isTrue);
       expect(res.mix.containsKey('broadwayHeavy'), isTrue);
+      expect(res.defaultTol, 0.10);
+      expect(res.byKeyTol['twoTone'], 0.04);
+      expect(res.minTotal, 75);
+    },
+  );
+
+  test(
+    'extractTargetMix parses file path with map tolerance and min total',
+    () {
+      final file = File('${Directory.systemTemp.path}/weights.json');
+      file.writeAsStringSync(
+        '{"targetMix":{"two_tone":0.3},"mixTolerance":{"two_tone":0.04},"mixMinTotal":75}',
+      );
+      final res = extractTargetMix(file.path);
+      expect(res, isNotNull);
+      expect(res!.mix['twoTone'], 0.3);
+      expect(res.defaultTol, 0.10);
+      expect(res.byKeyTol['twoTone'], 0.04);
+      expect(res.minTotal, 75);
+      file.deleteSync();
     },
   );
 }
+


### PR DESCRIPTION
## Summary
- handle per-key `mixTolerance` and `mixMinTotal` in `extractTargetMix`
- validate mix using per-key tolerance and skip tiny sample sizes
- add tests for per-key tolerance parsing and min-total guard

## Testing
- `dart test test/l3_cli_runner_weights_parse_test.dart` *(fails: dart not installed)*

------
https://chatgpt.com/codex/tasks/task_e_689d0450b704832a9159d95865ca7cb3