### PR TITLE
Add L3 weights contract and CI gate

### DIFF
--- a/.github/workflows/l3-contract.yml
+++ b/.github/workflows/l3-contract.yml
@@ -1,0 +1,53 @@
+name: L3 Weights Contract
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'lib/services/**'
+      - 'lib/l3/**'
+      - 'tool/l3/**'
+      - 'test/l3_cli_runner_weights_parse_test.dart'
+      - 'test/fixtures/l3/weights/**'
+      - '.github/workflows/l3-contract.yml'
+  push:
+    branches: [ main ]
+    paths:
+      - 'lib/services/**'
+      - 'lib/l3/**'
+      - 'tool/l3/**'
+      - 'test/l3_cli_runner_weights_parse_test.dart'
+      - 'test/fixtures/l3/weights/**'
+      - '.github/workflows/l3-contract.yml'
+
+jobs:
+  contract:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          flutter-version: '3.27.0'
+          cache: true
+
+      - run: flutter --version
+      - run: dart --version
+
+      - name: Cache Pub dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.pub-cache
+          key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pub-
+
+      - run: flutter pub get
+
+      - name: Precommit sanity
+        run: bash tool/dev/precommit_sanity.sh
+
+      - name: Run contract tests
+        run: dart test test/l3_cli_runner_weights_parse_test.dart

--- a/lib/l3/weights_contract.dart
+++ b/lib/l3/weights_contract.dart
@@ -1,0 +1,52 @@
+import '../utils/mix_keys.dart';
+
+const String kTargetMixKey = 'targetMix';
+const String kMixToleranceKey = 'mixTolerance';
+const String kMixMinTotalKey = 'mixMinTotal';
+
+/// All accepted keys for per-key tolerance maps.
+const Set<String> kPerKeyToleranceKeys = {
+  kMixToleranceKey,
+  'mixToleranceByKey',
+  'mixToleranceMap',
+  'toleranceByKey',
+  'tolerancesByKey',
+  'toleranceMap',
+  'perKeyTolerance',
+  'byKeyTol',
+  'byKey',
+};
+
+/// Aliases for min total guard.
+const Set<String> kMinTotalKeys = {
+  kMixMinTotalKey,
+  'minTotal',
+  'minTotalSamples',
+};
+
+/// Parses a [double] from [v], accepting numeric strings.
+double? parseDouble(dynamic v) {
+  if (v is num) return v.toDouble();
+  if (v is String) return double.tryParse(v);
+  return null;
+}
+
+/// Parses an [int] from [v], accepting numeric strings.
+int? parseInt(dynamic v) {
+  if (v is num) return v.toInt();
+  if (v is String) return int.tryParse(v);
+  return null;
+}
+
+/// Merges [raw] per-key tolerance map into [target], canonicalizing keys.
+void mergeTolMap(Map<String, double> target, dynamic raw) {
+  if (raw is Map) {
+    raw.forEach((key, value) {
+      final canon = canonicalMixKey(key.toString()) ?? key.toString();
+      final d = parseDouble(value);
+      if (canon.isNotEmpty && d != null) {
+        target[canon] = d;
+      }
+    });
+  }
+}

--- a/test/fixtures/l3/weights/numeric_min_total.json
+++ b/test/fixtures/l3/weights/numeric_min_total.json
@@ -1,0 +1,6 @@
+{
+  "targetMix": {"two_tone": 0.3},
+  "mixTolerance": 0.1,
+  "toleranceByKey": {"two_tone": 0.04},
+  "minTotal": 75
+}

--- a/test/fixtures/l3/weights/per_key_min_total_samples.json
+++ b/test/fixtures/l3/weights/per_key_min_total_samples.json
@@ -1,0 +1,5 @@
+{
+  "targetMix": {"two_tone": 0.3},
+  "toleranceByKey": {"two_tone": 0.04},
+  "minTotalSamples": 75
+}

--- a/test/fixtures/l3/weights/per_key_mix_min_total.json
+++ b/test/fixtures/l3/weights/per_key_mix_min_total.json
@@ -1,0 +1,5 @@
+{
+  "targetMix": {"two_tone": 0.3, "broadway": 0.25},
+  "mixTolerance": {"two_tone": 0.04},
+  "mixMinTotal": 75
+}

--- a/test/l3_cli_runner_weights_parse_test.dart
+++ b/test/l3_cli_runner_weights_parse_test.dart
@@ -1,38 +1,39 @@
-import 'dart:io';
-
 import 'package:test/test.dart';
 import 'package:poker_analyzer/services/l3_cli_runner.dart';
 
 void main() {
-  test(
-    'extractTargetMix parses inline json with map tolerance and min total',
-    () {
-      final res = extractTargetMix(
-        '{"targetMix":{"two_tone":0.3,"broadway":0.25},"mixTolerance":{"two_tone":0.04},"mixMinTotal":75}',
-      );
-      expect(res, isNotNull);
-      expect(res!.mix.containsKey('twoTone'), isTrue);
-      expect(res.mix.containsKey('broadwayHeavy'), isTrue);
-      expect(res.defaultTol, 0.10);
-      expect(res.byKeyTol['twoTone'], 0.04);
-      expect(res.minTotal, 75);
-    },
-  );
+  test('extractTargetMix parses inline per-key map with mixMinTotal', () {
+    final res = extractTargetMix(
+      '{"targetMix":{"two_tone":0.3,"broadway":0.25},"mixTolerance":{"two_tone":0.04},"mixMinTotal":75}',
+    );
+    expect(res, isNotNull);
+    expect(res!.mix.containsKey('twoTone'), isTrue);
+    expect(res.mix.containsKey('broadwayHeavy'), isTrue);
+    expect(res.byKeyTol['twoTone'], 0.04);
+    expect(res.minTotal, 75);
+  });
+
+  test('extractTargetMix parses inline numeric mixTolerance', () {
+    final res = extractTargetMix(
+      '{"targetMix":{"two_tone":0.3},"mixTolerance":0.10,"toleranceByKey":{"two_tone":0.04},"minTotal":75}',
+    );
+    expect(res, isNotNull);
+    expect(res!.mix['twoTone'], 0.3);
+    expect(res.defaultTol, 0.10);
+    expect(res.byKeyTol['twoTone'], 0.04);
+    expect(res.minTotal, 75);
+  });
 
   test(
-    'extractTargetMix parses file path with map tolerance and min total',
+    'extractTargetMix parses file path with per-key map and minTotalSamples',
     () {
-      final file = File('${Directory.systemTemp.path}/weights.json');
-      file.writeAsStringSync(
-        '{"targetMix":{"two_tone":0.3},"mixTolerance":{"two_tone":0.04},"mixMinTotal":75}',
+      final res = extractTargetMix(
+        'test/fixtures/l3/weights/per_key_min_total_samples.json',
       );
-      final res = extractTargetMix(file.path);
       expect(res, isNotNull);
       expect(res!.mix['twoTone'], 0.3);
-      expect(res.defaultTol, 0.10);
       expect(res.byKeyTol['twoTone'], 0.04);
       expect(res.minTotal, 75);
-      file.deleteSync();
     },
   );
 }


### PR DESCRIPTION
## Summary
- centralize weights parser keys and aliases in a new contract helper
- switch L3 CLI runner to the SSoT helpers and support numeric/per-key tolerances plus min-total aliases
- add targeted tests and CI workflow for the weights contract

## Testing
- `bash tool/dev/precommit_sanity.sh`
- `FLUTTER_ROOT=/usr/local/flutter dart test test/l3_cli_runner_weights_parse_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_689d1e74d120832a91f08d7aa906125b