### PR TITLE
Replace curly apostrophes with ASCII equivalents

### DIFF
--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -50,12 +50,12 @@ import 'app_localizations_ru.dart';
 ///
 /// iOS applications define key application metadata, including supported
 /// locales, in an Info.plist file that is built into the application bundle.
-/// To configure the locales supported by your app, you’ll need to edit this
+/// To configure the locales supported by your app, you'll need to edit this
 /// file.
 ///
-/// First, open your project’s ios/Runner.xcworkspace Xcode workspace file.
+/// First, open your project's ios/Runner.xcworkspace Xcode workspace file.
 /// Then, in the Project Navigator, open the Info.plist file under the Runner
-/// project’s Runner folder.
+/// project's Runner folder.
 ///
 /// Next, select the Information Property List item, select Add Item from the
 /// Editor menu, then select Localizations from the pop-up menu.

--- a/lib/services/lesson_reminder_scheduler.dart
+++ b/lib/services/lesson_reminder_scheduler.dart
@@ -52,7 +52,7 @@ class LessonReminderScheduler {
 
     await _plugin.zonedSchedule(
       _id,
-      '\uD83C\uDFC6 Don’t forget your daily poker training!',
+      '\uD83C\uDFC6 Don't forget your daily poker training!',
       'Complete your 5 hands and keep your streak alive \uD83D\uDD25',
       when,
       const NotificationDetails(


### PR DESCRIPTION
## Summary
- Replace remaining curly apostrophes in localization docs and reminder scheduler string with ASCII equivalents

## Testing
- `dart format lib/l10n/app_localizations.dart lib/services/lesson_reminder_scheduler.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dca9cc374832aa48e71a9f9a2ed09