### PR TITLE
feat: add street filter

### DIFF
--- a/README_DEV.md
+++ b/README_DEV.md
@@ -107,6 +107,15 @@ dart run bin/ev_rank_jam_fold_deltas.dart --dir reports/ --texture wet
 # Multiple tags: either 'wet' or 'paired'
 dart run bin/ev_rank_jam_fold_deltas.dart --glob "reports/**/*.json" --texture wet,paired --limit 50
 
+# Only flop spots, ranked by delta
+dart run bin/ev_rank_jam_fold_deltas.dart --dir reports/ --street flop
+
+# Turn-only with absolute impact and CSV fields
+dart run bin/ev_rank_jam_fold_deltas.dart \
+  --glob "reports/**/*.json" \
+  --street turn --abs-delta --min-delta 0.5 \
+  --format csv --fields path,board,delta
+
 # One hottest spot per file
 dart run bin/ev_rank_jam_fold_deltas.dart --dir reports/ --unique-by path
 


### PR DESCRIPTION
## Summary
- add manual `--street` flag to delta-ranking CLI
- document street filtering with usage examples
- test street filtering with hermetic corpora

## Testing
- `flutter test test/ev/ev_rank_jam_fold_cli_test.dart` *(fails: file_picker plugin has no inline implementation)*
- `dart test test/ev/ev_rank_jam_fold_cli_test.dart` *(fails: PathNotFoundException: Getting current working directory failed)*

------
https://chatgpt.com/codex/tasks/task_e_689dbc37cf4c832a902f366f01fab0bd