### PR TITLE
Cross: add L4 sessions to feed/build/pack/loader (MVS)

### DIFF
--- a/lib/cross/runtime_loader.dart
+++ b/lib/cross/runtime_loader.dart
@@ -4,7 +4,7 @@
 import 'dart:convert';
 import 'dart:io';
 
-enum FeedKind { l2_session, l3_session }
+enum FeedKind { l2_session, l3_session, l4_session }
 
 class LoadedSession {
   final FeedKind kind;
@@ -63,6 +63,9 @@ LoadedBundle loadTrainingBundle({
       case 'l3_session':
         kind = FeedKind.l3_session;
         break;
+      case 'l4_session':
+        kind = FeedKind.l4_session;
+        break;
       default:
         throw const FormatException('unknown kind');
     }
@@ -76,11 +79,13 @@ LoadedBundle loadTrainingBundle({
     int count;
     if (kind == FeedKind.l2_session) {
       count = _asList(sessionMap['items']).length;
-    } else {
+    } else if (kind == FeedKind.l3_session) {
       final inline = _asList(sessionMap['inlineItems']);
       count = inline.isNotEmpty
           ? inline.length
           : _asList(sessionMap['items']).length;
+    } else {
+      count = _asList(sessionMap['items']).length;
     }
 
     loaded.add(LoadedSession(kind: kind, path: path, count: count));

--- a/tool/cross/pack_training_library.dart
+++ b/tool/cross/pack_training_library.dart
@@ -68,6 +68,7 @@ void main(List<String> args) {
   final files = <Map<String, dynamic>>[];
   var l2 = 0;
   var l3 = 0;
+  var l4 = 0;
 
   for (final ref in refs) {
     final src = File(ref.path);
@@ -91,6 +92,8 @@ void main(List<String> args) {
       l2++;
     } else if (ref.kind == 'l3_session') {
       l3++;
+    } else if (ref.kind == 'l4_session') {
+      l4++;
     }
   }
 
@@ -108,7 +111,7 @@ void main(List<String> args) {
       .writeAsStringSync(encoder.convert(index));
 
   stdout.writeln(
-    'packed training_v1 out=$outDir files=${files.length} l2=$l2 l3=$l3 layout=$layout',
+    'packed training_v1 out=$outDir files=${files.length} l2=$l2 l3=$l3 l4=$l4 layout=$layout',
   );
 }
 

--- a/tool/cross/print_feed_summary.dart
+++ b/tool/cross/print_feed_summary.dart
@@ -17,9 +17,10 @@ void main(List<String> args) {
     final sessions = bundle.sessions;
     final l2 = sessions.where((s) => s.kind == FeedKind.l2_session).length;
     final l3 = sessions.where((s) => s.kind == FeedKind.l3_session).length;
+    final l4 = sessions.where((s) => s.kind == FeedKind.l4_session).length;
     final total = totalItems(bundle);
     stdout.writeln(
-      'bundle ${bundle.version} ok: sessions=${sessions.length} total=$total l2=$l2 l3=$l3',
+      'bundle ${bundle.version} ok: sessions=${sessions.length} total=$total l2=$l2 l3=$l3 l4=$l4',
     );
     for (var i = 0; i < sessions.length; i++) {
       final s = sessions[i];


### PR DESCRIPTION
## Summary
- Extend cross-layer tools to accept L4 ICM session manifests alongside L2/L3, updating feed/build, packer, and runtime loader for end-to-end app consumption.

## Testing
- `dart format tool/cross/build_feed.dart lib/cross/runtime_loader.dart tool/cross/pack_training_library.dart tool/cross/print_feed_summary.dart` *(fails: command not found: dart)*
- `dart analyze` *(fails: command not found: dart)*
- `dart test` *(fails: command not found: dart)*

## Risks
- Pure Dart; tiny diffs in cross/** only; backward compatible (L2/L3 unaffected); main risk is arg/usage churn, mitigated by keeping flags additive and preserving sort/order.


------
https://chatgpt.com/codex/tasks/task_e_689eacd35090832ab58adab121a421ac