### PR TITLE
feat: show spot explanations in session player

### DIFF
--- a/lib/ui/session_player/decoders.dart
+++ b/lib/ui/session_player/decoders.dart
@@ -24,6 +24,14 @@ List<UiSpot> decodeL2SessionJson(String jsonStr) {
       default:
         continue;
     }
+    String? explain;
+    final e = raw['explain'];
+    if (e is String) {
+      explain = e;
+    } else {
+      final w = raw['why'];
+      if (w is String) explain = w;
+    }
     spots.add(UiSpot(
       kind: spotKind,
       hand: '${raw['hand']}',
@@ -32,6 +40,7 @@ List<UiSpot> decodeL2SessionJson(String jsonStr) {
       action: '${raw['action']}',
       vsPos: raw['vsPos']?.toString(),
       limpers: raw['limpers']?.toString(),
+      explain: explain,
     ));
   }
   return spots;
@@ -49,6 +58,7 @@ List<UiSpot> decodeL4IcmSessionJson(String jsonStr) {
       pos: '${raw['heroPos']}',
       stack: '${raw['stackBb']}',
       action: '${raw['action']}',
+      explain: raw['explain'] is String ? raw['explain'] as String : null,
     ));
   }
   return spots;
@@ -76,6 +86,14 @@ Future<List<UiSpot>> decodeL3SessionJson(String jsonStr,
           break;
       }
       if (spotKind == null) continue;
+      String? explain;
+      final e = raw['explain'];
+      if (e is String) {
+        explain = e;
+      } else {
+        final w = raw['why'];
+        if (w is String) explain = w;
+      }
       spots.add(UiSpot(
         kind: spotKind,
         hand: '${raw['hand']}',
@@ -84,6 +102,7 @@ Future<List<UiSpot>> decodeL3SessionJson(String jsonStr,
         action: '${raw['action']}',
         vsPos: raw['vsPos']?.toString(),
         limpers: raw['limpers']?.toString(),
+        explain: explain,
       ));
     }
   } else {

--- a/lib/ui/session_player/models.dart
+++ b/lib/ui/session_player/models.dart
@@ -8,6 +8,7 @@ class UiSpot {
   final String action;
   final String? vsPos;
   final String? limpers;
+  final String? explain;
 
   const UiSpot({
     required this.kind,
@@ -17,6 +18,7 @@ class UiSpot {
     required this.action,
     this.vsPos,
     this.limpers,
+    this.explain,
   });
 }
 

--- a/lib/ui/session_player/mvs_player.dart
+++ b/lib/ui/session_player/mvs_player.dart
@@ -27,6 +27,7 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer> {
   final _focusNode = FocusNode();
   Timer? _ticker;
   String? _chosen;
+  bool _showExplain = false;
 
   @override
   void initState() {
@@ -74,6 +75,7 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer> {
     setState(() {
       _index++;
       _chosen = null;
+      _showExplain = false;
       _timer
         ..reset()
         ..start();
@@ -88,6 +90,7 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer> {
       _index = 0;
       _answers.clear();
       _chosen = null;
+      _showExplain = false;
       _timer
         ..reset()
         ..start();
@@ -147,7 +150,9 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer> {
             _onAction(actions[2]);
           }
         } else {
-          if (event.logicalKey == LogicalKeyboardKey.enter ||
+          if (event.logicalKey == LogicalKeyboardKey.keyH) {
+            setState(() => _showExplain = !_showExplain);
+          } else if (event.logicalKey == LogicalKeyboardKey.enter ||
               event.logicalKey == LogicalKeyboardKey.space) {
             _next();
           }
@@ -200,6 +205,25 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer> {
                             ? Colors.green
                             : Colors.red,
                       ),
+                    ),
+                    TextButton(
+                      onPressed: () =>
+                          setState(() => _showExplain = !_showExplain),
+                      style: TextButton.styleFrom(
+                        visualDensity: VisualDensity.compact,
+                      ),
+                      child: const Text('Why?'),
+                    ),
+                    AnimatedCrossFade(
+                      firstChild: const SizedBox.shrink(),
+                      secondChild: Padding(
+                        padding: const EdgeInsets.all(8),
+                        child: Text(spot.explain ?? 'No explanation'),
+                      ),
+                      crossFadeState: _showExplain
+                          ? CrossFadeState.showSecond
+                          : CrossFadeState.showFirst,
+                      duration: const Duration(milliseconds: 200),
                     ),
                     const SizedBox(height: 24),
                     ElevatedButton(


### PR DESCRIPTION
## Summary
- support optional `explain` field on `UiSpot`
- decode and store explanations from L2/L3/L4 session JSON
- allow players to reveal explanations via "Why?" button or `H` key

## Testing
- `dart format lib/ui/session_player/models.dart lib/ui/session_player/decoders.dart lib/ui/session_player/mvs_player.dart` *(command not found)*
- `apt-get install -y dart` *(package not found)*
- `flutter test` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f20d892e0832a818e4b892bc04eff