### PR TITLE
refactor: clean up jam/fold golden test

### DIFF
--- a/test/ev/ev_end_to_end_golden_test.dart
+++ b/test/ev/ev_end_to_end_golden_test.dart
@@ -154,7 +154,7 @@ void main() {
     await corpus.create();
 
     try {
-      // Один формат кейсов: список списков (без records)
+      // Единый формат кейсов: список списков (без records)
       final List<List<dynamic>> cases = [
         ['As Ks', 'AhKhQd', 0.5],
         ['7c 2d', '7c5s2h', 0.8],
@@ -232,7 +232,7 @@ void main() {
       });
       expect(rSummary.code, 0);
       final expected = await _expectedSummary(corpus);
-      // Сравниваем строки JSON, чтобы избежать проблем с равенством Map по ссылке
+      // Сравниваем строки JSON для строгой детерминированности
       expect(rSummary.out, jsonEncode(expected));
     } finally {
       await tmp.delete(recursive: true);


### PR DESCRIPTION
## Summary
- simplify jam/fold end-to-end golden test

## Testing
- `dart test test/ev/ev_end_to_end_golden_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d9eb2e334832a85d03c4d9fb47a04