### PR TITLE
chore: guard jam fold CLI from path

### DIFF
--- a/tool/dev/precommit_sanity.sh
+++ b/tool/dev/precommit_sanity.sh
@@ -17,6 +17,11 @@ if grep -R -q 'package:args' bin/ev_enrich_jam_fold.dart || grep -R -q 'ArgParse
   exit 1
 fi
 
+if grep -R -q 'package:path/' bin/ev_enrich_jam_fold.dart; then
+  echo 'bin/ev_enrich_jam_fold.dart must not depend on package:path.'
+  exit 1
+fi
+
 if grep -R -q 'sdk: flutter' pubspec.yaml; then
   if ! command -v flutter >/dev/null 2>&1; then
     echo 'SKIP analyze/test (no Flutter SDK)'


### PR DESCRIPTION
## Summary
- block `package:path` imports in EV jam/fold CLI via pre-commit check

## Testing
- `bash tool/dev/precommit_sanity.sh`
- `dart test test/ev` *(fails: Flutter SDK not available)*

------
https://chatgpt.com/codex/tasks/task_e_689d73c12824832a8be24b3ff2ae27b4