### PR TITLE
L2: Limped-response pack generator (MVS) + CLI

### DIFF
--- a/lib/l2/autogen_v1/limped_response_generator.dart
+++ b/lib/l2/autogen_v1/limped_response_generator.dart
@@ -1,0 +1,233 @@
+import 'dart:math';
+
+/// Player positions for limped spots.
+enum Pos { utg, mp, co, btn, sb, bb }
+
+/// Stack size buckets in big blinds.
+enum StackBin { bb5, bb10, bb15, bb20 }
+
+/// Number of limpers before hero.
+enum Limpers { one, multi }
+
+/// Available actions for limped spots.
+enum LimpAction { iso, overlimp, fold }
+
+/// Immutable limped spot description.
+class LimpSpot {
+  final String hand;
+  final Pos pos;
+  final StackBin stack;
+  final Limpers limpers;
+  final LimpAction action;
+  const LimpSpot({
+    required this.hand,
+    required this.pos,
+    required this.stack,
+    required this.limpers,
+    required this.action,
+  });
+
+  @override
+  bool operator ==(Object other) {
+    return other is LimpSpot &&
+        other.hand == hand &&
+        other.pos == pos &&
+        other.stack == stack &&
+        other.limpers == limpers &&
+        other.action == action;
+  }
+
+  @override
+  int get hashCode => Object.hash(hand, pos, stack, limpers, action);
+
+  @override
+  String toString() =>
+      '$hand ${pos.name} ${stack.name} ${limpers.name} ${action.name}';
+}
+
+/// Mix configuration for generation.
+class L2LimpMix {
+  final Map<Pos, double> posPct;
+  final Map<StackBin, double> stackPct;
+  final Map<Limpers, double> limpersPct;
+  const L2LimpMix({
+    required this.posPct,
+    required this.stackPct,
+    required this.limpersPct,
+  });
+
+  static const L2LimpMix _mvs = L2LimpMix(
+    posPct: {
+      Pos.utg: 0.10,
+      Pos.mp: 0.20,
+      Pos.co: 0.25,
+      Pos.btn: 0.25,
+      Pos.sb: 0.10,
+      Pos.bb: 0.10,
+    },
+    stackPct: {
+      StackBin.bb5: 0.25,
+      StackBin.bb10: 0.25,
+      StackBin.bb15: 0.25,
+      StackBin.bb20: 0.25,
+    },
+    limpersPct: {
+      Limpers.one: 0.60,
+      Limpers.multi: 0.40,
+    },
+  );
+
+  static L2LimpMix mvsDefault() => _mvs;
+}
+
+const _handPool = [
+  'AA',
+  'KK',
+  'QQ',
+  'JJ',
+  'TT',
+  '99',
+  '88',
+  '77',
+  'AKs',
+  'AQs',
+  'AJs',
+  'ATs',
+  'KQs',
+  'KJs',
+  'QJs',
+  'JTs',
+  'T9s',
+  '98s',
+  '87s',
+  'AJo',
+  'KQo',
+  'QJo',
+  'A9s',
+  'KTs',
+  'A5s',
+  '76s',
+  '65s',
+  '22',
+  '33',
+  '44',
+  '55',
+  'A4s',
+  'A3s',
+  'A2s',
+];
+
+const _isoHands = {
+  'AJo',
+  'KQo',
+  'KJs',
+  'KQs',
+  'QJs',
+  'TT',
+  'JJ',
+  'QQ',
+  'KK',
+  'AA',
+  'A5s',
+  'KTs',
+};
+
+const _overlimpHands = {
+  '22',
+  '33',
+  '44',
+  '55',
+  '66',
+  '77',
+  '88',
+  '99',
+  'T9s',
+  '98s',
+  '87s',
+  '76s',
+  '65s',
+  'A9s',
+  'A8s',
+  'A7s',
+  'A6s',
+  'A5s',
+  'A4s',
+  'A3s',
+  'A2s',
+  'KTs',
+  'QTs',
+  'JTs',
+};
+
+List<LimpSpot> generateLimpSpots({
+  required int seed,
+  required int count,
+  required L2LimpMix mix,
+}) {
+  final rand = Random(seed);
+  final items = <LimpSpot>[];
+  final used = <String>{};
+
+  final posQuota = _buildQuotas(mix.posPct, count, Pos.values);
+  final stackQuota = _buildQuotas(mix.stackPct, count, StackBin.values);
+  final limpQuota = _buildQuotas(mix.limpersPct, count, Limpers.values);
+
+  while (items.length < count && used.length < 100000) {
+    final hand = _handPool[rand.nextInt(_handPool.length)];
+    final pos = _pickWithQuota(rand, posQuota, Pos.values);
+    final stack = _pickWithQuota(rand, stackQuota, StackBin.values);
+    final limpers = _pickWithQuota(rand, limpQuota, Limpers.values);
+    final key = '$hand|${pos.name}|${stack.name}|${limpers.name}';
+    if (used.contains(key)) continue;
+    final action = _decide(hand, pos, limpers);
+    items.add(LimpSpot(
+      hand: hand,
+      pos: pos,
+      stack: stack,
+      limpers: limpers,
+      action: action,
+    ));
+    used.add(key);
+  }
+
+  return items;
+}
+
+LimpAction _decide(String hand, Pos pos, Limpers limpers) {
+  if ({Pos.co, Pos.btn, Pos.sb}.contains(pos) && _isoHands.contains(hand)) {
+    return LimpAction.iso;
+  }
+  if (limpers == Limpers.multi && _overlimpHands.contains(hand)) {
+    return LimpAction.overlimp;
+  }
+  return LimpAction.fold;
+}
+
+Map<T, int> _buildQuotas<T>(Map<T, double> pct, int total, List<T> order) {
+  final quotas = <T, int>{};
+  var remaining = total;
+  for (var i = 0; i < order.length; i++) {
+    final v = order[i];
+    final q = i == order.length - 1
+        ? remaining
+        : (total * (pct[v] ?? 0)).round();
+    quotas[v] = q;
+    remaining -= q;
+  }
+  return quotas;
+}
+
+T _pickWithQuota<T>(Random rand, Map<T, int> quota, List<T> order) {
+  var choice = order[rand.nextInt(order.length)];
+  if ((quota[choice] ?? 0) > 0) {
+    quota[choice] = quota[choice]! - 1;
+    return choice;
+  }
+  for (final v in order) {
+    if ((quota[v] ?? 0) > 0) {
+      quota[v] = quota[v]! - 1;
+      return v;
+    }
+  }
+  return order.first;
+}

