### PR TITLE
Add session decoders and runners

### DIFF
--- a/lib/ui/session_player/decoders.dart
+++ b/lib/ui/session_player/decoders.dart
@@ -1,0 +1,67 @@
+import 'dart:convert';
+
+import 'models.dart';
+
+List<UiSpot> decodeL2SessionJson(String jsonStr) {
+  final root = jsonDecode(jsonStr);
+  final items = root['items'] as List? ?? [];
+  final spots = <UiSpot>[];
+  for (final raw in items) {
+    if (raw is! Map) continue;
+    final kind = raw['kind'];
+    final SpotKind? spotKind;
+    switch (kind) {
+      case 'open_fold':
+        spotKind = SpotKind.l2_open_fold;
+        break;
+      case 'threebet_push':
+        spotKind = SpotKind.l2_threebet_push;
+        break;
+      case 'limped':
+        spotKind = SpotKind.l2_limped;
+        break;
+      default:
+        continue;
+    }
+    spots.add(UiSpot(
+      kind: spotKind,
+      hand: '${raw['hand']}',
+      pos: '${raw['pos']}',
+      stack: '${raw['stack']}',
+      action: '${raw['action']}',
+      vsPos: raw['vsPos']?.toString(),
+      limpers: raw['limpers']?.toString(),
+    ));
+  }
+  return spots;
+}
+
+List<UiSpot> decodeL4IcmSessionJson(String jsonStr) {
+  final root = jsonDecode(jsonStr);
+  final items = root['items'] as List? ?? [];
+  final spots = <UiSpot>[];
+  for (final raw in items) {
+    if (raw is! Map) continue;
+    spots.add(UiSpot(
+      kind: SpotKind.l4_icm,
+      hand: '${raw['hand']}',
+      pos: '${raw['heroPos']}',
+      stack: '${raw['stackBb']}',
+      action: '${raw['action']}',
+    ));
+  }
+  return spots;
+}
+
+String detectSessionKind(Map root) {
+  final items = root['items'];
+  if (items is List && items.isNotEmpty) {
+    final first = items.first;
+    if (first is Map) {
+      if (first.containsKey('kind')) return 'l2';
+      if (first.containsKey('heroPos') && first.containsKey('stackBb')) return 'l4';
+    }
+  }
+  return 'unknown';
+}
+

