### PR TITLE
Add filters to jam/fold delta ranking CLI

### DIFF
--- a/README_DEV.md
+++ b/README_DEV.md
@@ -74,4 +74,10 @@ dart run bin/ev_rank_jam_fold_deltas.dart --dir reports/ --limit 10
 
 # rank by absolute impact
 dart run bin/ev_rank_jam_fold_deltas.dart --glob "reports/**/*.json" --abs-delta
+
+# top 50, only positive jams with delta >= 0.5
+dart run bin/ev_rank_jam_fold_deltas.dart --dir reports/ --limit 50 --action jam --min-delta 0.5
+
+# absolute impact >= 1.0 regardless of action
+dart run bin/ev_rank_jam_fold_deltas.dart --glob "reports/**/*.json" --abs-delta --min-delta 1.0
 ```

--- a/test/ev/ev_rank_jam_fold_cli_test.dart
+++ b/test/ev/ev_rank_jam_fold_cli_test.dart
@@ -40,6 +40,14 @@ Future<Directory> _buildCorpus() async {
   return dir;
 }
 
+Future<Directory> _buildThresholdCorpus() async {
+  final dir = await Directory.systemTemp.createTemp('ev_rank_cli_thresh');
+  await _writeReport(dir, 'a', delta: 0.2);
+  await _writeReport(dir, 'b', delta: 0.6);
+  await _writeReport(dir, 'c', delta: -0.9);
+  return dir;
+}
+
 Future<String> _capturePrint(Future<void> Function() fn) async {
   final buffer = StringBuffer();
   await runZoned(
@@ -124,6 +132,124 @@ void main() {
       expect(exitCode, 0);
       final list = jsonDecode(output.trim()) as List;
       expect(list.length, 5);
+    } finally {
+      await dir.delete(recursive: true);
+    }
+  });
+
+  test('min-delta filter uses raw delta', () async {
+    final dir = await _buildThresholdCorpus();
+    try {
+      final output = await _capturePrint(() async {
+        exitCode = 0;
+        await cli.main(['--dir', dir.path, '--min-delta', '0.5']);
+      });
+      expect(exitCode, 0);
+      final list = jsonDecode(output.trim()) as List;
+      expect(list.length, 1);
+      final first = list.first as Map<String, dynamic>;
+      expect((first['delta'] as num).toDouble(), 0.6);
+      expect((first['path'] as String).endsWith('b.json'), true);
+    } finally {
+      await dir.delete(recursive: true);
+    }
+  });
+
+  test('min-delta filter respects abs-delta', () async {
+    final dir = await _buildThresholdCorpus();
+    try {
+      final output = await _capturePrint(() async {
+        exitCode = 0;
+        await cli.main([
+          '--dir',
+          dir.path,
+          '--abs-delta',
+          '--min-delta',
+          '0.7',
+        ]);
+      });
+      expect(exitCode, 0);
+      final list = jsonDecode(output.trim()) as List;
+      expect(list.length, 1);
+      final first = list.first as Map<String, dynamic>;
+      expect((first['delta'] as num).toDouble(), -0.9);
+    } finally {
+      await dir.delete(recursive: true);
+    }
+  });
+
+  test('action filter', () async {
+    final dir = await _buildCorpus();
+    try {
+      final jamOut = await _capturePrint(() async {
+        exitCode = 0;
+        await cli.main(['--dir', dir.path, '--action', 'jam']);
+      });
+      expect(exitCode, 0);
+      final jamList = jsonDecode(jamOut.trim()) as List;
+      for (final spot in jamList) {
+        expect((spot as Map<String, dynamic>)['bestAction'], 'jam');
+      }
+
+      final foldOut = await _capturePrint(() async {
+        exitCode = 0;
+        await cli.main(['--dir', dir.path, '--action', 'fold']);
+      });
+      expect(exitCode, 0);
+      final foldList = jsonDecode(foldOut.trim()) as List;
+      for (final spot in foldList) {
+        expect((spot as Map<String, dynamic>)['bestAction'], 'fold');
+      }
+    } finally {
+      await dir.delete(recursive: true);
+    }
+  });
+
+  test('invalid args', () async {
+    final dir = await _buildCorpus();
+    try {
+      await _capturePrint(() async {
+        exitCode = 0;
+        await cli.main(['--dir', dir.path, '--min-delta', 'nope']);
+      });
+      expect(exitCode, 64);
+
+      await _capturePrint(() async {
+        exitCode = 0;
+        await cli.main(['--dir', dir.path, '--action', 'lol']);
+      });
+      expect(exitCode, 64);
+    } finally {
+      await dir.delete(recursive: true);
+    }
+  });
+
+  test('determinism with filters', () async {
+    final dir = await _buildCorpus();
+    try {
+      final run1 = await _capturePrint(() async {
+        exitCode = 0;
+        await cli.main([
+          '--dir',
+          dir.path,
+          '--action',
+          'jam',
+          '--min-delta',
+          '0.4',
+        ]);
+      });
+      final run2 = await _capturePrint(() async {
+        exitCode = 0;
+        await cli.main([
+          '--dir',
+          dir.path,
+          '--action',
+          'jam',
+          '--min-delta',
+          '0.4',
+        ]);
+      });
+      expect(run1, run2);
     } finally {
       await dir.delete(recursive: true);
     }


### PR DESCRIPTION
## Summary
- Support `--min-delta` and `--action` flags to threshold and scope jam/fold spots before sorting
- Document new filter usage in README_DEV
- Test min-delta (raw/abs), action filtering, invalid args, and deterministic output

## Testing
- `dart format -o write bin/ev_rank_jam_fold_deltas.dart test/ev/ev_rank_jam_fold_cli_test.dart`
- `bash tool/dev/precommit_sanity.sh`
- `dart test test/ev/ev_rank_jam_fold_cli_test.dart` *(fails: Flutter SDK is not available)*
- `dart test test/ev/*` *(fails: Flutter SDK is not available)*

------
https://chatgpt.com/codex/tasks/task_e_689da941b388832aba2a396e3ca16751