### PR TITLE
feat: add batch EV enrichment with dry-run

### DIFF
--- a/README_DEV.md
+++ b/README_DEV.md
@@ -13,3 +13,21 @@ Generate jam vs fold EV for existing reports:
 ```sh
 dart run bin/ev_enrich_jam_fold.dart --in report.json --out report.json
 ```
+
+Batch enrich an entire directory:
+
+```sh
+dart run bin/ev_enrich_jam_fold.dart --dir reports/
+```
+
+Use a glob pattern:
+
+```sh
+dart run bin/ev_enrich_jam_fold.dart --glob "reports/**/*.json"
+```
+
+Preview changes without writing:
+
+```sh
+dart run bin/ev_enrich_jam_fold.dart --dir reports/ --dry-run
+```

--- a/bin/ev_enrich_jam_fold.dart
+++ b/bin/ev_enrich_jam_fold.dart
@@ -1,28 +1,92 @@
 import 'dart:io';
 
+import 'package:path/path.dart' as p;
 import 'package:poker_analyzer/ev/jam_fold_evaluator.dart';
 
 Future<void> main(List<String> args) async {
   String? inPath;
   String? outPath;
+  String? dirPath;
+  String? glob;
+  var dryRun = false;
   for (var i = 0; i < args.length; i++) {
     final arg = args[i];
     if (arg == '--in' && i + 1 < args.length) {
       inPath = args[++i];
     } else if (arg == '--out' && i + 1 < args.length) {
       outPath = args[++i];
+    } else if (arg == '--dir' && i + 1 < args.length) {
+      dirPath = args[++i];
+    } else if (arg == '--glob' && i + 1 < args.length) {
+      glob = args[++i];
+    } else if (arg == '--dry-run') {
+      dryRun = true;
     } else {
       stderr.writeln('Unknown or incomplete argument: $arg');
       exitCode = 64;
       return;
     }
   }
-  if (inPath == null) {
-    stderr.writeln('Missing --in path');
+
+  final modes = [inPath, dirPath, glob].whereType<String>();
+  if (modes.length != 1) {
+    stderr.writeln('Specify exactly one of --in, --dir, or --glob');
     exitCode = 64;
     return;
   }
-  outPath ??= inPath;
+
+  if ((dirPath != null || glob != null) && outPath != null) {
+    stderr.writeln('--out is not supported with --dir or --glob');
+    exitCode = 64;
+    return;
+  }
+
   const merger = JamFoldMerger();
-  await merger.processFile(inPath, outPath);
+  var scanned = 0;
+  var changed = 0;
+
+  Future<void> handle(String inFile, String outFile) async {
+    scanned++;
+    if (await merger.processFile(inFile, outFile, dryRun: dryRun)) {
+      changed++;
+    }
+  }
+
+  if (inPath != null) {
+    outPath ??= inPath;
+    await handle(inPath, outPath);
+  } else if (dirPath != null) {
+    final dir = Directory(dirPath);
+    if (!await dir.exists()) {
+      stderr.writeln('Directory not found: $dirPath');
+      exitCode = 64;
+      return;
+    }
+    await for (final entity in dir.list(recursive: true)) {
+      if (entity is File && entity.path.endsWith('.json')) {
+        await handle(entity.path, entity.path);
+      }
+    }
+  } else if (glob != null) {
+    final regex = _globToRegExp(glob!);
+    final root = Directory.current.path;
+    await for (final entity in Directory.current.list(recursive: true, followLinks: false)) {
+      if (entity is! File) continue;
+      final rel = p.relative(entity.path, from: root).replaceAll('\\', '/');
+      if (regex.hasMatch(rel)) {
+        await handle(entity.path, entity.path);
+      }
+    }
+  }
+
+  final skipped = scanned - changed;
+  print('Scanned $scanned files: $changed changed, $skipped skipped');
+}
+
+RegExp _globToRegExp(String pattern) {
+  var escaped = RegExp.escape(pattern);
+  escaped = escaped.replaceAll('\\*\\*', '::DOUBLE_STAR::');
+  escaped = escaped.replaceAll('\\*', '[^/]*');
+  escaped = escaped.replaceAll('::DOUBLE_STAR::', '.*');
+  return RegExp('^' + escaped + r'\$');
 }

--- a/lib/ev/jam_fold_evaluator.dart
+++ b/lib/ev/jam_fold_evaluator.dart
@@ -106,16 +106,22 @@ String enrichJson(String content) {
 class JamFoldMerger {
   const JamFoldMerger();
 
-  Future<void> processFile(String inPath, String outPath) async {
+  Future<bool> processFile(
+    String inPath,
+    String outPath, {
+    bool dryRun = false,
+  }) async {
     final inFile = File(inPath);
     final outFile = File(outPath);
     final original = await inFile.readAsString();
     final merged = enrichJson(original);
     final exists = await outFile.exists();
     final current = exists ? await outFile.readAsString() : '';
-    if (current != merged) {
+    final changed = current != merged;
+    if (changed && !dryRun) {
       await outFile.writeAsString(merged);
     }
+    return changed;
   }
 }
 

--- a/test/ev/ev_enrich_jam_fold_cli_test.dart
+++ b/test/ev/ev_enrich_jam_fold_cli_test.dart
@@ -1,0 +1,108 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+import '../../bin/ev_enrich_jam_fold.dart' as cli;
+
+Map<String, dynamic> spotForHand(String cards) {
+  return {
+    'hand': {
+      'heroCards': cards,
+      'heroIndex': 0,
+      'playerCount': 2,
+      'stacks': {'0': 10, '1': 10},
+      'actions': {
+        '0': [
+          {'street': 0, 'playerIndex': 0, 'action': 'push', 'amount': 10},
+          {'street': 0, 'playerIndex': 1, 'action': 'fold'},
+        ],
+      },
+      'anteBb': 0,
+    },
+  };
+}
+
+Future<String> _writeReport(Directory dir, String name, String hand) async {
+  final file = File('${dir.path}/$name.json');
+  final map = {'spots': [spotForHand(hand)]};
+  await file.writeAsString(const JsonEncoder.withIndent('  ').convert(map));
+  return file.path;
+}
+
+Future<String> _capturePrint(Future<void> Function() fn) async {
+  final buffer = StringBuffer();
+  await runZoned(() async {
+    await fn();
+  }, zoneSpecification: ZoneSpecification(print: (self, parent, zone, line) {
+    buffer.writeln(line);
+  }));
+  return buffer.toString();
+}
+
+void main() {
+  test('batch directory idempotence', () async {
+    final dir = await Directory.systemTemp.createTemp('ev_batch');
+    try {
+      await _writeReport(dir, 'a', 'As Ks');
+      await _writeReport(dir, 'b', '7c 2d');
+      await _writeReport(dir, 'c', 'Qh Jd');
+
+      await cli.main(['--dir', dir.path]);
+      final first = <String, String>{};
+      await for (final e in dir.list()) {
+        if (e is File) {
+          first[e.path] = await e.readAsString();
+        }
+      }
+      await cli.main(['--dir', dir.path]);
+      await for (final e in dir.list()) {
+        if (e is File) {
+          expect(await e.readAsString(), first[e.path]);
+        }
+      }
+    } finally {
+      await dir.delete(recursive: true);
+    }
+  });
+
+  test('backward compat deep compare', () async {
+    final dir = await Directory.systemTemp.createTemp('ev_single');
+    try {
+      final path = await _writeReport(dir, 'one', 'As Ks');
+      final original = jsonDecode(await File(path).readAsString());
+      await cli.main(['--in', path]);
+      final merged = jsonDecode(await File(path).readAsString());
+      final spot = (merged['spots'] as List).first as Map<String, dynamic>;
+      expect(spot['jamFold'], isNotNull);
+      spot.remove('jamFold');
+      expect(merged, original);
+    } finally {
+      await dir.delete(recursive: true);
+    }
+  });
+
+  test('dry-run summary', () async {
+    final dir = await Directory.systemTemp.createTemp('ev_dry');
+    try {
+      await _writeReport(dir, 'a', 'As Ks');
+      await _writeReport(dir, 'b', '7c 2d');
+      await _writeReport(dir, 'c', 'Qh Jd');
+
+      final output = await _capturePrint(() async {
+        await cli.main(['--dir', dir.path, '--dry-run']);
+      });
+      expect(output, contains('Scanned 3 files: 3 changed, 0 skipped'));
+      await for (final e in dir.list()) {
+        if (e is File) {
+          final json = jsonDecode(await e.readAsString());
+          final spot = (json['spots'] as List).first as Map<String, dynamic>;
+          expect(spot['jamFold'], isNull);
+        }
+      }
+    } finally {
+      await dir.delete(recursive: true);
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- expand `ev_enrich_jam_fold.dart` to handle single files, directories, or glob patterns and add `--dry-run`
- expose `JamFoldMerger.processFile` change flag with optional dry-run
- document new CLI options and add tests for batch processing, idempotence, and dry-run counts

## Testing
- `dart format -o write bin/ev_enrich_jam_fold.dart lib/ev/jam_fold_evaluator.dart test/ev/ev_enrich_jam_fold_cli_test.dart` *(failed: command not found)*
- `bash tool/dev/precommit_sanity.sh` *(failed: dart: command not found)*
- `dart test` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d6f4edb88832abbcd5726b8a55491