### PR TITLE
feat: cap delta rankings per group

### DIFF
--- a/README_DEV.md
+++ b/README_DEV.md
@@ -103,6 +103,18 @@ dart run bin/ev_rank_jam_fold_deltas.dart --glob "reports/**/*.json" --abs-delta
 dart run bin/ev_rank_jam_fold_deltas.dart \
   --dir reports/ --spr mid --action jam --min-delta 0.5 \
   --unique-by hand --format csv --fields path,hand,delta
+
+# Keep at most 2 hottest spots per file
+dart run bin/ev_rank_jam_fold_deltas.dart --dir reports/ --per path --per-limit 2
+
+# Top-3 per hand across the whole tree (by absolute impact)
+dart run bin/ev_rank_jam_fold_deltas.dart --glob "reports/**/*.json" --abs-delta --per hand --per-limit 3
+
+# Compose with filters & CSV
+dart run bin/ev_rank_jam_fold_deltas.dart \
+  --dir reports/ --spr mid --action jam --min-delta 0.5 \
+  --per board --per-limit 2 \
+  --format csv --fields path,board,delta
 ```
 
 Alternate output formats:


### PR DESCRIPTION
## Summary
- add --per and --per-limit flags to ev_rank_jam_fold_deltas.dart
- support per-group capping before dedupe/limit
- document CLI usage and cover with tests

## Testing
- `bash tool/dev/precommit_sanity.sh`
- `dart test test/ev/ev_rank_jam_fold_cli_test.dart` *(fails: Flutter SDK is not available)*
- `dart test test/ev/*` *(fails: Flutter SDK is not available)*

------
https://chatgpt.com/codex/tasks/task_e_689db4eeb5b4832a84a7d05e332df49f