### PR TITLE
Add jam/fold EV enrichment library and CLI

### DIFF
--- a/README_DEV.md
+++ b/README_DEV.md
@@ -16,3 +16,17 @@ await prefs.setBool('theory.schedulerEnabled', true);
 await prefs.setBool('theory.ablationEnabled', false); // flip ablation
 await prefs.setInt('theory.maxPerModule', 3); // adjust caps
 ```
+
+## Jam/Fold EV Enrichment
+
+Generate jam vs fold EV for existing reports:
+
+```sh
+dart run bin/ev_enrich_jam_fold.dart --in report.json --out report.json
+```
+
+Run only the enrichment tests:
+
+```sh
+dart test test/ev/jam_fold_evaluator_test.dart
+```

--- a/bin/ev_enrich_jam_fold.dart
+++ b/bin/ev_enrich_jam_fold.dart
@@ -1,0 +1,21 @@
+import 'dart:io';
+
+import 'package:args/args.dart';
+
+import 'package:poker_analyzer/ev/jam_fold_evaluator.dart';
+
+Future<void> main(List<String> args) async {
+  final parser = ArgParser()
+    ..addOption('in', help: 'Input JSON file')
+    ..addOption('out', help: 'Output JSON file');
+  final result = parser.parse(args);
+  final inPath = result['in'] as String?;
+  if (inPath == null) {
+    stderr.writeln('Missing --in path');
+    exitCode = 64;
+    return;
+  }
+  final outPath = result['out'] as String? ?? inPath;
+  const merger = JamFoldMerger();
+  await merger.processFile(inPath, outPath);
+}

--- a/lib/ev/jam_fold_evaluator.dart
+++ b/lib/ev/jam_fold_evaluator.dart
@@ -1,0 +1,121 @@
+import 'dart:convert';
+import 'dart:io';
+
+import '../helpers/hand_utils.dart';
+import '../models/action_entry.dart';
+import '../utils/push_fold.dart';
+import '../services/push_fold_ev_service.dart' show computePushEV;
+
+class JamFoldResult {
+  final double evJam;
+  final double evFold;
+  final String bestAction;
+  final double delta;
+
+  const JamFoldResult({
+    required this.evJam,
+    required this.evFold,
+    required this.bestAction,
+    required this.delta,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'evJam': evJam,
+        'evFold': evFold,
+        'bestAction': bestAction,
+        'delta': delta,
+      };
+}
+
+class JamFoldEvaluator {
+  const JamFoldEvaluator();
+
+  JamFoldResult? evaluateSpot(Map<String, dynamic> spot) {
+    final hand = spot['hand'];
+    if (hand is! Map<String, dynamic>) return null;
+
+    final heroIndex = hand['heroIndex'] as int?;
+    final playerCount = hand['playerCount'] as int?;
+    final heroCards = hand['heroCards'] as String?;
+    final stacks = hand['stacks'] as Map<String, dynamic>?;
+    final anteBb = (hand['anteBb'] as num?)?.round() ?? 0;
+    final actionsRaw = hand['actions'] as Map<String, dynamic>?;
+
+    if (heroIndex == null ||
+        playerCount == null ||
+        heroCards == null ||
+        stacks == null ||
+        actionsRaw == null) {
+      return null;
+    }
+
+    final actions = <int, List<ActionEntry>>{};
+    for (final entry in actionsRaw.entries) {
+      final street = int.tryParse(entry.key);
+      if (street == null) continue;
+      final list = (entry.value as List)
+          .map(
+            (e) => e is Map<String, dynamic> ? ActionEntry.fromJson(e) : null,
+          )
+          .whereType<ActionEntry>()
+          .toList();
+      actions[street] = list;
+    }
+
+    if (!isPushFoldSpot(actions, 0, heroIndex)) return null;
+
+    final heroStack = (stacks['$heroIndex'] as num?)?.round();
+    final handCodeStr = handCode(heroCards);
+    if (heroStack == null || handCodeStr == null) return null;
+
+    final evJam = computePushEV(
+      heroBbStack: heroStack,
+      bbCount: playerCount - 1,
+      heroHand: handCodeStr,
+      anteBb: anteBb,
+    );
+    const evFold = 0.0;
+    final delta = evJam - evFold;
+    final bestAction = delta >= 0 ? 'jam' : 'fold';
+
+    return JamFoldResult(
+      evJam: evJam,
+      evFold: evFold,
+      bestAction: bestAction,
+      delta: delta,
+    );
+  }
+}
+
+String enrichJson(String content) {
+  final data = jsonDecode(content);
+  if (data is! Map<String, dynamic>) return content;
+  final spots = data['spots'];
+  if (spots is! List) return content;
+  const evaluator = JamFoldEvaluator();
+  for (final spot in spots) {
+    if (spot is Map<String, dynamic>) {
+      final res = evaluator.evaluateSpot(spot);
+      if (res != null) {
+        spot['jamFold'] = res.toJson();
+      }
+    }
+  }
+  return const JsonEncoder.withIndent('  ').convert(data);
+}
+
+class JamFoldMerger {
+  const JamFoldMerger();
+
+  Future<void> processFile(String inPath, String outPath) async {
+    final inFile = File(inPath);
+    final outFile = File(outPath);
+    final original = await inFile.readAsString();
+    final merged = enrichJson(original);
+    final exists = await outFile.exists();
+    final current = exists ? await outFile.readAsString() : '';
+    if (current != merged) {
+      await outFile.writeAsString(merged);
+    }
+  }
+}

--- a/test/ev/jam_fold_evaluator_test.dart
+++ b/test/ev/jam_fold_evaluator_test.dart
@@ -1,0 +1,83 @@
+import 'dart:convert';
+
+import 'package:poker_analyzer/ev/jam_fold_evaluator.dart';
+import 'package:poker_analyzer/helpers/hand_utils.dart';
+import 'package:poker_analyzer/services/push_fold_ev_service.dart';
+import 'package:test/test.dart';
+
+Map<String, dynamic> spotForHand(String cards) {
+  return {
+    'hand': {
+      'heroCards': cards,
+      'heroIndex': 0,
+      'playerCount': 2,
+      'stacks': {'0': 10, '1': 10},
+      'actions': {
+        '0': [
+          {'street': 0, 'playerIndex': 0, 'action': 'push', 'amount': 10},
+          {'street': 0, 'playerIndex': 1, 'action': 'fold'},
+        ],
+      },
+      'anteBb': 0,
+    },
+  };
+}
+
+void main() {
+  const evaluator = JamFoldEvaluator();
+
+  test('deterministic outputs for canonical hands', () {
+    final strong = evaluator.evaluateSpot(spotForHand('As Ks'))!;
+    final strongEv = computePushEV(
+      heroBbStack: 10,
+      bbCount: 1,
+      heroHand: handCode('As Ks')!,
+      anteBb: 0,
+    );
+    expect(strong.evJam, strongEv);
+    expect(strong.bestAction, 'jam');
+
+    final weak = evaluator.evaluateSpot(spotForHand('7c 2d'))!;
+    final weakEv = computePushEV(
+      heroBbStack: 10,
+      bbCount: 1,
+      heroHand: handCode('7c 2d')!,
+      anteBb: 0,
+    );
+    expect(weak.evJam, weakEv);
+    expect(weak.bestAction, 'fold');
+
+    final mid = evaluator.evaluateSpot(spotForHand('Qh Jd'))!;
+    final midEv = computePushEV(
+      heroBbStack: 10,
+      bbCount: 1,
+      heroHand: handCode('Qh Jd')!,
+      anteBb: 0,
+    );
+    expect(mid.evJam, midEv);
+  });
+
+  test('JSON backward compatibility and idempotence', () async {
+    final originalMap = {
+      'spots': [spotForHand('As Ks')],
+    };
+    final originalJson = const JsonEncoder.withIndent(
+      '  ',
+    ).convert(originalMap);
+
+    final mergedJson = enrichJson(originalJson);
+    final mergedMap = jsonDecode(mergedJson) as Map<String, dynamic>;
+
+    // jamFold should be added
+    final spot = mergedMap['spots'][0] as Map<String, dynamic>;
+    expect(spot['jamFold'], isNotNull);
+
+    // Removing jamFold yields original map
+    spot.remove('jamFold');
+    expect(mergedMap, originalMap);
+
+    // idempotent formatting
+    final mergedTwice = enrichJson(mergedJson);
+    expect(mergedTwice, mergedJson);
+  });
+}


### PR DESCRIPTION
## Summary
- add JamFoldEvaluator to compute jam vs fold EV and attach results to spots
- provide CLI tool `ev_enrich_jam_fold.dart` to merge results into JSON reports
- document usage and tests in README_DEV

## Testing
- `bash tool/dev/precommit_sanity.sh`
- `flutter test test/ev/jam_fold_evaluator_test.dart` *(fails: Package file_picker:linux references file_picker:linux as the default plugin, ... No tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_689d5cd09fe0832aa5f3a7c103f321ee