### PR TITLE
refactor: avoid non-null assertion on customLabel

### DIFF
--- a/lib/helpers/training_pack_validator.dart
+++ b/lib/helpers/training_pack_validator.dart
@@ -14,7 +14,7 @@ List<String> _extractBoard(TrainingPackSpot s) => [
       for (final street in [1, 2, 3])
         for (final a in s.hand.actions[street] ?? [])
           if (a.action == 'board' && a.customLabel?.isNotEmpty == true)
-            ...a.customLabel!.split(' ')
+            ...(a.customLabel?.split(' ') ?? [])
     ];
 
 final List<SpotRule> spotRules = [


### PR DESCRIPTION
## Summary
- ensure null-safe splitting of custom labels in training pack validator

## Testing
- `dart format lib/helpers/training_pack_validator.dart` *(fails: command not found)*
- `dart analyze lib/helpers/training_pack_validator.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e620cd8bc832abe20034718bbaafe