### PR TITLE
Clarify glob case sensitivity and test null hand filtering

### DIFF
--- a/README_DEV.md
+++ b/README_DEV.md
@@ -110,6 +110,9 @@ dart run bin/ev_rank_jam_fold_deltas.dart \
   --spr mid --action jam --abs-delta --min-delta 0.5 \
   --format csv --fields path,hand,delta
 
+> **Note:** Hand and path glob matching is **case-sensitive** (same as `_globToRegExp`).
+> The examples assume uppercase ranks and lowercase suits (e.g., `As Ks`, `*s *s`).
+
 # Only low-SPR (<1) jams, ranked by delta
 dart run bin/ev_rank_jam_fold_deltas.dart --dir reports/ --spr low --action jam
 


### PR DESCRIPTION
## Summary
- document case-sensitive glob matching in README_DEV
- add tests ensuring null-hand semantics for include/exclude hand filters

## Testing
- `dart format test/ev/ev_rank_jam_fold_cli_test.dart` *(fails: command not found)*
- `dart test test/ev/ev_rank_jam_fold_cli_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dc29e9e94832ab7f3896bca91dc43