### PR TITLE
chore: suppress unused import in generated pack library

### DIFF
--- a/lib/generated/pack_library.g.dart
+++ b/lib/generated/pack_library.g.dart
@@ -1,5 +1,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: unused_import
 
+import 'dart:convert';
 import 'package:poker_analyzer/models/v2/training_pack_spot.dart';
 
 final Map<String, List<TrainingPackSpot>> packLibrary = {};

--- a/lib/services/pack_library_generator_service.dart
+++ b/lib/services/pack_library_generator_service.dart
@@ -14,7 +14,7 @@ class PackLibraryGeneratorService {
   final TrainingPackTemplateCompiler _compiler;
 
   const PackLibraryGeneratorService({TrainingPackTemplateCompiler? compiler})
-      : _compiler = compiler ?? const TrainingPackTemplateCompiler();
+    : _compiler = compiler ?? const TrainingPackTemplateCompiler();
 
   /// Compiles [paths] and writes the resulting map to [outPath].
   Future<void> generate(
@@ -25,6 +25,7 @@ class PackLibraryGeneratorService {
     final keys = grouped.keys.toList()..sort();
     final buffer = StringBuffer()
       ..writeln('// GENERATED CODE - DO NOT MODIFY BY HAND')
+      ..writeln('// ignore_for_file: unused_import')
       ..writeln('')
       ..writeln("import 'dart:convert';")
       ..writeln(


### PR DESCRIPTION
## Summary
- suppress `unused_import` lint in generated pack_library files

## Testing
- `dart format lib/services/pack_library_generator_service.dart lib/generated/pack_library.g.dart`
- `dart analyze`
- `flutter test` *(fails: package file_picker missing inline implementation, many missing files)*

------
https://chatgpt.com/codex/tasks/task_e_689ec2d2ec24832a821c4274290b4c8b