### PR TITLE
Add jam/fold pack summary CLI

### DIFF
--- a/README_DEV.md
+++ b/README_DEV.md
@@ -55,3 +55,11 @@ Fail if jam rate drops below a threshold:
 ```sh
 dart run bin/ev_report_jam_fold.dart --dir reports/ --fail-under 0.95
 ```
+
+## Jam/Fold Pack Summary
+
+Summarize jam/fold decisions across reports:
+
+```sh
+dart run bin/ev_summary_jam_fold.dart --dir reports/
+```

--- a/bin/ev_summary_jam_fold.dart
+++ b/bin/ev_summary_jam_fold.dart
@@ -1,0 +1,153 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:collection';
+
+import 'package:poker_analyzer/services/board_texture_classifier.dart';
+
+Future<void> main(List<String> args) async {
+  String? inPath;
+  String? dirPath;
+  String? glob;
+
+  for (var i = 0; i < args.length; i++) {
+    final arg = args[i];
+    if (arg == '--in' && i + 1 < args.length) {
+      inPath = args[++i];
+    } else if (arg == '--dir' && i + 1 < args.length) {
+      dirPath = args[++i];
+    } else if (arg == '--glob' && i + 1 < args.length) {
+      glob = args[++i];
+    } else {
+      stderr.writeln('Unknown or incomplete argument: $arg');
+      exitCode = 64;
+      return;
+    }
+  }
+
+  final modes = [inPath, dirPath, glob].whereType<String>();
+  if (modes.length != 1) {
+    stderr.writeln('Specify exactly one of --in, --dir, or --glob');
+    exitCode = 64;
+    return;
+  }
+
+  var files = 0;
+  var spots = 0;
+  var withJamFold = 0;
+  var jamCount = 0;
+
+  final bySpr = {
+    'spr_low': [0, 0],
+    'spr_mid': [0, 0],
+    'spr_high': [0, 0],
+  };
+  final byTextureCounts = <String, List<int>>{};
+  const classifier = BoardTextureClassifier();
+
+  Future<void> handle(String path) async {
+    files++;
+    final content = await File(path).readAsString();
+    final data = jsonDecode(content);
+    if (data is! Map<String, dynamic>) return;
+    final list = data['spots'];
+    if (list is! List) return;
+    spots += list.length;
+    for (final spot in list) {
+      if (spot is! Map<String, dynamic>) continue;
+      final jf = spot['jamFold'];
+      if (jf is! Map<String, dynamic>) continue;
+      withJamFold++;
+      final best = jf['bestAction'];
+      final isJam = best == 'jam';
+      if (isJam) jamCount++;
+      final sprVal = (spot['spr'] as num?)?.toDouble();
+      if (sprVal != null) {
+        final bucket = sprVal < 1
+            ? 'spr_low'
+            : sprVal < 2
+            ? 'spr_mid'
+            : 'spr_high';
+        final entry = bySpr[bucket]!;
+        entry[1]++;
+        if (isJam) entry[0]++;
+      }
+      final board = spot['board'];
+      if (board is String) {
+        final tags = classifier.classify(board);
+        for (final t in tags) {
+          final entry = byTextureCounts.putIfAbsent(t, () => [0, 0]);
+          entry[1]++;
+          if (isJam) entry[0]++;
+        }
+      }
+    }
+  }
+
+  if (inPath != null) {
+    await handle(inPath);
+  } else if (dirPath != null) {
+    final dir = Directory(dirPath);
+    if (!await dir.exists()) {
+      stderr.writeln('Directory not found: $dirPath');
+      exitCode = 64;
+      return;
+    }
+    await for (final entity in dir.list(recursive: true)) {
+      if (entity is File && entity.path.endsWith('.json')) {
+        await handle(entity.path);
+      }
+    }
+  } else if (glob != null) {
+    final regex = _globToRegExp(glob!);
+    final root = Directory.current.path;
+    await for (final entity in Directory.current.list(
+      recursive: true,
+      followLinks: false,
+    )) {
+      if (entity is! File) continue;
+      var rel = entity.path;
+      if (rel.startsWith(root)) {
+        rel = rel.substring(root.length);
+        if (rel.startsWith(Platform.pathSeparator)) {
+          rel = rel.substring(1);
+        }
+      }
+      rel = rel.replaceAll('\\\\', '/');
+      if (regex.hasMatch(rel)) {
+        await handle(entity.path);
+      }
+    }
+  }
+
+  double rate(int jam, int total) {
+    if (total == 0) return 0.0;
+    return double.parse((jam / total).toStringAsFixed(2));
+  }
+
+  final bySprRates = <String, double>{
+    for (final e in bySpr.entries) e.key: rate(e.value[0], e.value[1]),
+  };
+
+  final byTextureRates = SplayTreeMap<String, double>();
+  for (final e in byTextureCounts.entries) {
+    byTextureRates[e.key] = rate(e.value[0], e.value[1]);
+  }
+
+  final summary = {
+    'files': files,
+    'spots': spots,
+    'withJamFold': withJamFold,
+    'jamRate': rate(jamCount, withJamFold),
+    'bySPR': bySprRates,
+    'byTexture': byTextureRates,
+  };
+  print(jsonEncode(summary));
+}
+
+RegExp _globToRegExp(String pattern) {
+  var escaped = RegExp.escape(pattern);
+  escaped = escaped.replaceAll('\\*\\*', '::DOUBLE_STAR::');
+  escaped = escaped.replaceAll('\\*', '[^/]*');
+  escaped = escaped.replaceAll('::DOUBLE_STAR::', '.*');
+  return RegExp('^' + escaped + r'\$');
+}