--- a/lib/l2/autogen_v1/limped_spot_pack.dart
+++ b/lib/l2/autogen_v1/limped_spot_pack.dart
@@ -1,0 +1,88 @@
+import 'dart:convert';
+
+import 'limped_response_generator.dart';
+
+class LimpDTO {
+  final String hand;
+  final String pos;
+  final String stack;
+  final String limpers;
+  final String action;
+  const LimpDTO({
+    required this.hand,
+    required this.pos,
+    required this.stack,
+    required this.limpers,
+    required this.action,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'hand': hand,
+        'pos': pos,
+        'stack': stack,
+        'limpers': limpers,
+        'action': action,
+      };
+}
+
+class LimpPack {
+  final String version;
+  final int seed;
+  final int count;
+  final L2LimpMix mix;
+  final List<LimpDTO> items;
+  const LimpPack({
+    required this.version,
+    required this.seed,
+    required this.count,
+    required this.mix,
+    required this.items,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'version': version,
+        'seed': seed,
+        'count': count,
+        'mix': {
+          'posPct': {
+            for (final e in mix.posPct.entries) e.key.name: e.value,
+          },
+          'stackPct': {
+            for (final e in mix.stackPct.entries) e.key.name: e.value,
+          },
+          'limpersPct': {
+            for (final e in mix.limpersPct.entries) e.key.name: e.value,
+          },
+        },
+        'items': [for (final i in items) i.toJson()],
+      };
+}
+
+LimpPack buildLimpPack({
+  required int seed,
+  required int count,
+  required L2LimpMix mix,
+}) {
+  final spots = generateLimpSpots(seed: seed, count: count, mix: mix);
+  return LimpPack(
+    version: 'v1',
+    seed: seed,
+    count: count,
+    mix: mix,
+    items: [
+      for (final s in spots)
+        LimpDTO(
+          hand: s.hand,
+          pos: s.pos.name,
+          stack: s.stack.name,
+          limpers: s.limpers.name,
+          action: s.action.name,
+        )
+    ],
+  );
+}
+
+String encodeLimpPackCompact(LimpPack pack) => jsonEncode(pack.toJson());
+
+String encodeLimpPackPretty(LimpPack pack) =>
+    const JsonEncoder.withIndent('  ').convert(pack.toJson());

--- a/tool/l2/autogen_v1_limped_pack_cli.dart
+++ b/tool/l2/autogen_v1_limped_pack_cli.dart
@@ -1,0 +1,45 @@
+import 'dart:io';
+
+import 'package:poker_analyzer/l2/autogen_v1/limped_spot_pack.dart';
+
+void main(List<String> args) {
+  final opts = <String, String>{};
+  for (var i = 0; i < args.length; i++) {
+    var a = args[i];
+    if (a.startsWith('--')) {
+      a = a.substring(2);
+      final eq = a.indexOf('=');
+      if (eq != -1) {
+        opts[a.substring(0, eq)] = a.substring(eq + 1);
+      } else if (i + 1 < args.length && !args[i + 1].startsWith('--')) {
+        opts[a] = args[++i];
+      } else {
+        opts[a] = 'true';
+      }
+    }
+  }
+
+  final seedStr = opts['seed'];
+  final countStr = opts['count'] ?? '40';
+  final preset = opts['preset'] ?? 'mvs';
+  final format = opts['format'] ?? 'compact';
+
+  final seed = seedStr != null ? int.tryParse(seedStr) : null;
+  final count = int.tryParse(countStr);
+  if (seed == null || count == null || preset != 'mvs' ||
+      (format != 'compact' && format != 'pretty')) {
+    _usage();
+    exit(2);
+  }
+
+  final mix = L2LimpMix.mvsDefault();
+  final pack = buildLimpPack(seed: seed, count: count, mix: mix);
+  final json =
+      format == 'pretty' ? encodeLimpPackPretty(pack) : encodeLimpPackCompact(pack);
+  stdout.write(json);
+}
+
+void _usage() {
+  stderr.writeln(
+      'Usage: dart run tool/l2/autogen_v1_limped_pack_cli.dart --seed <int> [--count <int>] [--preset mvs] [--format compact|pretty]');
+}


### PR DESCRIPTION
## Summary
- Add seed-deterministic limped-pot generator and pack builder with simple iso/overlimp/fold heuristics
- Provide CLI to emit JSON limped-response packs for the MVS preset

## Testing
- `dart format lib/l2/autogen_v1/limped_response_generator.dart lib/l2/autogen_v1/limped_spot_pack.dart tool/l2/autogen_v1_limped_pack_cli.dart` *(command not found)*
- `dart analyze lib/l2/autogen_v1/limped_response_generator.dart lib/l2/autogen_v1/limped_spot_pack.dart tool/l2/autogen_v1_limped_pack_cli.dart` *(command not found)*
- `dart run tool/l2/autogen_v1_limped_pack_cli.dart --seed 2027 --count 40 --preset mvs --format compact` *(command not found)*

## Risks
- Pure Dart under lib/l2/** and tool/l2/**; no new deps; uses simple, deterministic heuristics (late-pos iso set, multi-limp overlimp set); no UI/i18n/CI changes.


------
https://chatgpt.com/codex/tasks/task_e_689e9c4e95b8832a82e6a43491d259e5