### PR TITLE
Handle missing input args and test combined help

### DIFF
--- a/bin/ev_rank_jam_fold_deltas.dart
+++ b/bin/ev_rank_jam_fold_deltas.dart
@@ -284,7 +284,12 @@ Future<void> main(List<String> args) async {
   }
 
   final modes = [inPath, dirPath, glob].whereType<String>();
-  if (modes.length != 1) {
+  if (modes.isEmpty) {
+    stderr.writeln('No input specified. Pass --in, --dir, or --glob. See --help.');
+    exitCode = 64;
+    return;
+  }
+  if (modes.length > 1) {
     stderr.writeln('Specify exactly one of --in, --dir, or --glob');
     exitCode = 64;
     return;

--- a/test/ev/ev_rank_jam_fold_cli_help_test.dart
+++ b/test/ev/ev_rank_jam_fold_cli_help_test.dart
@@ -27,4 +27,18 @@ void main() {
     final stdoutStr = result.stdout as String;
     expect(stdoutStr, contains('Usage:'));
   });
+
+  test('--help works with extra args', () async {
+    final dart = Platform.resolvedExecutable;
+    final result = await Process.run(dart, [
+      'run',
+      'bin/ev_rank_jam_fold_deltas.dart',
+      '--help',
+      '--dir',
+      '.',
+    ]);
+    expect(result.exitCode, 0);
+    final stdoutStr = result.stdout as String;
+    expect(stdoutStr, contains('Usage:'));
+  });
 }


### PR DESCRIPTION
## Summary
- warn when no input source is provided to the CLI
- add test ensuring --help works even with other flags

## Testing
- `./tool/dev/precommit_sanity.sh` *(fails: dart: command not found)*
- `sudo apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_689dd3834030832a80c8409271d5e838