### PR TITLE
fix: make session player state ticker provider

### DIFF
--- a/lib/ui/session_player/mvs_player.dart
+++ b/lib/ui/session_player/mvs_player.dart
@@ -21,7 +21,8 @@ class MvsSessionPlayer extends StatefulWidget {
   State<MvsSessionPlayer> createState() => _MvsSessionPlayerState();
 }
 
-class _MvsSessionPlayerState extends State<MvsSessionPlayer> {
+class _MvsSessionPlayerState extends State<MvsSessionPlayer>
+    with SingleTickerProviderStateMixin {
   late List<UiSpot> _spots;
   int _index = 0;
   final _answers = <UiAnswer>[];


### PR DESCRIPTION
## Summary
- make `_MvsSessionPlayerState` a `SingleTickerProviderStateMixin` so AnimationController can use `vsync: this`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f4cf812bc832aacfc4e1a5d9c7e8a