### PR TITLE
Add mistakes quick play from logs

### DIFF
--- a/lib/ui/session_player/dev_menu.dart
+++ b/lib/ui/session_player/dev_menu.dart
@@ -10,6 +10,7 @@ import 'demo_seed.dart';
 import 'mvs_player.dart';
 import 'plan_runner.dart';
 import 'quickstart_launcher.dart';
+import 'mistakes_quick_play.dart';
 
 class DevMenuPage extends StatelessWidget {
   const DevMenuPage({super.key});
@@ -86,6 +87,16 @@ class DevMenuPage extends StatelessWidget {
                     initialManifest:
                         'out/l4_sessions/session_icm_v1_mvs_k1_n20.json',
                   ),
+                ),
+              );
+            },
+          ),
+          ListTile(
+            title: const Text('Mistakes quick play'),
+            onTap: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (_) => const QuickMistakesPlayPage(),
                 ),
               );
             },

--- a/lib/ui/session_player/mistakes_loader.dart
+++ b/lib/ui/session_player/mistakes_loader.dart
@@ -1,0 +1,62 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'models.dart';
+
+Future<List<UiSpot>> loadMistakeSpotsFromLogs({String dir = 'out/session_logs'}) async {
+  final directory = Directory(dir);
+  if (!await directory.exists()) return [];
+  final files = await directory
+      .list()
+      .where((e) => e is File && e.path.endsWith('.json'))
+      .cast<File>()
+      .toList();
+  files.sort((a, b) => a.path.compareTo(b.path));
+  final spots = <UiSpot>[];
+  for (final file in files) {
+    try {
+      final content = await file.readAsString();
+      final root = jsonDecode(content);
+      if (root is! Map) continue;
+      final items = root['items'];
+      if (items is! List) continue;
+      for (final raw in items) {
+        try {
+          if (raw is! Map) continue;
+          if (raw['correct'] == true) continue;
+          final kind = _spotKindFromString(raw['kind'] as String?);
+          if (kind == null) continue;
+          spots.add(UiSpot(
+            kind: kind,
+            hand: raw['hand'] as String? ?? '',
+            pos: raw['pos'] as String? ?? '',
+            stack: raw['stack'] as String? ?? '',
+            action: raw['expected'] as String? ?? '',
+            vsPos: raw['vsPos']?.toString(),
+            limpers: raw['limpers']?.toString(),
+            explain: null,
+          ));
+        } catch (_) {
+          // skip malformed item
+        }
+      }
+    } catch (_) {
+      // skip malformed file
+    }
+  }
+  return spots;
+}
+
+SpotKind? _spotKindFromString(String? s) {
+  switch (s) {
+    case 'l2_open_fold':
+      return SpotKind.l2_open_fold;
+    case 'l2_threebet_push':
+      return SpotKind.l2_threebet_push;
+    case 'l2_limped':
+      return SpotKind.l2_limped;
+    case 'l4_icm':
+      return SpotKind.l4_icm;
+  }
+  return null;
+}

--- a/lib/ui/session_player/mistakes_quick_play.dart
+++ b/lib/ui/session_player/mistakes_quick_play.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+
+import 'mistakes_loader.dart';
+import 'models.dart';
+import 'mvs_player.dart';
+
+class QuickMistakesPlayPage extends StatefulWidget {
+  final String logsDir;
+  const QuickMistakesPlayPage({super.key, this.logsDir = 'out/session_logs'});
+
+  @override
+  State<QuickMistakesPlayPage> createState() => _QuickMistakesPlayPageState();
+}
+
+class _QuickMistakesPlayPageState extends State<QuickMistakesPlayPage> {
+  late Future<List<UiSpot>> _future;
+
+  @override
+  void initState() {
+    super.initState();
+    _future = loadMistakeSpotsFromLogs(dir: widget.logsDir);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Mistakes quick play')),
+      body: FutureBuilder<List<UiSpot>>(
+        future: _future,
+        builder: (context, snap) {
+          if (snap.connectionState != ConnectionState.done) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (snap.hasError) {
+            return Center(child: Text('Error: ${snap.error}'));
+          }
+          final spots = snap.data ?? [];
+          if (spots.isEmpty) {
+            return const Center(child: Text('No mistakes found'));
+          }
+          return Center(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text('Mistakes: ${spots.length}'),
+                const SizedBox(height: 16),
+                ElevatedButton(
+                  onPressed: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute(
+                        builder: (_) =>
+                            Scaffold(body: MvsSessionPlayer(spots: spots)),
+                      ),
+                    );
+                  },
+                  child: const Text('Play mistakes deck'),
+                ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add loader to assemble spots from saved answer logs
- introduce QuickMistakesPlayPage to run mistakes deck via existing session player
- link new quick play mode from dev menu

## Testing
- `dart format lib/ui/session_player/mistakes_loader.dart lib/ui/session_player/mistakes_quick_play.dart lib/ui/session_player/dev_menu.dart` *(fails: command not found)*
- `flutter format lib/ui/session_player/mistakes_loader.dart lib/ui/session_player/mistakes_quick_play.dart lib/ui/session_player/dev_menu.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f299409d4832a89c38d2bd0e99f0d