### PR TITLE
refactor: drop args dependency from jam/fold CLI

### DIFF
--- a/README_DEV.md
+++ b/README_DEV.md
@@ -19,14 +19,14 @@ await prefs.setInt('theory.maxPerModule', 3); // adjust caps
 
 ## Jam/Fold EV Enrichment
 
-Generate jam vs fold EV for existing reports:
-
-```sh
-dart run bin/ev_enrich_jam_fold.dart --in report.json --out report.json
-```
-
 Run only the enrichment tests:
 
 ```sh
 dart test test/ev/jam_fold_evaluator_test.dart
+```
+
+Generate jam vs fold EV for existing reports:
+
+```sh
+dart run bin/ev_enrich_jam_fold.dart --in report.json --out report.json
 ```

--- a/bin/ev_enrich_jam_fold.dart
+++ b/bin/ev_enrich_jam_fold.dart
@@ -1,21 +1,28 @@
 import 'dart:io';
 
-import 'package:args/args.dart';
-
 import 'package:poker_analyzer/ev/jam_fold_evaluator.dart';
 
 Future<void> main(List<String> args) async {
-  final parser = ArgParser()
-    ..addOption('in', help: 'Input JSON file')
-    ..addOption('out', help: 'Output JSON file');
-  final result = parser.parse(args);
-  final inPath = result['in'] as String?;
+  String? inPath;
+  String? outPath;
+  for (var i = 0; i < args.length; i++) {
+    final arg = args[i];
+    if (arg == '--in' && i + 1 < args.length) {
+      inPath = args[++i];
+    } else if (arg == '--out' && i + 1 < args.length) {
+      outPath = args[++i];
+    } else {
+      stderr.writeln('Unknown or incomplete argument: $arg');
+      exitCode = 64;
+      return;
+    }
+  }
   if (inPath == null) {
     stderr.writeln('Missing --in path');
     exitCode = 64;
     return;
   }
-  final outPath = result['out'] as String? ?? inPath;
+  outPath ??= inPath;
   const merger = JamFoldMerger();
   await merger.processFile(inPath, outPath);
 }


### PR DESCRIPTION
## Summary
- remove package:args from EV enrichment CLI and parse `--in`/`--out` manually
- document dart test/run commands for Jam/Fold enrichment

## Testing
- `bash tool/dev/precommit_sanity.sh` *(fails: formatting needed; dart analyze issues)*
- `dart test` *(fails: Method not found: 'Offset' in Flutter SDK)*

------
https://chatgpt.com/codex/tasks/task_e_689d60abace0832aa259bf26767537b9