### PR TITLE
chore: harden precommit script for portability

### DIFF
--- a/tool/dev/precommit_sanity.sh
+++ b/tool/dev/precommit_sanity.sh
@@ -7,17 +7,17 @@ if [[ -n "$FILES" ]]; then
 fi
 
 # Guard checks for EV scope hygiene
-if rg -q -e 'package:flutter/' -e 'dart:ui' lib/ev test/ev bin/ev*; then
+if grep -R -q -e 'package:flutter/' -e 'dart:ui' lib/ev test/ev bin/ev*; then
   echo 'EV code must not import Flutter.'
   exit 1
 fi
 
-if rg -q 'package:args' bin/ev_enrich_jam_fold.dart || rg -q 'ArgParser' bin/ev_enrich_jam_fold.dart; then
+if grep -R -q 'package:args' bin/ev_enrich_jam_fold.dart || grep -R -q 'ArgParser' bin/ev_enrich_jam_fold.dart; then
   echo 'bin/ev_enrich_jam_fold.dart must not depend on package:args.'
   exit 1
 fi
 
-if rg -q 'sdk: flutter' pubspec.yaml; then
+if grep -R -q 'sdk: flutter' pubspec.yaml; then
   if ! command -v flutter >/dev/null 2>&1; then
     echo 'SKIP analyze/test (no Flutter SDK)'
     exit 0


### PR DESCRIPTION
## Summary
- replace `rg` with portable `grep -R` in precommit_sanity.sh

## Testing
- `bash tool/dev/precommit_sanity.sh`
- `/tmp/dart-sdk/dart-sdk/bin/dart analyze lib/ev bin test/ev --fatal-warnings --fatal-infos` *(fails: Target of URI doesn't exist: 'package:path/path.dart')*
- `/tmp/dart-sdk/dart-sdk/bin/dart test test/ev/jam_fold_evaluator_test.dart` *(fails: Because poker_analyzer depends on flutter_test from sdk which doesn't exist (the Flutter SDK is not available), version solving failed.)*


------
https://chatgpt.com/codex/tasks/task_e_689d6dd82ef4832aaa76e714507d2161