### PR TITLE
fix: escape lesson reminder apostrophe

### DIFF
--- a/lib/services/lesson_reminder_scheduler.dart
+++ b/lib/services/lesson_reminder_scheduler.dart
@@ -52,7 +52,7 @@ class LessonReminderScheduler {
 
     await _plugin.zonedSchedule(
       _id,
-      '\uD83C\uDFC6 Don't forget your daily poker training!',
+      "\uD83C\uDFC6 Don't forget your daily poker training!",
       'Complete your 5 hands and keep your streak alive \uD83D\uDD25',
       when,
       const NotificationDetails(


### PR DESCRIPTION
## Summary
- use double quotes for lesson reminder message to avoid unescaped apostrophe

## Testing
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689dcbbc05e8832a8d9af9d38b28de66