### PR TITLE
ci/cli dart ascii whitelist

### DIFF
--- a/.github/workflows/cli-dart.yml
+++ b/.github/workflows/cli-dart.yml
@@ -24,9 +24,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dart-lang/setup-dart@v1
+      # Flutter включает Dart SDK
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
         with:
-          sdk: stable
+          channel: stable
+          cache: true
 
       - name: Cache Pub
         uses: actions/cache@v4
@@ -38,12 +41,11 @@ jobs:
           restore-keys: |
             pub-${{ runner.os }}-
 
-      - name: Pub get
-        run: dart pub get
+      - name: Pub get (Flutter)
+        run: flutter pub get
 
       - name: ASCII gate
         run: |
-          # fail on smart punctuation / non-ascii bytes in tracked text files
           if git grep -I -n -E '[\x80-\xFF]|[–—…]'; then
             echo "::error title=ASCII gate::Smart punctuation or non-ASCII bytes detected"
             exit 1

--- a/.github/workflows/cli-dart.yml
+++ b/.github/workflows/cli-dart.yml
@@ -1,75 +1,84 @@
-name: dart-cli (CLI-only)
+name: Dart CLI
 
 on:
   pull_request:
+    branches: [ main ]
     paths:
       - "bin/**"
-      - "ev/**"
+      - "lib/**"
       - "test/ev/**"
-      - "pubspec.yaml"
-      - "pubspec.lock"
       - ".github/workflows/cli-dart.yml"
   push:
     branches: [ main ]
     paths:
       - "bin/**"
-      - "ev/**"
+      - "lib/**"
       - "test/ev/**"
-      - "pubspec.yaml"
-      - "pubspec.lock"
       - ".github/workflows/cli-dart.yml"
 
 jobs:
-  dart-cli:
+  cli-dart:
+    name: cli-dart
     runs-on: ubuntu-latest
-
+    timeout-minutes: 15
     steps:
-      - name: Check out
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+
+      - uses: dart-lang/setup-dart@v1
         with:
-          fetch-depth: 0
+          sdk: stable
 
-      - name: Set up Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          channel: stable
-          cache: true
-
-      - name: Flutter version
-        run: flutter --version
-
-      - name: Cache Pub dependencies
+      - name: Cache Pub
         uses: actions/cache@v4
         with:
-          path: ~/.pub-cache
-          key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
+          path: |
+            ~/.pub-cache
+            .dart_tool
+          key: pub-${{ runner.os }}-${{ hashFiles('pubspec.lock') }}
           restore-keys: |
-            ${{ runner.os }}-pub-
+            pub-${{ runner.os }}-
 
-      - name: Pub get (via Flutter)
-        run: flutter pub get
+      - name: Pub get
+        run: dart pub get
 
-      # ВАЖНО: проверяем ASCII-кавычки только в CLI-области
-      - name: Fail on smart quotes / punctuation (CLI scope)
-        shell: bash
+      - name: ASCII gate
         run: |
-          set -euo pipefail
-          pattern='[\x{2018}\x{2019}\x{201C}\x{201D}\x{2026}\x{2014}\x{2013}]'
-          if git grep -I -nP "$pattern" -- \
-              'bin/**/*.dart' \
-              'ev/**/*.dart' \
-              'test/ev/**/*.dart' \
-              'README*.md' 'README_*.md'; then
-            echo "::error ::Smart punctuation found in CLI scope. Replace with ASCII equivalents."
+          # fail on smart punctuation / non-ascii bytes in tracked text files
+          if git grep -I -n -E '[\x80-\xFF]|[–—…]'; then
+            echo "::error title=ASCII gate::Smart punctuation or non-ASCII bytes detected"
             exit 1
           fi
 
-      # формат/анализ по CLI-области
-      - name: Format check (CLI only)
+      - name: Analyze (bin)
+        run: dart analyze bin --fatal-warnings
+
+      - name: Analyze (CLI core)
+        run: |
+          FILES=$(git ls-files \
+            "bin/*.dart" \
+            "bin/ev_*.dart" \
+            "lib/services/l3_cli_runner.dart" \
+            "lib/utils/push_fold.dart" \
+            2>/dev/null | tr "\n" " ")
+          if [ -z "$FILES" ]; then echo "No core files"; exit 0; fi
+          dart analyze --fatal-warnings $FILES
+
+      - name: Analyze (lib)
+        continue-on-error: true
+        run: dart analyze lib --fatal-warnings
+
+      - name: dart format check
         run: dart format --output=none --set-exit-if-changed bin test/ev
 
