### PR TITLE
Add jam/fold report summary CLI

### DIFF
--- a/README_DEV.md
+++ b/README_DEV.md
@@ -33,3 +33,19 @@ Preview changes without writing:
 ```sh
 dart run bin/ev_enrich_jam_fold.dart --dir reports/ --dry-run
 ```
+
+## Jam/Fold Report Summary
+
+Aggregate jam/fold data from enriched reports. Exactly one of `--in`, `--dir`, or `--glob` must be provided. Use `--validate` to ensure every spot has `jamFold` with a `bestAction` of `jam` or `fold`.
+
+Summarize a directory:
+
+```sh
+dart run bin/ev_report_jam_fold.dart --dir reports/
+```
+
+Validate a single report:
+
+```sh
+dart run bin/ev_report_jam_fold.dart --in report.json --validate
+```

--- a/bin/ev_report_jam_fold.dart
+++ b/bin/ev_report_jam_fold.dart
@@ -1,0 +1,123 @@
+import 'dart:convert';
+import 'dart:io';
+
+Future<void> main(List<String> args) async {
+  String? inPath;
+  String? dirPath;
+  String? glob;
+  var validate = false;
+
+  for (var i = 0; i < args.length; i++) {
+    final arg = args[i];
+    if (arg == '--in' && i + 1 < args.length) {
+      inPath = args[++i];
+    } else if (arg == '--dir' && i + 1 < args.length) {
+      dirPath = args[++i];
+    } else if (arg == '--glob' && i + 1 < args.length) {
+      glob = args[++i];
+    } else if (arg == '--validate') {
+      validate = true;
+    } else {
+      stderr.writeln('Unknown or incomplete argument: $arg');
+      exitCode = 64;
+      return;
+    }
+  }
+
+  final modes = [inPath, dirPath, glob].whereType<String>();
+  if (modes.length != 1) {
+    stderr.writeln('Specify exactly one of --in, --dir, or --glob');
+    exitCode = 64;
+    return;
+  }
+
+  var files = 0;
+  var spots = 0;
+  var withJamFold = 0;
+  var invalid = false;
+
+  Future<void> handle(String path) async {
+    files++;
+    final content = await File(path).readAsString();
+    final data = jsonDecode(content);
+    if (data is Map<String, dynamic>) {
+      final list = data['spots'];
+      if (list is List) {
+        spots += list.length;
+        for (final spot in list) {
+          if (spot is Map<String, dynamic>) {
+            final jf = spot['jamFold'];
+            if (jf is Map<String, dynamic>) {
+              withJamFold++;
+              final best = jf['bestAction'];
+              if (validate && best != 'jam' && best != 'fold') {
+                invalid = true;
+              }
+            } else {
+              if (validate) invalid = true;
+            }
+          } else {
+            if (validate) invalid = true;
+          }
+        }
+      }
+    }
+  }
+
+  if (inPath != null) {
+    await handle(inPath);
+  } else if (dirPath != null) {
+    final dir = Directory(dirPath);
+    if (!await dir.exists()) {
+      stderr.writeln('Directory not found: $dirPath');
+      exitCode = 64;
+      return;
+    }
+    await for (final entity in dir.list(recursive: true)) {
+      if (entity is File && entity.path.endsWith('.json')) {
+        await handle(entity.path);
+      }
+    }
+  } else if (glob != null) {
+    final regex = _globToRegExp(glob);
+    final root = Directory.current.path;
+    await for (final entity in Directory.current.list(
+      recursive: true,
+      followLinks: false,
+    )) {
+      if (entity is! File) continue;
+      var rel = entity.path;
+      if (rel.startsWith(root)) {
+        rel = rel.substring(root.length);
+        if (rel.startsWith(Platform.pathSeparator)) {
+          rel = rel.substring(1);
+        }
+      }
+      rel = rel.replaceAll('\\', '/');
+      if (regex.hasMatch(rel)) {
+        await handle(entity.path);
+      }
+    }
+  }
+
+  final rate = spots == 0 ? 0.0 : withJamFold / spots;
+  final summary = {
+    'files': files,
+    'spots': spots,
+    'withJamFold': withJamFold,
+    'jamRate': double.parse(rate.toStringAsFixed(2)),
+    'changed': 0,
+  };
+  print(jsonEncode(summary));
+  if (validate && invalid) {
+    exitCode = 1;
+  }
+}
+
+RegExp _globToRegExp(String pattern) {
+  var escaped = RegExp.escape(pattern);
+  escaped = escaped.replaceAll('\\*\\*', '::DOUBLE_STAR::');
+  escaped = escaped.replaceAll('\\*', '[^/]*');
+  escaped = escaped.replaceAll('::DOUBLE_STAR::', '.*');
+  return RegExp('^' + escaped + r'\\$');
+}

