### PR TITLE
feat: cluster pack spots with inline theory notes

### DIFF
--- a/lib/models/v2/training_pack_spot.dart
+++ b/lib/models/v2/training_pack_spot.dart
@@ -242,11 +242,6 @@ class TrainingPackSpot
   TrainingPackSpot Function(Map<String, dynamic> json) get fromJson =>
       TrainingPackSpot.fromJson;
 
-  /// Converts this spot to a YAML-compatible map.
-  ///
-  /// The returned map omits empty or null values, mirroring [toJson].
-  Map<String, dynamic> toYaml() => toJson();
-
   /// Creates a [TrainingPackSpot] from a YAML map.
   ///
   /// The method is tolerant to missing fields and invalid values to maintain


### PR DESCRIPTION
## Summary
- add TheoryNoteEntry model for brief instructional snippets
- extend TrainingPackSpot to flag inline theory notes and serialize to YAML
- introduce InlinePackTheoryClusterer service and tests; remove duplicate toYaml method

## Testing
- `flutter test test/services/inline_pack_theory_clusterer_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689415203714832ab15afef729e13ffc