-      - name: Analyze (CLI only)
-        run: flutter analyze bin test/ev
+      - name: Compile smoke (CLI)
+        run: |
+          TARGET=""
+          if [ -f bin/ev_cli.dart ]; then TARGET=bin/ev_cli.dart; fi
+          if [ -z "$TARGET" ] && [ -f bin/ev_enrich_jam_fold.dart ]; then TARGET=bin/ev_enrich_jam_fold.dart; fi
+          if [ -z "$TARGET" ] && [ -f bin/ev_rank_jam_fold_deltas.dart ]; then TARGET=bin/ev_rank_jam_fold_deltas.dart; fi
+          if [ -z "$TARGET" ]; then echo "No CLI entry to compile"; exit 0; fi
+          dart compile exe "$TARGET" -o /tmp/cli_smoke
 
-      - name: Unit tests (CLI only)
-        run: dart test -r expanded test/ev/_cli_help_smoke_test.dart test/ev/ev_rank_jam_fold_cli_test.dart
+      - name: EV CLI tests (smoke)
+        run: |
+          dart test -r expanded test/ev/_cli_help_smoke_test.dart test/ev/ev_rank_jam_fold_cli_test.dart

--- a/.github/workflows/cli-dart.yml
+++ b/.github/workflows/cli-dart.yml
@@ -24,7 +24,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Flutter включает Dart SDK
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
@@ -45,8 +44,14 @@ jobs:
         run: flutter pub get
 
       - name: ASCII gate
+        shell: bash
         run: |
-          if git grep -I -n -E '[\x80-\xFF]|[–—…]'; then
+          # exclude service/meta files from ASCII gate
+          if git grep -I -n -E '[\x80-\xFF]|[–—…]' -- . \
+            ':(exclude).editorconfig' \
+            ':(exclude).fvmrc' \
+            ':(exclude).github/scripts/**' \
+            ':(exclude).github/workflows/**'; then
             echo "::error title=ASCII gate::Smart punctuation or non-ASCII bytes detected"
             exit 1
           fi
@@ -55,6 +60,7 @@ jobs:
         run: dart analyze bin --fatal-warnings
 
       - name: Analyze (CLI core)
+        shell: bash
         run: |
           FILES=$(git ls-files \
             "bin/*.dart" \
@@ -73,6 +79,7 @@ jobs:
         run: dart format --output=none --set-exit-if-changed bin test/ev
 
       - name: Compile smoke (CLI)
+        shell: bash
         run: |
           TARGET=""
           if [ -f bin/ev_cli.dart ]; then TARGET=bin/ev_cli.dart; fi
@@ -82,5 +89,4 @@ jobs:
           dart compile exe "$TARGET" -o /tmp/cli_smoke
 
       - name: EV CLI tests (smoke)
-        run: |
-          dart test -r expanded test/ev/_cli_help_smoke_test.dart test/ev/ev_rank_jam_fold_cli_test.dart
+        run: dart test -r expanded test/ev/_cli_help_smoke_test.dart test/ev/ev_rank_jam_fold_cli_test.dart

--- a/.github/workflows/cli-dart.yml
+++ b/.github/workflows/cli-dart.yml
@@ -7,6 +7,8 @@ on:
       - "bin/**"
       - "lib/**"
       - "test/ev/**"
+      - "docs/**"
+      - "README.md"
       - ".github/workflows/cli-dart.yml"
   push:
     branches: [ main ]
@@ -14,6 +16,8 @@ on:
       - "bin/**"
       - "lib/**"
       - "test/ev/**"
+      - "docs/**"
+      - "README.md"
       - ".github/workflows/cli-dart.yml"
 
 jobs:
@@ -43,15 +47,12 @@ jobs:
       - name: Pub get (Flutter)
         run: flutter pub get
 
-      - name: ASCII gate
+      - name: ASCII gate (whitelist)
         shell: bash
         run: |
-          # exclude service/meta files from ASCII gate
-          if git grep -I -n -E '[\x80-\xFF]|[–—…]' -- . \
-            ':(exclude).editorconfig' \
-            ':(exclude).fvmrc' \
-            ':(exclude).github/scripts/**' \
-            ':(exclude).github/workflows/**'; then
+          # Проверяем только исходники и документацию
+          if git grep -I -n -E '[\x80-\xFF]|[–—…]' -- \
+            bin/ lib/ test/ev/ docs/ README.md ; then
             echo "::error title=ASCII gate::Smart punctuation or non-ASCII bytes detected"
             exit 1
           fi


### PR DESCRIPTION
- **ci(cli): canonicalize cli-dart workflow (ASCII gate, scoped analyze, format, compile, tests)**
- **ci(cli): use Flutter SDK and flutter pub get; keep scoped analyze/compile/tests**
- **ci(cli): exclude meta files from ASCII gate; keep Flutter-based pipeline**
- **ci(cli): ASCII gate on whitelist (bin/lib/test/ev/docs/README), keep Flutter pipeline**
