### PR TITLE
Use stable hash IDs for play plan slices

### DIFF
--- a/lib/cross/play_plan.dart
+++ b/lib/cross/play_plan.dart
@@ -1,6 +1,8 @@
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'feed_fs.dart';
+import 'hash32.dart';
 
 class PlayPlanItem {
   final String id;
@@ -54,12 +56,10 @@ PlayPlan buildPlayPlan(
   for (final ref in refs) {
     var remaining = ref.count;
     var start = 0;
-    var index = 0;
-    final baseId = normFileName(ref.path);
     while (remaining > 0) {
       final take = remaining < target ? remaining : target;
-      final idx = index.toString().padLeft(4, '0');
-      final id = '${baseId}_$idx';
+      final input = '${ref.kind}|${ref.path}|$start|$take';
+      final id = fnv32Hex(Uint8List.fromList(utf8.encode(input)));
       items.add(
         PlayPlanItem(
           id: id,
@@ -75,7 +75,6 @@ PlayPlan buildPlayPlan(
       }
       start += take;
       remaining -= take;
-      index++;
     }
   }
 

--- a/tool/cross/build_play_plan.dart
+++ b/tool/cross/build_play_plan.dart
@@ -52,6 +52,10 @@ void main(List<String> args) {
   }
 
   final refs = readFeedRefs(feedFile);
+  if (refs.isEmpty) {
+    stderr.writeln('invalid or empty feed: $feedPath');
+    exit(2);
+  }
   final plan = buildPlayPlan(refs, target: target, maxSlices: maxSlices);
   var l2Count = 0;
   var l3Count = 0;


### PR DESCRIPTION
## Summary
- generate deterministic slice IDs using FNV-1a hash
- validate feed file before building play plan

## Testing
- `dart format lib/cross/play_plan.dart tool/cross/build_play_plan.dart` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689eb39115fc832a9589132b3ec4da71