### PR TITLE
feat: unify L3 session decoding

### DIFF
--- a/lib/ui/session_player/decoders.dart
+++ b/lib/ui/session_player/decoders.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io';
 
 import 'models.dart';
 
@@ -53,13 +54,77 @@ List<UiSpot> decodeL4IcmSessionJson(String jsonStr) {
   return spots;
 }
 
+Future<List<UiSpot>> decodeL3SessionJson(String jsonStr,
+    {required String baseDir}) async {
+  final root = jsonDecode(jsonStr);
+  final spots = <UiSpot>[];
+  final inlineItems = root['inlineItems'];
+  if (inlineItems is List) {
+    for (final raw in inlineItems) {
+      if (raw is! Map) continue;
+      final kind = raw['kind'];
+      SpotKind? spotKind;
+      switch (kind) {
+        case 'open_fold':
+          spotKind = SpotKind.l2_open_fold;
+          break;
+        case 'threebet_push':
+          spotKind = SpotKind.l2_threebet_push;
+          break;
+        case 'limped':
+          spotKind = SpotKind.l2_limped;
+          break;
+      }
+      if (spotKind == null) continue;
+      spots.add(UiSpot(
+        kind: spotKind,
+        hand: '${raw['hand']}',
+        pos: '${raw['pos']}',
+        stack: '${raw['stack']}',
+        action: '${raw['action']}',
+        vsPos: raw['vsPos']?.toString(),
+        limpers: raw['limpers']?.toString(),
+      ));
+    }
+  } else {
+    final items = root['items'];
+    if (items is List) {
+      for (final entry in items) {
+        String? filePath;
+        if (entry is String) {
+          filePath = entry;
+        } else if (entry is Map) {
+          final f = entry['file'];
+          if (f is String) filePath = f;
+        }
+        if (filePath == null) continue;
+        if (!filePath.startsWith('/') &&
+            !(filePath.length > 1 && filePath[1] == ':')) {
+          filePath = '$baseDir/$filePath';
+        }
+        final text = await File(filePath).readAsString();
+        spots.addAll(decodeL2SessionJson(text));
+      }
+    }
+  }
+  if (spots.isEmpty) throw FormatException('empty l3 session');
+  return spots;
+}
+
 String detectSessionKind(Map root) {
+  final inlineItems = root['inlineItems'];
+  if (inlineItems is List) return 'l3';
   final items = root['items'];
   if (items is List && items.isNotEmpty) {
+    final isL3 =
+        items.every((e) => e is String || (e is Map && e['file'] != null));
+    if (isL3) return 'l3';
     final first = items.first;
     if (first is Map) {
       if (first.containsKey('kind')) return 'l2';
-      if (first.containsKey('heroPos') && first.containsKey('stackBb')) return 'l4';
+      if (first.containsKey('heroPos') && first.containsKey('stackBb')) {
+        return 'l4';
+      }
     }
   }
   return 'unknown';

--- a/lib/ui/session_player/file_runner.dart
+++ b/lib/ui/session_player/file_runner.dart
@@ -14,19 +14,13 @@ class PlayFromFilePage extends StatelessWidget {
   Future<List<UiSpot>> _load() async {
     final jsonStr = await File(path).readAsString();
     final root = jsonDecode(jsonStr);
-    final items = root['items'];
-    final inlineItems = root['inlineItems'];
-    final isL3 = inlineItems is List ||
-        (items is List &&
-            items.every((e) =>
-                e is String || (e is Map && e['file'] is String)));
-    if (isL3) {
-      return _decodeL3(jsonStr, baseDir: File(path).parent.path);
-    }
     final kind = detectSessionKind(root);
     switch (kind) {
       case 'l2':
         return decodeL2SessionJson(jsonStr);
+      case 'l3':
+        return await decodeL3SessionJson(jsonStr,
+            baseDir: File(path).parent.path);
       case 'l4':
         return decodeL4IcmSessionJson(jsonStr);
       default:
@@ -50,62 +44,5 @@ class PlayFromFilePage extends StatelessWidget {
       },
     );
   }
-}
-
-Future<List<UiSpot>> _decodeL3(String jsonStr,
-    {required String baseDir}) async {
-  final root = jsonDecode(jsonStr);
-  final spots = <UiSpot>[];
-  final inlineItems = root['inlineItems'];
-  if (inlineItems is List) {
-    for (final raw in inlineItems) {
-      if (raw is! Map) continue;
-      final kind = raw['kind'];
-      SpotKind? spotKind;
-      switch (kind) {
-        case 'open_fold':
-          spotKind = SpotKind.l2_open_fold;
-          break;
-        case 'threebet_push':
-          spotKind = SpotKind.l2_threebet_push;
-          break;
-        case 'limped':
-          spotKind = SpotKind.l2_limped;
-          break;
-      }
-      if (spotKind == null) continue;
-      spots.add(UiSpot(
-        kind: spotKind,
-        hand: '${raw['hand']}',
-        pos: '${raw['pos']}',
-        stack: '${raw['stack']}',
-        action: '${raw['action']}',
-        vsPos: raw['vsPos']?.toString(),
-        limpers: raw['limpers']?.toString(),
-      ));
-    }
-  } else {
-    final items = root['items'];
-    if (items is List) {
-      for (final entry in items) {
-        String? filePath;
-        if (entry is String) {
-          filePath = entry;
-        } else if (entry is Map) {
-          final f = entry['file'];
-          if (f is String) filePath = f;
-        }
-        if (filePath == null) continue;
-        if (!filePath.startsWith('/') &&
-            !(filePath.length > 1 && filePath[1] == ':')) {
-          filePath = '$baseDir/$filePath';
-        }
-        final text = await File(filePath).readAsString();
-        spots.addAll(decodeL2SessionJson(text));
-      }
-    }
-  }
-  if (spots.isEmpty) throw Exception('empty session');
-  return spots;
 }
 

--- a/lib/ui/session_player/plan_runner.dart
+++ b/lib/ui/session_player/plan_runner.dart
@@ -46,82 +46,33 @@ Future<List<UiSpot>> loadSliceSpots({
   required Directory bundleDir,
   required PlanSlice slice,
 }) async {
-  final path = slice.file.startsWith('/')
+  final resolvedPath = slice.file.startsWith('/')
       ? slice.file
       : '${bundleDir.path}/${slice.file}';
-  final jsonStr = await File(path).readAsString();
-  List<UiSpot> spots = [];
-  if (slice.kind == 'l3_session') {
-    // TODO: replace with direct L3 decoder once schema stabilizes
-    final root = jsonDecode(jsonStr);
-    final inlineItems = root['inlineItems'];
-    if (inlineItems is List) {
-      for (final raw in inlineItems) {
-        if (raw is! Map) continue;
-        final kind = raw['kind'];
-        SpotKind? spotKind;
-        switch (kind) {
-          case 'open_fold':
-            spotKind = SpotKind.l2_open_fold;
-            break;
-          case 'threebet_push':
-            spotKind = SpotKind.l2_threebet_push;
-            break;
-          case 'limped':
-            spotKind = SpotKind.l2_limped;
-            break;
-        }
-        if (spotKind == null) continue;
-        spots.add(UiSpot(
-          kind: spotKind,
-          hand: '${raw['hand']}',
-          pos: '${raw['pos']}',
-          stack: '${raw['stack']}',
-          action: '${raw['action']}',
-          vsPos: raw['vsPos']?.toString(),
-          limpers: raw['limpers']?.toString(),
-        ));
-      }
-    } else {
-      final items = root['items'];
-      if (items is List) {
-        for (final entry in items) {
-          String? filePath;
-          if (entry is String) {
-            filePath = entry;
-          } else if (entry is Map) {
-            final f = entry['file'];
-            if (f is String) filePath = f;
-          }
-          if (filePath == null) continue;
-          if (!filePath.startsWith('/') &&
-              !(filePath.length > 1 && filePath[1] == ':')) {
-            filePath = '${bundleDir.path}/$filePath';
-          }
-          final text = await File(filePath).readAsString();
-          spots.addAll(decodeL2SessionJson(text));
-        }
-      }
-    }
-    if (spots.isEmpty) throw Exception('empty session');
-  } else {
-    switch (slice.kind) {
-      case 'l2_session':
-        spots = decodeL2SessionJson(jsonStr);
-        break;
-      case 'l4_session':
-        spots = decodeL4IcmSessionJson(jsonStr);
-        break;
-      default:
-        spots = [];
-    }
+  final jsonStr = await File(resolvedPath).readAsString();
+  List<UiSpot> spots;
+  switch (slice.kind) {
+    case 'l2_session':
+      spots = decodeL2SessionJson(jsonStr);
+      break;
+    case 'l3_session':
+      spots = await decodeL3SessionJson(jsonStr,
+          baseDir: File(resolvedPath).parent.path);
+      break;
+    case 'l4_session':
+      spots = decodeL4IcmSessionJson(jsonStr);
+      break;
+    default:
+      spots = [];
   }
   var start = slice.start;
   if (start < 0) start = 0;
   if (start > spots.length) start = spots.length;
   var end = slice.count <= 0 ? spots.length : start + slice.count;
   if (end > spots.length) end = spots.length;
-  return spots.sublist(start, end);
+  final sub = spots.sublist(start, end);
+  if (sub.isEmpty) throw Exception('empty slice');
+  return sub;
 }
 
 class PlayFromPlanPage extends StatefulWidget {


### PR DESCRIPTION
## Summary
- add L3 session decoder and detection
- refactor file and plan runners to use centralized L3 decoding

## Testing
- `dart format lib/ui/session_player/decoders.dart lib/ui/session_player/file_runner.dart lib/ui/session_player/plan_runner.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f1a7657c8832ab3eaaaa138fdb97a