### PR TITLE
Add optional side pot badges overlay

### DIFF
--- a/lib/widgets/poker_table_view.dart
+++ b/lib/widgets/poker_table_view.dart
@@ -14,6 +14,7 @@ import '../models/table_state.dart';
 import '../services/table_edit_history.dart';
 import '../models/card_model.dart';
 import 'playing_card_widget.dart';
+import 'side_pot_badges.dart';
 
 enum PlayerAction { none, fold, push, call, raise, post }
 
@@ -57,6 +58,8 @@ class PokerTableView extends StatefulWidget {
   final bool showRevealedCards;
   final bool showPlayerActions;
   final bool showBoardLabels;
+  final List<int>? sidePotsChips;
+  final double bbChips;
   const PokerTableView({
     super.key,
     required this.heroIndex,
@@ -88,6 +91,8 @@ class PokerTableView extends StatefulWidget {
     this.showRevealedCards = true,
     this.showPlayerActions = true,
     this.showBoardLabels = true,
+    this.sidePotsChips,
+    this.bbChips = 1.0,
   });
 
   @override
@@ -101,7 +106,9 @@ class _PokerTableViewState extends State<PokerTableView> {
     if (widget.heroIndex != oldWidget.heroIndex ||
         widget.theme != oldWidget.theme ||
         widget.potSize != oldWidget.potSize ||
-        !listEquals(widget.playerStacks, oldWidget.playerStacks)) {
+        !listEquals(widget.playerStacks, oldWidget.playerStacks) ||
+        !listEquals(widget.sidePotsChips, oldWidget.sidePotsChips) ||
+        widget.bbChips != oldWidget.bbChips) {
       setState(() {});
     }
     if (widget.theme != oldWidget.theme) {
@@ -149,6 +156,15 @@ class _PokerTableViewState extends State<PokerTableView> {
                   ),
                 ),
                 _buildBoards(),
+                if ((widget.sidePotsChips ?? const []).isNotEmpty)
+                  Align(
+                    alignment: const Alignment(0, -0.05),
+                    child: SidePotBadges(
+                      sidePotsChips: widget.sidePotsChips!,
+                      bb: widget.bbChips <= 0 ? 1.0 : widget.bbChips,
+                      padding: const EdgeInsets.symmetric(horizontal: 8),
+                    ),
+                  ),
                 GestureDetector(
                   onTap: () async {
                     final controller =

--- a/lib/widgets/side_pot_badges.dart
+++ b/lib/widgets/side_pot_badges.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+
+class SidePotBadges extends StatelessWidget {
+  final List<int> sidePotsChips; // in chips; order: side pot #1, #2, ...
+  final double bb; // 1 BB in chips
+  final EdgeInsets padding; // default EdgeInsets.zero
+  const SidePotBadges({
+    super.key,
+    required this.sidePotsChips,
+    required this.bb,
+    this.padding = EdgeInsets.zero,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (sidePotsChips.isEmpty || bb <= 0) return const SizedBox.shrink();
+    return IgnorePointer(
+      ignoring: true,
+      child: Padding(
+        padding: padding,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            for (int i = 0; i < sidePotsChips.length; i++)
+              Container(
+                margin: const EdgeInsets.symmetric(vertical: 4),
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+                decoration: BoxDecoration(
+                  color: Colors.black.withOpacity(0.55),
+                  borderRadius: BorderRadius.circular(12),
+                  border: Border.all(color: Colors.white24, width: 1),
+                ),
+                child: Text(
+                  'Side Pot #${i + 1}: ${(sidePotsChips[i] / bb).toStringAsFixed(1)} BB',
+                  style: const TextStyle(color: Colors.white),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `SidePotBadges` widget for labeled side pot display
- integrate optional `sidePotsChips` and `bbChips` into `PokerTableView`
- overlay badges near table center when side pots are provided

## Testing
- `dart format lib/widgets/side_pot_badges.dart lib/widgets/poker_table_view.dart` *(fails: command not found)*
- `dart analyze lib/widgets/side_pot_badges.dart lib/widgets/poker_table_view.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f3c81ae3c832aa94c2067f5f3bf75