### PR TITLE
Cross: deterministic play-plan builder CLI (MVS)

### DIFF
--- a/tool/cross/build_play_plan.dart
+++ b/tool/cross/build_play_plan.dart
@@ -1,6 +1,5 @@
-import 'dart:convert';
 import 'dart:io';
-
+import '../../lib/cross/feed_fs.dart';
 import '../../lib/cross/play_plan.dart';
 
 void main(List<String> args) {
@@ -52,59 +51,20 @@ void main(List<String> args) {
     exit(2);
   }
 
-  final feedData = jsonDecode(feedFile.readAsStringSync());
-  if (feedData is! Map || feedData['items'] is! List) {
-    stderr.writeln('invalid feed: $feedPath');
-    exit(2);
-  }
-  final itemsData = feedData['items'] as List;
-
-  final planItems = <PlayPlanItem>[];
+  final refs = readFeedRefs(feedFile);
+  final plan = buildPlayPlan(refs, target: target, maxSlices: maxSlices);
   var l2Count = 0;
   var l3Count = 0;
   var l4Count = 0;
-
-  outer:
-  for (final item in itemsData) {
-    if (item is! Map) {
-      continue;
-    }
-    final kind = item['kind'] as String? ?? '';
-    final file = item['file'] as String? ?? '';
-    final total = item['count'] is int
-        ? item['count'] as int
-        : int.tryParse('${item['count']}') ?? 0;
-    var start = 0;
-    var remaining = total;
-    while (remaining > 0) {
-      final take = remaining < target ? remaining : target;
-      final idInput = '$kind|$file|$start|$take';
-      final id = _h32(idInput);
-      planItems.add(
-        PlayPlanItem(
-          id: id,
-          kind: kind,
-          file: file,
-          start: start,
-          count: take,
-        ),
-      );
-      if (kind == 'l2_session') {
-        l2Count++;
-      } else if (kind == 'l3_session') {
-        l3Count++;
-      } else if (kind == 'l4_session') {
-        l4Count++;
-      }
-      if (maxSlices > 0 && planItems.length >= maxSlices) {
-        break outer;
-      }
-      start += take;
-      remaining -= take;
+  for (final item in plan.items) {
+    if (item.kind == 'l2_session') {
+      l2Count++;
+    } else if (item.kind == 'l3_session') {
+      l3Count++;
+    } else if (item.kind == 'l4_session') {
+      l4Count++;
     }
   }
-
-  final plan = PlayPlan(items: planItems);
 
   final dir = Directory(outDir);
   if (!dir.existsSync()) {
@@ -115,18 +75,9 @@ void main(List<String> args) {
       format == 'pretty' ? encodePlayPlanPretty(plan) : encodePlayPlanCompact(plan);
   File(outPath).writeAsStringSync(json);
 
-  stdout.writeln(
-      'wrote plan name=$name slices=${planItems.length} target=$target from feed=$feedPath kinds=l2:$l2Count l3:$l3Count l4:$l4Count');
-}
-
-String _h32(String s) {
-  const int prime = 0x01000193;
-  var hash = 0x811c9dc5;
-  for (var i = 0; i < s.length; i++) {
-    hash ^= s.codeUnitAt(i);
-    hash = (hash * prime) & 0xffffffff;
-  }
-  return hash.toRadixString(16).padLeft(8, '0');
+  stdout.writeln('wrote plan name=$name slices=${plan.items.length} '
+      'target=$target from feed=$feedPath '
+      'kinds=l2:$l2Count l3:$l3Count l4:$l4Count');
 }
 
 void _usage() {


### PR DESCRIPTION
## Summary
- Slice L2/L3/L4 sessions from feed.json into fixed-size, ordered play units with stable IDs so the app can run a daily plan immediately.

## Testing
- `dart format lib/cross/play_plan.dart tool/cross/build_play_plan.dart` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `dart analyze lib/cross tool/cross` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689eb231b710832aa772250c9abe0326