### PR TITLE
Add SPR bucket filter to delta ranking CLI

### DIFF
--- a/README_DEV.md
+++ b/README_DEV.md
@@ -80,6 +80,12 @@ dart run bin/ev_rank_jam_fold_deltas.dart --dir reports/ --limit 50 --action jam
 
 # absolute impact >= 1.0 regardless of action
 dart run bin/ev_rank_jam_fold_deltas.dart --glob "reports/**/*.json" --abs-delta --min-delta 1.0
+
+# Only low-SPR (<1) jams, ranked by delta
+dart run bin/ev_rank_jam_fold_deltas.dart --dir reports/ --spr low --action jam
+
+# Absolute impact on high-SPR (>=2) spots only
+dart run bin/ev_rank_jam_fold_deltas.dart --glob "reports/**/*.json" --spr high --abs-delta --min-delta 1.0
 ```
 
 Alternate output formats:

--- a/bin/ev_rank_jam_fold_deltas.dart
+++ b/bin/ev_rank_jam_fold_deltas.dart
@@ -9,6 +9,7 @@ Future<void> main(List<String> args) async {
   var absDelta = false;
   double? minDelta;
   var action = 'any';
+  var sprBucket = 'any';
   var format = 'json';
   List<String>? fields;
 
@@ -46,6 +47,17 @@ Future<void> main(List<String> args) async {
         return;
       }
       action = value;
+    } else if (arg == '--spr' && i + 1 < args.length) {
+      final value = args[++i];
+      if (value != 'low' &&
+          value != 'mid' &&
+          value != 'high' &&
+          value != 'any') {
+        stderr.writeln('Invalid --spr value: ' + value);
+        exitCode = 64;
+        return;
+      }
+      sprBucket = value;
     } else if (arg == '--abs-delta') {
       absDelta = true;
     } else if (arg == '--format' && i + 1 < args.length) {
@@ -192,6 +204,16 @@ Future<void> main(List<String> args) async {
     for (final p in paths) {
       await handle(p);
     }
+  }
+
+  if (sprBucket != 'any') {
+    spots.removeWhere((s) {
+      final spr = s['spr'] as double?;
+      if (spr == null) return true;
+      if (sprBucket == 'low') return !(spr < 1);
+      if (sprBucket == 'mid') return !(spr >= 1 && spr < 2);
+      return !(spr >= 2);
+    });
   }
 
   if (action != 'any') {


### PR DESCRIPTION
## Summary
- support `--spr` low|mid|high|any filtering prior to sorting
- document SPR-filtered ranking examples
- test SPR buckets and combination with other filters

## Testing
- `dart format -o write bin/ev_rank_jam_fold_deltas.dart test/ev/ev_rank_jam_fold_cli_test.dart`
- `bash tool/dev/precommit_sanity.sh`
- `dart test test/ev/ev_rank_jam_fold_cli_test.dart` *(fails: Flutter SDK not available)*
- `dart test test/ev/*` *(fails: Flutter SDK not available)*

------
https://chatgpt.com/codex/tasks/task_e_689dadd8cd3c832a970338a13ec43d59