### PR TITLE
feat: add quickstart launcher and dev menu

### DIFF
--- a/lib/ui/session_player/dev_menu.dart
+++ b/lib/ui/session_player/dev_menu.dart
@@ -1,0 +1,74 @@
+// Example:
+// Navigator.of(context).push(MaterialPageRoute(
+//   builder: (_) => const DevMenuPage(),
+// ));
+
+import 'package:flutter/material.dart';
+
+import 'demo_seed.dart';
+import 'mvs_player.dart';
+import 'plan_runner.dart';
+import 'quickstart_launcher.dart';
+
+class DevMenuPage extends StatelessWidget {
+  const DevMenuPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Dev menu')),
+      body: ListView(
+        children: [
+          ListTile(
+            title: const Text('Play demo spots'),
+            onTap: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (_) =>
+                      Scaffold(body: MvsSessionPlayer(spots: demoSpots())),
+                ),
+              );
+            },
+          ),
+          ListTile(
+            title: const Text('Quickstart launcher'),
+            onTap: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (_) => const QuickstartLauncherPage(),
+                ),
+              );
+            },
+          ),
+          ListTile(
+            title: const Text('Quickstart (defaults)'),
+            onTap: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (_) => const PlayFromPlanPage(
+                    planPath: 'out/plan/play_plan_v1.json',
+                    bundleDir: 'dist/training_v1',
+                  ),
+                ),
+              );
+            },
+          ),
+          ListTile(
+            title: const Text('Play manifest (enter path)'),
+            onTap: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (_) => const QuickstartLauncherPage(
+                    initialManifest:
+                        'out/l4_sessions/session_icm_v1_mvs_k1_n20.json',
+                  ),
+                ),
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}
+

--- a/lib/ui/session_player/quickstart_launcher.dart
+++ b/lib/ui/session_player/quickstart_launcher.dart
@@ -1,0 +1,133 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+
+import 'file_runner.dart';
+import 'plan_runner.dart';
+
+class QuickstartLauncherPage extends StatefulWidget {
+  final String? initialPlan;
+  final String? initialBundle;
+  final String? initialManifest;
+  const QuickstartLauncherPage({
+    super.key,
+    this.initialPlan,
+    this.initialBundle,
+    this.initialManifest,
+  });
+
+  @override
+  State<QuickstartLauncherPage> createState() => _QuickstartLauncherPageState();
+}
+
+class _QuickstartLauncherPageState extends State<QuickstartLauncherPage> {
+  late final TextEditingController _planCtrl;
+  late final TextEditingController _bundleCtrl;
+  late final TextEditingController _manifestCtrl;
+
+  @override
+  void initState() {
+    super.initState();
+    _planCtrl = TextEditingController(
+      text: widget.initialPlan ?? 'out/plan/play_plan_v1.json',
+    );
+    _bundleCtrl = TextEditingController(
+      text: widget.initialBundle ?? 'dist/training_v1',
+    );
+    _manifestCtrl = TextEditingController(
+      text: widget.initialManifest ?? '',
+    );
+  }
+
+  @override
+  void dispose() {
+    _planCtrl.dispose();
+    _bundleCtrl.dispose();
+    _manifestCtrl.dispose();
+    super.dispose();
+  }
+
+  void _openPlan() {
+    final plan = _planCtrl.text.trim();
+    final bundle = _bundleCtrl.text.trim();
+    if (!File(plan).existsSync()) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Plan not found')),
+      );
+      return;
+    }
+    if (!Directory(bundle).existsSync()) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Bundle dir not found')),
+      );
+      return;
+    }
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => PlayFromPlanPage(
+          planPath: plan,
+          bundleDir: bundle,
+        ),
+      ),
+    );
+  }
+
+  void _playManifest() {
+    final manifest = _manifestCtrl.text.trim();
+    if (!File(manifest).existsSync()) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Manifest not found')),
+      );
+      return;
+    }
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => PlayFromFilePage(path: manifest),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Quickstart')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: ListView(
+          children: [
+            TextField(
+              controller: _planCtrl,
+              decoration: const InputDecoration(
+                labelText: 'Plan path',
+                hintText: 'out/plan/play_plan_v1.json',
+              ),
+            ),
+            TextField(
+              controller: _bundleCtrl,
+              decoration: const InputDecoration(
+                labelText: 'Bundle dir',
+                hintText: 'dist/training_v1',
+              ),
+            ),
+            ElevatedButton(
+              onPressed: _openPlan,
+              child: const Text('Open plan slices'),
+            ),
+            const Divider(),
+            TextField(
+              controller: _manifestCtrl,
+              decoration: const InputDecoration(
+                labelText: 'Manifest path',
+              ),
+            ),
+            ElevatedButton(
+              onPressed: _playManifest,
+              child: const Text('Play manifest'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- add quickstart launcher to run plan+bundle or manifest files
- add developer menu to access demo spots and quickstart helpers

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f14033fd4832aa295c0be4680bbfb