--- a/test/ev/ev_summary_jam_fold_cli_test.dart
+++ b/test/ev/ev_summary_jam_fold_cli_test.dart
@@ -1,0 +1,151 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:collection';
+
+import 'package:test/test.dart';
+import 'package:poker_analyzer/services/board_texture_classifier.dart';
+
+import '../../bin/ev_summary_jam_fold.dart' as cli;
+
+Future<String> _writeReport(
+  Directory dir,
+  String name,
+  String board,
+  double spr,
+  String bestAction,
+) async {
+  final file = File('${dir.path}/$name.json');
+  final spot = {
+    'board': board,
+    'spr': spr,
+    'jamFold': {
+      'evJam': 1,
+      'evFold': 0,
+      'bestAction': bestAction,
+      'delta': bestAction == 'jam' ? 1 : -1,
+    },
+  };
+  final map = {
+    'spots': [spot],
+  };
+  await file.writeAsString(jsonEncode(map));
+  return file.path;
+}
+
+Future<String> _capturePrint(Future<void> Function() fn) async {
+  final buffer = StringBuffer();
+  await runZoned(
+    () async {
+      await fn();
+    },
+    zoneSpecification: ZoneSpecification(
+      print: (self, parent, zone, line) {
+        buffer.writeln(line);
+      },
+    ),
+  );
+  return buffer.toString();
+}
+
+void main() {
+  test('directory summary counts', () async {
+    final dir = await Directory.systemTemp.createTemp('ev_sum');
+    try {
+      await _writeReport(dir, 'a', 'AsKsQs', 0.8, 'jam');
+      await _writeReport(dir, 'b', 'Ah7d2c', 1.5, 'fold');
+      await _writeReport(dir, 'c', '9c8d7s', 2.5, 'jam');
+
+      final output = await _capturePrint(() async {
+        exitCode = 0;
+        await cli.main(['--dir', dir.path]);
+      });
+      expect(exitCode, 0);
+      final summary = jsonDecode(output.trim()) as Map<String, dynamic>;
+      expect(summary['files'], 3);
+      expect(summary['spots'], 3);
+      expect(summary['withJamFold'], 3);
+      expect(summary['jamRate'], closeTo(0.67, 0.01));
+      final bySpr = summary['bySPR'] as Map<String, dynamic>;
+      expect(bySpr['spr_low'], 1.0);
+      expect(bySpr['spr_mid'], 0.0);
+      expect(bySpr['spr_high'], 1.0);
+      final byTexture = summary['byTexture'] as Map<String, dynamic>;
+      expect(byTexture['wet'], 1.0);
+      expect(byTexture['dry'], 0.0);
+    } finally {
+      await dir.delete(recursive: true);
+    }
+  });
+
+  test('idempotent output', () async {
+    final dir = await Directory.systemTemp.createTemp('ev_sum_idem');
+    try {
+      await _writeReport(dir, 'a', 'AsKsQs', 0.8, 'jam');
+      final out1 = await _capturePrint(() async {
+        exitCode = 0;
+        await cli.main(['--dir', dir.path]);
+      });
+      final out2 = await _capturePrint(() async {
+        exitCode = 0;
+        await cli.main(['--dir', dir.path]);
+      });
+      expect(out1, out2);
+    } finally {
+      await dir.delete(recursive: true);
+    }
+  });
+
+  test('deterministic JSON output', () async {
+    final dir = await Directory.systemTemp.createTemp('ev_sum_det');
+    try {
+      await _writeReport(dir, 'a', 'AsKsQs', 0.8, 'jam');
+      await _writeReport(dir, 'b', 'Ah7d2c', 1.5, 'fold');
+      await _writeReport(dir, 'c', '9c8d7s', 2.5, 'jam');
+      final classifier = const BoardTextureClassifier();
+      final textureCounts = <String, List<int>>{};
+      final spots = [
+        {'board': 'AsKsQs', 'spr': 0.8, 'best': 'jam'},
+        {'board': 'Ah7d2c', 'spr': 1.5, 'best': 'fold'},
+        {'board': '9c8d7s', 'spr': 2.5, 'best': 'jam'},
+      ];
+      final bySpr = {
+        'spr_low': [1, 1],
+        'spr_mid': [0, 1],
+        'spr_high': [1, 1],
+      };
+      for (final s in spots) {
+        final tags = classifier.classify(s['board'] as String);
+        final isJam = s['best'] == 'jam';
+        for (final t in tags) {
+          final entry = textureCounts.putIfAbsent(t, () => [0, 0]);
+          entry[1]++;
+          if (isJam) entry[0]++;
+        }
+      }
+      double rate(int jam, int total) =>
+          total == 0 ? 0.0 : double.parse((jam / total).toStringAsFixed(2));
+      final byTexture = SplayTreeMap<String, double>();
+      for (final e in textureCounts.entries) {
+        byTexture[e.key] = rate(e.value[0], e.value[1]);
+      }
+      final expected = {
+        'files': 3,
+        'spots': 3,
+        'withJamFold': 3,
+        'jamRate': rate(2, 3),
+        'bySPR': {
+          for (final e in bySpr.entries) e.key: rate(e.value[0], e.value[1]),
+        },
+        'byTexture': byTexture,
+      };
+      final output = await _capturePrint(() async {
+        exitCode = 0;
+        await cli.main(['--dir', dir.path]);
+      });
+      expect(output.trim(), jsonEncode(expected));
+    } finally {
+      await dir.delete(recursive: true);
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- add `ev_summary_jam_fold.dart` CLI for aggregating jam/fold decisions with SPR and board texture breakdowns
- cover CLI with tests for counts, idempotence, and deterministic output
- document pack summary usage in README_DEV

## Testing
- `dart format bin/ev_summary_jam_fold.dart test/ev/ev_summary_jam_fold_cli_test.dart`
- `flutter pub get` *(fails: Failed to find the latest git commit date)*
- `dart test test/ev/ev_summary_jam_fold_cli_test.dart` *(fails: Flutter SDK is not available)*

------
https://chatgpt.com/codex/tasks/task_e_689d7d7d28a0832a92534851ec75cdc4