### PR TITLE
Fix autogen board CLI cascade and add generator determinism test

### DIFF
--- a/test/board_street_generator_test.dart
+++ b/test/board_street_generator_test.dart
@@ -1,0 +1,26 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/services/autogen_v4.dart';
+
+void main() {
+  test('BoardStreetGenerator is deterministic and unique', () {
+    const seed = 42;
+    const count = 50;
+    final gen1 = BoardStreetGenerator(seed: seed);
+    final gen2 = BoardStreetGenerator(seed: seed);
+
+    final spots1 = gen1.generate(count: count, preset: 'postflop_default');
+    final spots2 = gen2.generate(count: count, preset: 'postflop_default');
+
+    final boards1 = spots1
+        .map((s) => (s['board'] as List).cast<String>().join())
+        .toList(growable: false);
+    final boards2 = spots2
+        .map((s) => (s['board'] as List).cast<String>().join())
+        .toList(growable: false);
+
+    expect(boards1, boards2, reason: 'deterministic for same seed');
+    expect(boards1.toSet().length, count, reason: 'boards are unique');
+    expect(spots1.length, count);
+  });
+}
+

--- a/tool/l3/pack_run_cli.dart
+++ b/tool/l3/pack_run_cli.dart
@@ -22,11 +22,11 @@ void main(List<String> args) {
     ..addOption('weights')
     ..addOption('weightsPreset', allowed: ['aggro', 'nitty', 'default'])
     ..addOption('priors')
-    ..addFlag('explain', negatable: false)
     ..addOption('seed')
     ..addOption('count')
     ..addOption('preset', defaultsTo: 'postflop_default')
-    ..addOption('targetMix');
+    ..addOption('targetMix')
+    ..addFlag('explain', negatable: false);
   final res = parser.parse(args);
   final outPath = res['out'] as String;
 
@@ -56,18 +56,16 @@ void main(List<String> args) {
         'preset': presetArg ?? 'postflop_default',
       },
     };
-    var reportJson = jsonEncode(report);
-    final stats = buildAutogenStats(reportJson);
+    final stats = buildAutogenStats(jsonEncode(report));
     if (stats != null) {
       (report['autogen'] as Map<String, dynamic>)['stats'] = {
         'total': stats.total,
         'textures': stats.textures,
       };
-      reportJson = jsonEncode(report);
     }
     final outFile = File(outPath);
     outFile.parent.createSync(recursive: true);
-    outFile.writeAsStringSync(reportJson);
+    outFile.writeAsStringSync(jsonEncode(report));
     return;
   }
 


### PR DESCRIPTION
## Summary
- fix ArgParser cascade and autogen stats merge in pack_run_cli
- add unit test verifying board generator determinism and uniqueness

## Testing
- `dart analyze` *(fails: dart: command not found)*
- `dart test test/board_street_generator_test.dart` *(fails: dart: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d1f9d9320832abadc63a6d625db0a