### PR TITLE
Handle missing reward data in gallery

### DIFF
--- a/lib/screens/reward_gallery_screen.dart
+++ b/lib/screens/reward_gallery_screen.dart
@@ -54,7 +54,7 @@ class _RewardGalleryScreenState extends State<RewardGalleryScreen> {
               ),
             );
           }
-          final groups = snapshot.data!;
+          final groups = snapshot.data ?? const <TrackRewardGroup>[];
           if (groups.isEmpty) {
             return const Center(child: Text('Вы ещё не получили наград'));
           }
@@ -109,7 +109,7 @@ class _RewardGalleryScreenState extends State<RewardGalleryScreen> {
                     padding: const EdgeInsets.only(left: 72, top: 4, bottom: 8),
                     child: Text('Этап ${r.stageIndex}'),
                   ),
-              ]
+              ],
             ],
           );
         },


### PR DESCRIPTION
## Summary
- avoid crashes when reward data is null by defaulting to empty list in reward gallery
- tidy reward list formatting

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f2381f394832ab5c5b9c191f75491