--- a/test/ev/ev_report_jam_fold_cli_test.dart
+++ b/test/ev/ev_report_jam_fold_cli_test.dart
@@ -1,0 +1,100 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+import '../../bin/ev_report_jam_fold.dart' as cli;
+
+Future<String> _writeReport(
+  Directory dir,
+  String name, {
+  bool includeJamFold = true,
+}) async {
+  final file = File('${dir.path}/$name.json');
+  final spot = <String, dynamic>{};
+  if (includeJamFold) {
+    spot['jamFold'] = {
+      'evJam': 1,
+      'evFold': 0,
+      'bestAction': 'jam',
+      'delta': 1,
+    };
+  }
+  final map = {
+    'spots': [spot],
+  };
+  await file.writeAsString(const JsonEncoder.withIndent('  ').convert(map));
+  return file.path;
+}
+
+Future<String> _capturePrint(Future<void> Function() fn) async {
+  final buffer = StringBuffer();
+  await runZoned(
+    () async {
+      await fn();
+    },
+    zoneSpecification: ZoneSpecification(
+      print: (self, parent, zone, line) {
+        buffer.writeln(line);
+      },
+    ),
+  );
+  return buffer.toString();
+}
+
+void main() {
+  test('directory summary counts', () async {
+    final dir = await Directory.systemTemp.createTemp('ev_summary');
+    try {
+      await _writeReport(dir, 'a');
+      await _writeReport(dir, 'b');
+      await _writeReport(dir, 'c');
+
+      final output = await _capturePrint(() async {
+        exitCode = 0;
+        await cli.main(['--dir', dir.path]);
+      });
+      expect(exitCode, 0);
+      final summary = jsonDecode(output.trim()) as Map<String, dynamic>;
+      expect(summary['files'], 3);
+      expect(summary['spots'], 3);
+      expect(summary['withJamFold'], 3);
+      expect(summary['jamRate'], 1.0);
+      expect(summary['changed'], 0);
+    } finally {
+      await dir.delete(recursive: true);
+    }
+  });
+
+  test('validate missing jamFold exits 1', () async {
+    final dir = await Directory.systemTemp.createTemp('ev_validate');
+    try {
+      final path = await _writeReport(dir, 'one', includeJamFold: false);
+      await _capturePrint(() async {
+        exitCode = 0;
+        await cli.main(['--in', path, '--validate']);
+      });
+      expect(exitCode, 1);
+    } finally {
+      await dir.delete(recursive: true);
+    }
+  });
+
+  test('idempotent no writes', () async {
+    final dir = await Directory.systemTemp.createTemp('ev_idem');
+    try {
+      final path = await _writeReport(dir, 'one');
+      final before = await File(path).readAsString();
+      await _capturePrint(() async {
+        exitCode = 0;
+        await cli.main(['--dir', dir.path]);
+      });
+      expect(exitCode, 0);
+      final after = await File(path).readAsString();
+      expect(after, before);
+    } finally {
+      await dir.delete(recursive: true);
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- add `ev_report_jam_fold.dart` CLI to summarize jam/fold enrichment outputs and optional validation
- document summary/validation usage in README_DEV
- add tests covering summary counts, validation failure, and idempotence

## Testing
- `tool/dev/precommit_sanity.sh` *(fails: Could not find an option or flag "-q" when running `flutter pub get`)*
- `dart analyze lib/ev bin test/ev --fatal-warnings --fatal-infos`
- `dart test test/ev` *(fails: Flutter SDK not available)*

------
https://chatgpt.com/codex/tasks/task_e_689d75636fcc832a97855d34c912d88a