### PR TITLE
fix: clean precommit and glob anchor

### DIFF
--- a/bin/ev_report_jam_fold.dart
+++ b/bin/ev_report_jam_fold.dart
@@ -119,5 +119,5 @@ RegExp _globToRegExp(String pattern) {
   escaped = escaped.replaceAll('\\*\\*', '::DOUBLE_STAR::');
   escaped = escaped.replaceAll('\\*', '[^/]*');
   escaped = escaped.replaceAll('::DOUBLE_STAR::', '.*');
-  return RegExp('^' + escaped + r'\\$');
+  return RegExp('^' + escaped + r'\$');
 }

--- a/tool/dev/precommit_sanity.sh
+++ b/tool/dev/precommit_sanity.sh
@@ -12,22 +12,24 @@ if grep -R -q -e 'package:flutter/' -e 'dart:ui' lib/ev test/ev bin/ev*; then
   exit 1
 fi
 
-if grep -R -q 'package:args' bin/ev_enrich_jam_fold.dart || grep -R -q 'ArgParser' bin/ev_enrich_jam_fold.dart; then
-  echo 'bin/ev_enrich_jam_fold.dart must not depend on package:args.'
-  exit 1
-fi
+for file in bin/ev_enrich_jam_fold.dart bin/ev_report_jam_fold.dart; do
+  if grep -R -q -e 'package:args' -e 'ArgParser' "$file"; then
+    echo "$file must not depend on package:args."
+    exit 1
+  fi
 
-if grep -R -q 'package:path/' bin/ev_enrich_jam_fold.dart; then
-  echo 'bin/ev_enrich_jam_fold.dart must not depend on package:path.'
-  exit 1
-fi
+  if grep -R -q 'package:path/' "$file"; then
+    echo "$file must not depend on package:path."
+    exit 1
+  fi
+done
 
 if grep -R -q 'sdk: flutter' pubspec.yaml; then
   if ! command -v flutter >/dev/null 2>&1; then
     echo 'SKIP analyze/test (no Flutter SDK)'
     exit 0
   fi
-  flutter pub get -q
+  flutter pub get
 fi
 
 dart analyze lib/ev bin test/ev --fatal-warnings --fatal-infos


### PR DESCRIPTION
## Summary
- guard EV CLIs against args/path packages
- flutter-aware precommit uses `flutter pub get`
- fix report glob regex anchor

## Testing
- `dart format -o write bin/ev_report_jam_fold.dart` *(fails: command not found)*
- `bash tool/dev/precommit_sanity.sh` *(fails: dart: command not found)*
- `dart analyze lib/ev bin test/ev --fatal-warnings --fatal-infos` *(fails: command not found)*
- `dart test test/ev/*` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d78c2a370832ab0af4ccfabe22480