### PR TITLE
Guard pack summary CLI and fix path normalization

### DIFF
--- a/bin/ev_summary_jam_fold.dart
+++ b/bin/ev_summary_jam_fold.dart
@@ -112,7 +112,7 @@ Future<void> main(List<String> args) async {
           rel = rel.substring(1);
         }
       }
-      rel = rel.replaceAll('\\\\', '/');
+      rel = rel.replaceAll('\\', '/');
       if (regex.hasMatch(rel)) {
         await handle(entity.path);
       }

--- a/tool/dev/precommit_sanity.sh
+++ b/tool/dev/precommit_sanity.sh
@@ -12,7 +12,7 @@ if grep -R -q -e 'package:flutter/' -e 'dart:ui' lib/ev test/ev bin/ev*; then
   exit 1
 fi
 
-for file in bin/ev_enrich_jam_fold.dart bin/ev_report_jam_fold.dart; do
+for file in bin/ev_enrich_jam_fold.dart bin/ev_report_jam_fold.dart bin/ev_summary_jam_fold.dart; do
   if grep -R -q -e 'package:args' -e 'ArgParser' "$file"; then
     echo "$file must not depend on package:args."
     exit 1


### PR DESCRIPTION
## Summary
- Normalize Windows paths in `ev_summary_jam_fold.dart` by replacing single backslashes
- Extend `precommit_sanity.sh` guards to cover `ev_summary_jam_fold.dart`

## Testing
- `dart format -o write bin/ev_summary_jam_fold.dart` *(fails: dart not installed)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `bash tool/dev/precommit_sanity.sh` *(skipped: no Flutter SDK)*

------
https://chatgpt.com/codex/tasks/task_e_689d81bfaad4832a82512500e90ae1b8