### PR TITLE
feat: add answer review and export log

### DIFF
--- a/lib/ui/session_player/answer_log.dart
+++ b/lib/ui/session_player/answer_log.dart
@@ -1,0 +1,84 @@
+import 'models.dart';
+
+class AnswerLogItem {
+  final String kind;
+  final String hand;
+  final String pos;
+  final String? vsPos;
+  final String? limpers;
+  final String stack;
+  final String expected;
+  final String chosen;
+  final bool correct;
+  final int elapsedMs;
+
+  const AnswerLogItem({
+    required this.kind,
+    required this.hand,
+    required this.pos,
+    required this.vsPos,
+    required this.limpers,
+    required this.stack,
+    required this.expected,
+    required this.chosen,
+    required this.correct,
+    required this.elapsedMs,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'kind': kind,
+        'hand': hand,
+        'pos': pos,
+        'vsPos': vsPos,
+        'limpers': limpers,
+        'stack': stack,
+        'expected': expected,
+        'chosen': chosen,
+        'correct': correct,
+        'elapsedMs': elapsedMs,
+      };
+}
+
+class AnswerLog {
+  final String version;
+  final int total;
+  final int correct;
+  final List<AnswerLogItem> items;
+
+  const AnswerLog({
+    this.version = 'v1',
+    required this.total,
+    required this.correct,
+    required this.items,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'version': version,
+        'total': total,
+        'correct': correct,
+        'items': items.map((e) => e.toJson()).toList(),
+      };
+}
+
+AnswerLog buildAnswerLog(List<UiSpot> spots, List<UiAnswer> answers) {
+  final items = <AnswerLogItem>[];
+  var correct = 0;
+  for (var i = 0; i < answers.length; i++) {
+    final spot = spots[i];
+    final ans = answers[i];
+    if (ans.correct) correct++;
+    items.add(AnswerLogItem(
+      kind: spot.kind.name,
+      hand: spot.hand,
+      pos: spot.pos,
+      vsPos: spot.vsPos,
+      limpers: spot.limpers,
+      stack: spot.stack,
+      expected: ans.expected,
+      chosen: ans.chosen,
+      correct: ans.correct,
+      elapsedMs: ans.elapsed.inMilliseconds,
+    ));
+  }
+  return AnswerLog(total: answers.length, correct: correct, items: items);
+}

--- a/lib/ui/session_player/result_summary.dart
+++ b/lib/ui/session_player/result_summary.dart
@@ -1,6 +1,11 @@
-import 'package:flutter/material.dart';
+import 'dart:convert';
 
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import 'answer_log.dart';
 import 'models.dart';
+import 'review_page.dart';
 
 class ResultSummaryView extends StatelessWidget {
   final List<UiSpot> spots;
@@ -61,6 +66,32 @@ class ResultSummaryView extends StatelessWidget {
           OutlinedButton(
             onPressed: onRestart,
             child: const Text('Restart'),
+          ),
+          const SizedBox(height: 8),
+          OutlinedButton(
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => ReviewAnswersPage(
+                    spots: spots,
+                    answers: answers,
+                  ),
+                ),
+              );
+            },
+            child: const Text('Review answers'),
+          ),
+          const SizedBox(height: 8),
+          OutlinedButton(
+            onPressed: () async {
+              final json = const JsonEncoder.withIndent('  ')
+                  .convert(buildAnswerLog(spots, answers).toJson());
+              await Clipboard.setData(ClipboardData(text: json));
+              ScaffoldMessenger.of(context)
+                  .showSnackBar(const SnackBar(content: Text('Copied')));
+            },
+            child: const Text('Export JSON'),
           ),
         ],
       ),

--- a/lib/ui/session_player/review_page.dart
+++ b/lib/ui/session_player/review_page.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+
+import 'models.dart';
+
+class ReviewAnswersPage extends StatelessWidget {
+  final List<UiSpot> spots;
+  final List<UiAnswer> answers;
+
+  const ReviewAnswersPage({super.key, required this.spots, required this.answers});
+
+  @override
+  Widget build(BuildContext ctx) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Review')),
+      body: ListView.builder(
+        itemCount: answers.length,
+        itemBuilder: (context, i) {
+          final spot = spots[i];
+          final answer = answers[i];
+          final t = answer.elapsed.inMilliseconds / 1000;
+          return ListTile(
+            leading: Container(
+              width: 12,
+              height: 12,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: answer.correct ? Colors.green : Colors.red,
+              ),
+            ),
+            title: Text('${spot.hand} • ${spot.pos} • ${spot.stack}'),
+            subtitle: Text(
+                'expected: ${answer.expected} • chosen: ${answer.chosen} • t=${t.toStringAsFixed(1)}s'),
+          );
+        },
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add AnswerLog models to encode session results
- allow reviewing answers in a simple list view
- enable JSON export of results from summary screen

## Testing
- `dart format lib/ui/session_player/answer_log.dart lib/ui/session_player/review_page.dart lib/ui/session_player/result_summary.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f1bbcbea4832a8ab7983a7fc705ba