### PR TITLE
chore: remove unused dart:convert import

### DIFF
--- a/lib/generated/pack_library.g.dart
+++ b/lib/generated/pack_library.g.dart
@@ -1,7 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-import 'dart:convert';
-
 import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
 
 final Map<String, List<TrainingPackSpot>> packLibrary = {};


### PR DESCRIPTION
## Summary
- tidy up generated pack library by dropping unused dart:convert import

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ebb5edee0832aa339a76c52a652bd