### PR TITLE
fix: correct generator initializer and ignore long lines

### DIFF
--- a/lib/generated/pack_library.g.dart
+++ b/lib/generated/pack_library.g.dart
@@ -1,5 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: unused_import
+// ignore_for_file: unused_import, lines_longer_than_80_chars
 
 import 'dart:convert';
 import 'package:poker_analyzer/models/v2/training_pack_spot.dart';

--- a/lib/services/pack_library_generator_service.dart
+++ b/lib/services/pack_library_generator_service.dart
@@ -14,7 +14,7 @@ class PackLibraryGeneratorService {
   final TrainingPackTemplateCompiler _compiler;
 
   const PackLibraryGeneratorService({TrainingPackTemplateCompiler? compiler})
-    : _compiler = compiler ?? const TrainingPackTemplateCompiler();
+      : _compiler = compiler ?? const TrainingPackTemplateCompiler();
 
   /// Compiles [paths] and writes the resulting map to [outPath].
   Future<void> generate(
@@ -25,7 +25,9 @@ class PackLibraryGeneratorService {
     final keys = grouped.keys.toList()..sort();
     final buffer = StringBuffer()
       ..writeln('// GENERATED CODE - DO NOT MODIFY BY HAND')
-      ..writeln('// ignore_for_file: unused_import')
+      ..writeln(
+        '// ignore_for_file: unused_import, lines_longer_than_80_chars',
+      )
       ..writeln('')
       ..writeln("import 'dart:convert';")
       ..writeln(


### PR DESCRIPTION
## Summary
- remove duplicated initializer in `PackLibraryGeneratorService`
- suppress long-line lint for generated pack library code

## Testing
- `dart analyze` *(fails: command not found: dart)*
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_689ec479e3b8832aa7b69a7ba3daf7c4