### PR TITLE
docs: note shell globbing and tighten null-hand tests

### DIFF
--- a/README_DEV.md
+++ b/README_DEV.md
@@ -112,6 +112,7 @@ dart run bin/ev_rank_jam_fold_deltas.dart \
 
 > **Note:** Hand and path glob matching is **case-sensitive** (same as `_globToRegExp`).
 > The examples assume uppercase ranks and lowercase suits (e.g., `As Ks`, `*s *s`).
+> **Shell globbing:** quote patterns to avoid expansion by your shell (e.g., `--include-hand '* *'`). Use single quotes on macOS/Linux and PowerShell; on cmd.exe, escape `*` or use double quotes where no files match.
 
 # Only low-SPR (<1) jams, ranked by delta
 dart run bin/ev_rank_jam_fold_deltas.dart --dir reports/ --spr low --action jam

--- a/test/ev/ev_rank_jam_fold_cli_test.dart
+++ b/test/ev/ev_rank_jam_fold_cli_test.dart
@@ -187,7 +187,7 @@ Future<Directory> _buildNullHandCorpus() async {
     {
       'spr': 1.0,
       'jamFold': {'evJam': 0.5, 'evFold': 0, 'bestAction': 'jam', 'delta': 0.5},
-    }
+    },
   ]);
   // Spot with a concrete hand
   await _writeReportMulti(dir, 'ak', [
@@ -585,7 +585,10 @@ void main() {
       });
       expect(exitCode, 0);
       final list = jsonDecode(out.trim()) as List;
-      final hands = list.map((e) => (e as Map<String, dynamic>)['hand']).toList();
+      final hands = list
+          .map((e) => (e as Map<String, dynamic>)['hand'])
+          .toList();
+      expect(list.length, 1);
       expect(hands.contains(null), false);
       expect(hands.contains('As Ks'), true);
       Directory.current = prev;
@@ -605,8 +608,11 @@ void main() {
       });
       expect(exitCode, 0);
       final list = jsonDecode(out.trim()) as List;
-      final hands = list.map((e) => (e as Map<String, dynamic>)['hand']).toList();
+      final hands = list
+          .map((e) => (e as Map<String, dynamic>)['hand'])
+          .toList();
       // All non-null hands with a space are excluded; null should remain.
+      expect(list.length, 1);
       expect(hands.contains(null), true);
       expect(hands.contains('As Ks'), false);
       Directory.current = prev;


### PR DESCRIPTION
## Summary
- mention shell globbing to prevent hand filter patterns from being expanded by the shell
- assert single row remains in null-hand include/exclude tests

## Testing
- `flutter test` *(fails: The current Dart SDK version is 3.3.4 ... lottie ^3.3.1 requires SDK version ^3.6.0)*
- `dart tools/validate_training_content.dart --ci` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689dc403524c832a9efe401699b82459