### PR TITLE
fix: document help flag and use resolved dart in tests

### DIFF
--- a/bin/ev_rank_jam_fold_deltas.dart
+++ b/bin/ev_rank_jam_fold_deltas.dart
@@ -7,6 +7,9 @@ const _USAGE = r'''
 Usage:
   dart run bin/ev_rank_jam_fold_deltas.dart [INPUT] [FILTERS] [RANKING] [OUTPUT]
 
+GENERAL:
+  --help | -h                       # print this help and exit
+
 INPUT (pick exactly one):
   --in <file.json>
   --dir <dir>

--- a/test/ev/ev_rank_jam_fold_cli_help_test.dart
+++ b/test/ev/ev_rank_jam_fold_cli_help_test.dart
@@ -3,10 +3,12 @@ import 'package:test/test.dart';
 
 void main() {
   test('--help prints usage', () async {
-    final result = await Process.run(
-      'dart',
-      ['run', 'bin/ev_rank_jam_fold_deltas.dart', '--help'],
-    );
+    final dart = Platform.resolvedExecutable;
+    final result = await Process.run(dart, [
+      'run',
+      'bin/ev_rank_jam_fold_deltas.dart',
+      '--help',
+    ]);
     expect(result.exitCode, 0);
     final stdoutStr = result.stdout as String;
     expect(stdoutStr, contains('Usage:'));
@@ -15,10 +17,12 @@ void main() {
   });
 
   test('-h prints usage', () async {
-    final result = await Process.run(
-      'dart',
-      ['run', 'bin/ev_rank_jam_fold_deltas.dart', '-h'],
-    );
+    final dart = Platform.resolvedExecutable;
+    final result = await Process.run(dart, [
+      'run',
+      'bin/ev_rank_jam_fold_deltas.dart',
+      '-h',
+    ]);
     expect(result.exitCode, 0);
     final stdoutStr = result.stdout as String;
     expect(stdoutStr, contains('Usage:'));


### PR DESCRIPTION
## Summary
- document `--help` flag in CLI usage text
- run CLI help tests with the resolved Dart executable for portability

## Testing
- `git grep -n -P "[\x{2018}\x{2019}\x{201c}\x{201d}\x{2014}\x{2026}]" -- bin/ev_rank_jam_fold_deltas.dart test/ev/ev_rank_jam_fold_cli_help_test.dart`
- `dart test test/ev/ev_rank_jam_fold_cli_help_test.dart` *(fails: Flutter SDK is not available)*

------
https://chatgpt.com/codex/tasks/task_e_689dd1dcd89c832aba144e9c66466da9