### PR TITLE
test: decode summary result in e2e golden

### DIFF
--- a/test/ev/ev_end_to_end_golden_test.dart
+++ b/test/ev/ev_end_to_end_golden_test.dart
@@ -220,8 +220,9 @@ void main() {
         await ev_summary.main(['--dir', corpus.path]);
       });
       expect(summaryResult.code, 0);
+      final summaryJson = jsonDecode(summaryResult.out) as Map<String, dynamic>;
       final expected = await _expectedSummary(corpus);
-      expect(summaryResult.out, jsonEncode(expected));
+      expect(summaryJson, expected);
     } finally {
       await tmp.delete(recursive: true);
     }


### PR DESCRIPTION
## Summary
- decode summary CLI output to a JSON map before comparison

## Testing
- `bash tool/dev/precommit_sanity.sh`
- `dart test test/ev/ev_end_to_end_golden_test.dart` *(fails: Flutter SDK is not available)*
- `dart test test/ev/*` *(fails: Flutter SDK is not available)*

------
https://chatgpt.com/codex/tasks/task_e_689d95e050a0832aa7d7827b6faeca0b