### PR TITLE
Add bet recall option to action sizing widgets

### DIFF
--- a/lib/widgets/action_dialog.dart
+++ b/lib/widgets/action_dialog.dart
@@ -23,6 +23,7 @@ class ActionDialog extends StatefulWidget {
 }
 
 class _ActionDialogState extends State<ActionDialog> {
+  static double? _lastAmountChips;
   String? _selected;
   double _amount = 1;
 
@@ -34,6 +35,7 @@ class _ActionDialogState extends State<ActionDialog> {
   }
 
   void _selectBetAmount(double amount) {
+    _lastAmountChips = amount.toDouble();
     Navigator.pop(
       context,
       ActionEntry(widget.street, widget.playerIndex, _selected!,
@@ -74,6 +76,7 @@ class _ActionDialogState extends State<ActionDialog> {
       bb: 1.0,
       pot: widget.pot.toDouble(),
       stack: widget.stackSize.toDouble(),
+      recall: _lastAmountChips,
       onChanged: (v) => setState(() => _amount = v),
       onConfirm: () => _selectBetAmount(_amount),
     );

--- a/lib/widgets/bet_sizer.dart
+++ b/lib/widgets/bet_sizer.dart
@@ -11,6 +11,7 @@ class BetSizer extends StatefulWidget {
   final double stack;  // chips
   final ValueChanged<double> onChanged;
   final VoidCallback onConfirm;
+  final double? recall; // last chosen amount in chips; null = hidden
 
   const BetSizer({
     super.key,
@@ -22,6 +23,7 @@ class BetSizer extends StatefulWidget {
     required this.stack,
     required this.onChanged,
     required this.onConfirm,
+    this.recall,
   });
 
   @override
@@ -123,6 +125,19 @@ class _BetSizerState extends State<BetSizer> {
           spacing: 8,
           runSpacing: 8,
           children: [
+            if (widget.recall != null)
+              OutlinedButton(
+                style: OutlinedButton.styleFrom(
+                  visualDensity: VisualDensity.compact,
+                ),
+                onPressed: () {
+                  final v =
+                      widget.recall!.clamp(widget.min, widget.max).toDouble();
+                  setState(() => _value = v);
+                  widget.onChanged(v);
+                },
+                child: const Text('Recall'),
+              ),
             _presetButton('1/4', _clamp(widget.pot * 0.25)),
             _presetButton('1/2', _clamp(widget.pot * 0.5)),
             _presetButton('2/3', _clamp(widget.pot * 2 / 3)),

--- a/lib/widgets/detailed_action_bottom_sheet.dart
+++ b/lib/widgets/detailed_action_bottom_sheet.dart
@@ -47,6 +47,7 @@ class _DetailedActionSheet extends StatefulWidget {
 }
 
 class _DetailedActionSheetState extends State<_DetailedActionSheet> {
+  static double? _lastAmountChips;
   String? _action;
   double _amount = 1;
   late int _street;
@@ -81,6 +82,9 @@ class _DetailedActionSheetState extends State<_DetailedActionSheet> {
 
   void _confirm() {
     if (_action == null) return;
+    if (_action == 'bet' || _action == 'raise') {
+      _lastAmountChips = _amount;
+    }
     final result = <String, dynamic>{
       'action': _action,
       'amount': _needAmount ? _amount.round() : null,
@@ -149,6 +153,7 @@ class _DetailedActionSheetState extends State<_DetailedActionSheet> {
               bb: 1.0,
               pot: widget.potSizeBB.toDouble(),
               stack: widget.stackSizeBB.toDouble(),
+              recall: _lastAmountChips,
               onChanged: (v) => setState(() => _amount = v),
               onConfirm: _confirm,
             ),


### PR DESCRIPTION
## Summary
- extend BetSizer with optional recall amount and Recall preset button
- remember last bet/raise amount in action dialog and detailed sheet
- use remembered amount for quick recall on subsequent actions

## Testing
- `dart format lib/widgets/bet_sizer.dart lib/widgets/action_dialog.dart lib/widgets/detailed_action_bottom_sheet.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f47711a70832a9bf27b29da7e2a60