--- a/lib/ui/session_player/file_runner.dart
+++ b/lib/ui/session_player/file_runner.dart
@@ -1,0 +1,45 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+
+import 'decoders.dart';
+import 'mvs_player.dart';
+import 'models.dart';
+
+class PlayFromFilePage extends StatelessWidget {
+  final String path;
+  const PlayFromFilePage({super.key, required this.path});
+
+  Future<List<UiSpot>> _load() async {
+    final jsonStr = await File(path).readAsString();
+    final root = jsonDecode(jsonStr);
+    final kind = detectSessionKind(root);
+    switch (kind) {
+      case 'l2':
+        return decodeL2SessionJson(jsonStr);
+      case 'l4':
+        return decodeL4IcmSessionJson(jsonStr);
+      default:
+        throw Exception('unknown session kind');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<List<UiSpot>>(
+      future: _load(),
+      builder: (context, snap) {
+        if (snap.connectionState != ConnectionState.done) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        if (snap.hasError) {
+          return Center(child: Text('Error: ${snap.error}'));
+        }
+        final spots = snap.data ?? [];
+        return MvsSessionPlayer(spots: spots);
+      },
+    );
+  }
+}
+

--- a/lib/ui/session_player/plan_runner.dart
+++ b/lib/ui/session_player/plan_runner.dart
@@ -1,0 +1,149 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+
+import 'decoders.dart';
+import 'mvs_player.dart';
+import 'models.dart';
+
+class PlanSlice {
+  final String id;
+  final String kind;
+  final String file;
+  final int start;
+  final int count;
+  const PlanSlice({
+    required this.id,
+    required this.kind,
+    required this.file,
+    required this.start,
+    required this.count,
+  });
+}
+
+Future<List<PlanSlice>> loadPlanSlices({required String planPath}) async {
+  final jsonStr = await File(planPath).readAsString();
+  final root = jsonDecode(jsonStr);
+  final items = root['items'] as List? ?? [];
+  final slices = <PlanSlice>[];
+  for (final raw in items) {
+    if (raw is! Map) continue;
+    final start = raw['start'];
+    final count = raw['count'];
+    slices.add(PlanSlice(
+      id: '${raw['id']}',
+      kind: '${raw['kind']}',
+      file: '${raw['file']}',
+      start: start is int ? start : int.tryParse('$start') ?? 0,
+      count: count is int ? count : int.tryParse('$count') ?? 0,
+    ));
+  }
+  return slices;
+}
+
+Future<List<UiSpot>> loadSliceSpots({
+  required Directory bundleDir,
+  required PlanSlice slice,
+}) async {
+  if (slice.kind == 'l3_session') {
+    // TODO: implement L3 decoding
+    return [];
+  }
+  final path = slice.file.startsWith('/')
+      ? slice.file
+      : '${bundleDir.path}/${slice.file}';
+  final jsonStr = await File(path).readAsString();
+  List<UiSpot> spots;
+  switch (slice.kind) {
+    case 'l2_session':
+      spots = decodeL2SessionJson(jsonStr);
+      break;
+    case 'l4_session':
+      spots = decodeL4IcmSessionJson(jsonStr);
+      break;
+    default:
+      spots = [];
+  }
+  var start = slice.start;
+  if (start < 0) start = 0;
+  if (start > spots.length) start = spots.length;
+  var end = slice.count <= 0 ? spots.length : start + slice.count;
+  if (end > spots.length) end = spots.length;
+  return spots.sublist(start, end);
+}
+
+class PlayFromPlanPage extends StatefulWidget {
+  final String planPath;
+  final String bundleDir;
+  const PlayFromPlanPage({super.key, required this.planPath, required this.bundleDir});
+
+  @override
+  State<PlayFromPlanPage> createState() => _PlayFromPlanPageState();
+}
+
+class _PlayFromPlanPageState extends State<PlayFromPlanPage> {
+  late Future<List<PlanSlice>> _future;
+
+  @override
+  void initState() {
+    super.initState();
+    _future = loadPlanSlices(planPath: widget.planPath);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<List<PlanSlice>>(
+      future: _future,
+      builder: (context, snap) {
+        if (snap.connectionState != ConnectionState.done) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        if (snap.hasError) {
+          return Center(child: Text('Error: ${snap.error}'));
+        }
+        final slices = snap.data ?? [];
+        return ListView(
+          children: [
+            for (final slice in slices)
+              ListTile(
+                title: Text(slice.id),
+                subtitle: Text('${slice.kind} · ${slice.count}'),
+                trailing: TextButton(
+                  onPressed: () async {
+                    try {
+                      final spots = await loadSliceSpots(
+                        bundleDir: Directory(widget.bundleDir),
+                        slice: slice,
+                      );
+                      if (spots.isEmpty) {
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          const SnackBar(content: Text('No spots')),
+                        );
+                        return;
+                      }
+                      if (!context.mounted) return;
+                      Navigator.of(context).push(
+                        MaterialPageRoute(
+                          builder: (_) => Scaffold(
+                            body: MvsSessionPlayer(spots: spots),
+                          ),
+                        ),
+                      );
+                    } catch (e) {
+                      if (!context.mounted) return;
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(content: Text('Error: $e')),
+                      );
+                    }
+                  },
+                  child: const Text('Play'),
+                ),
+              ),
+          ],
+        );
+      },
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- add JSON decoders for L2 and L4 ICM session manifests and a helper to detect session kind
- add PlayFromFilePage to load a manifest and launch MvsSessionPlayer
- add plan runner with PlanSlice model and helpers to play slices from a bundle

## Testing
- `dart format lib/ui/session_player/decoders.dart lib/ui/session_player/file_runner.dart lib/ui/session_player/plan_runner.dart` *(fails: command not found)*
- `flutter format lib/ui/session_player/decoders.dart lib/ui/session_player/file_runner.dart lib/ui/session_player/plan_runner.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f127f49f8832ab377061da587224b