### PR TITLE
Add unique-by deduplication to delta ranking CLI

### DIFF
--- a/README_DEV.md
+++ b/README_DEV.md
@@ -92,6 +92,17 @@ dart run bin/ev_rank_jam_fold_deltas.dart --dir reports/ --texture wet
 
 # Multiple tags: either 'wet' or 'paired'
 dart run bin/ev_rank_jam_fold_deltas.dart --glob "reports/**/*.json" --texture wet,paired --limit 50
+
+# One hottest spot per file
+dart run bin/ev_rank_jam_fold_deltas.dart --dir reports/ --unique-by path
+
+# One hottest per board across the tree (by absolute impact)
+dart run bin/ev_rank_jam_fold_deltas.dart --glob "reports/**/*.json" --abs-delta --unique-by board
+
+# Combine with filters & CSV
+dart run bin/ev_rank_jam_fold_deltas.dart \
+  --dir reports/ --spr mid --action jam --min-delta 0.5 \
+  --unique-by hand --format csv --fields path,hand,delta
 ```
 
 Alternate output formats:


### PR DESCRIPTION
## Summary
- support `--unique-by <none|path|hand|board>` in delta ranking CLI
- document new dedup examples
- test dedup by path, hand, board, null keys, invalid arg, and combo filters

## Testing
- `dart format -o write bin/ev_rank_jam_fold_deltas.dart test/ev/ev_rank_jam_fold_cli_test.dart`
- `bash tool/dev/precommit_sanity.sh`
- `dart test test/ev/ev_rank_jam_fold_cli_test.dart` *(fails: Flutter SDK not available)*
- `dart test test/ev/*` *(fails: Flutter SDK not available)*

------
https://chatgpt.com/codex/tasks/task_e_689db2b0a754832aa1b52f88578f9fd3