### PR TITLE
feat(cli): add hand filters to delta ranking

### DIFF
--- a/README_DEV.md
+++ b/README_DEV.md
@@ -95,6 +95,21 @@ dart run bin/ev_rank_jam_fold_deltas.dart \
   --include "packs/**" --exclude "packs/**/old/**" \
   --abs-delta --min-delta 1.0 --format csv --fields path,delta,bestAction
 
+# Only AK combos anywhere
+dart run bin/ev_rank_jam_fold_deltas.dart --dir reports/ --include-hand "A*s K*s,A*h K*h"
+
+# Include broad, then exclude suited broadways
+dart run bin/ev_rank_jam_fold_deltas.dart \
+  --glob "reports/**/*.json" \
+  --include-hand "A* K*,Q* J*" --exclude-hand "*s *s"
+
+# Compose with other filters & CSV
+dart run bin/ev_rank_jam_fold_deltas.dart \
+  --dir reports/ \
+  --include-hand "A* A*" \
+  --spr mid --action jam --abs-delta --min-delta 0.5 \
+  --format csv --fields path,hand,delta
+
 # Only low-SPR (<1) jams, ranked by delta
 dart run bin/ev_rank_jam_fold_deltas.dart --dir reports/ --spr low --action jam
 

--- a/bin/ev_rank_jam_fold_deltas.dart
+++ b/bin/ev_rank_jam_fold_deltas.dart
@@ -21,6 +21,8 @@ Future<void> main(List<String> args) async {
   List<String>? textures;
   List<String>? includes;
   List<String>? excludes;
+  List<String>? includeHands;
+  List<String>? excludeHands;
 
   for (var i = 0; i < args.length; i++) {
     final arg = args[i];
@@ -129,6 +131,34 @@ Future<void> main(List<String> args) async {
       }
       excludes ??= <String>[];
       excludes!.addAll(parts);
+    } else if (arg == '--include-hand' && i + 1 < args.length) {
+      final value = args[++i];
+      final parts = value
+          .split(',')
+          .map((s) => s.trim())
+          .where((s) => s.isNotEmpty)
+          .toList();
+      if (parts.isEmpty) {
+        stderr.writeln('Invalid --include-hand value: ' + value);
+        exitCode = 64;
+        return;
+      }
+      includeHands ??= <String>[];
+      includeHands!.addAll(parts);
+    } else if (arg == '--exclude-hand' && i + 1 < args.length) {
+      final value = args[++i];
+      final parts = value
+          .split(',')
+          .map((s) => s.trim())
+          .where((s) => s.isNotEmpty)
+          .toList();
+      if (parts.isEmpty) {
+        stderr.writeln('Invalid --exclude-hand value: ' + value);
+        exitCode = 64;
+        return;
+      }
+      excludeHands ??= <String>[];
+      excludeHands!.addAll(parts);
     } else if (arg == '--per' && i + 1 < args.length) {
       final value = args[++i];
       if (value != 'none' &&
@@ -319,6 +349,29 @@ Future<void> main(List<String> args) async {
       final p = s['path'] as String;
       for (final r in regs) {
         if (r.hasMatch(p)) return true;
+      }
+      return false;
+    });
+  }
+
+  if (includeHands != null) {
+    final regs = includeHands!.map(_globToRegExp).toList();
+    spots.removeWhere((s) {
+      final h = s['hand'] as String?;
+      if (h == null) return true;
+      for (final r in regs) {
+        if (r.hasMatch(h)) return false;
+      }
+      return true;
+    });
+  }
+  if (excludeHands != null) {
+    final regs = excludeHands!.map(_globToRegExp).toList();
+    spots.removeWhere((s) {
+      final h = s['hand'] as String?;
+      if (h == null) return false;
+      for (final r in regs) {
+        if (r.hasMatch(h)) return true;
       }
       return false;
     });


### PR DESCRIPTION
## Summary
- add `--include-hand`/`--exclude-hand` glob filters to delta ranking CLI
- document hand filter usage examples
- test hand filtering behavior and error cases

## Testing
- `dart format bin/ev_rank_jam_fold_deltas.dart test/ev/ev_rank_jam_fold_cli_test.dart`
- `flutter test test/ev/ev_rank_jam_fold_cli_test.dart` *(fails: The current Dart SDK version is 3.4.3... lottie ^3.3.1 is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689dbf28e72c832a96d8a1c9d13517b3