### PR TITLE
Cross: training feed v1 (L2+L3) JSON + CLI (MVS)

### DIFF
--- a/lib/cross/feed.dart
+++ b/lib/cross/feed.dart
@@ -1,0 +1,39 @@
+import 'dart:convert';
+
+class FeedItem {
+  final String kind;
+  final String file;
+  final int count;
+  final String version;
+
+  const FeedItem({
+    required this.kind,
+    required this.file,
+    required this.count,
+    this.version = 'v1',
+  });
+
+  Map<String, dynamic> toJson() => {
+    'kind': kind,
+    'file': file,
+    'count': count,
+    'version': version,
+  };
+}
+
+class TrainingFeed {
+  final String version;
+  final List<FeedItem> items;
+
+  const TrainingFeed({this.version = 'v1', required this.items});
+
+  Map<String, dynamic> toJson() => {
+    'version': version,
+    'items': items.map((e) => e.toJson()).toList(),
+  };
+}
+
+String encodeFeedCompact(TrainingFeed f) => jsonEncode(f.toJson());
+
+String encodeFeedPretty(TrainingFeed f) =>
+    const JsonEncoder.withIndent('  ').convert(f.toJson());

--- a/tool/cross/build_feed.dart
+++ b/tool/cross/build_feed.dart
@@ -1,0 +1,104 @@
+import 'dart:convert';
+import 'dart:io';
+
+import '../../lib/cross/feed.dart';
+
+void main(List<String> args) {
+  String? l2Arg;
+  String? l3Arg;
+  var format = 'compact';
+  var outDir = 'out/feed';
+  var name = 'feed_v1.json';
+
+  for (final arg in args) {
+    if (arg.startsWith('--l2=')) {
+      l2Arg = arg.substring(5);
+    } else if (arg.startsWith('--l3=')) {
+      l3Arg = arg.substring(5);
+    } else if (arg.startsWith('--format=')) {
+      final v = arg.substring(9);
+      if (v == 'compact' || v == 'pretty') {
+        format = v;
+      } else {
+        _usage();
+      }
+    } else if (arg.startsWith('--out=')) {
+      outDir = arg.substring(6);
+    } else if (arg.startsWith('--name=')) {
+      name = arg.substring(7);
+    }
+  }
+
+  final l2Files = l2Arg == null || l2Arg.isEmpty
+      ? <String>[]
+      : l2Arg.split(',').where((e) => e.isNotEmpty).toList();
+  final l3Files = l3Arg == null || l3Arg.isEmpty
+      ? <String>[]
+      : l3Arg.split(',').where((e) => e.isNotEmpty).toList();
+
+  if (l2Files.isEmpty && l3Files.isEmpty) {
+    _usage();
+  }
+
+  final items = <FeedItem>[];
+  var l2Count = 0;
+  var l3Count = 0;
+
+  for (final path in l2Files) {
+    final file = File(path);
+    if (!file.existsSync()) {
+      stderr.writeln('missing file: $path');
+      exit(2);
+    }
+    final data = jsonDecode(file.readAsStringSync());
+    final count = (data['items'] is List) ? (data['items'] as List).length : 0;
+    items.add(
+      FeedItem(kind: 'l2_session', file: path, count: count, version: 'v1'),
+    );
+    l2Count++;
+  }
+
+  for (final path in l3Files) {
+    final file = File(path);
+    if (!file.existsSync()) {
+      stderr.writeln('missing file: $path');
+      exit(2);
+    }
+    final data = jsonDecode(file.readAsStringSync());
+    var count = 0;
+    if (data['inlineItems'] is List) {
+      count = (data['inlineItems'] as List).length;
+    } else if (data['items'] is List) {
+      count = (data['items'] as List).length;
+    }
+    items.add(
+      FeedItem(kind: 'l3_session', file: path, count: count, version: 'v1'),
+    );
+    l3Count++;
+  }
+
+  items.sort((a, b) => a.file.compareTo(b.file));
+  final feed = TrainingFeed(version: 'v1', items: items);
+
+  final dir = Directory(outDir);
+  if (!dir.existsSync()) {
+    dir.createSync(recursive: true);
+  }
+  final outPath = outDir.endsWith('/') ? '$outDir$name' : '$outDir/$name';
+  final json = format == 'pretty'
+      ? encodeFeedPretty(feed)
+      : encodeFeedCompact(feed);
+  File(outPath).writeAsStringSync(json);
+
+  final total = items.length;
+  stdout.writeln(
+    'wrote feed name=$name items=$total l2=$l2Count l3=$l3Count format=$format',
+  );
+}
+
+void _usage() {
+  stdout.writeln(
+    'usage: --l2 a.json,b.json [--l3 c.json,d.json] [--format compact|pretty] [--out dir] [--name file]',
+  );
+  exit(2);
+}


### PR DESCRIPTION
## Summary
- implement `FeedItem`/`TrainingFeed` models and JSON encoders
- add zero-dependency `build_feed.dart` CLI to build deterministic training feed

## Testing
- `dart format lib/cross/feed.dart tool/cross/build_feed.dart`
- `dart analyze lib/cross/feed.dart tool/cross/build_feed.dart`
- `dart tool/cross/build_feed.dart --l2=/tmp/l2a.json --l3=/tmp/l3a.json --out=/tmp --name=feed.json --format=pretty`
- `dart test` *(fails: Flutter SDK is not available)*

------
https://chatgpt.com/codex/tasks/task_e_689e9fbcb378832aacf6654ca2a9fa0e