### PR TITLE
Add hotkeys cheat sheet

### DIFF
--- a/lib/ui/session_player/hotkeys_sheet.dart
+++ b/lib/ui/session_player/hotkeys_sheet.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+
+class HotkeysSheet extends StatelessWidget {
+  const HotkeysSheet({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    Widget row(String k, String d) => Padding(
+          padding: const EdgeInsets.symmetric(vertical: 6),
+          child: Row(
+            children: [
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                decoration: BoxDecoration(
+                  color: Colors.black.withOpacity(0.75),
+                  borderRadius: BorderRadius.circular(8),
+                  border: Border.all(color: Colors.white24, width: 1),
+                ),
+                child: Text(k, style: const TextStyle(color: Colors.white)),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                  child: Text(d, style: const TextStyle(color: Colors.white))),
+            ],
+          ),
+        );
+
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: DefaultTextStyle(
+          style: const TextStyle(color: Colors.white),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              const Text('Hotkeys',
+                  style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+              const SizedBox(height: 12),
+              row('1 / 2 / 3', 'Choose action'),
+              row('Enter / Space', 'Next after answer'),
+              row('H', 'Toggle "Why?"'),
+              row('A', 'Toggle Auto-next'),
+              row('T', 'Toggle Answer timer'),
+              const Divider(height: 24),
+              const Text('BetSizer',
+                  style: TextStyle(fontWeight: FontWeight.bold)),
+              const SizedBox(height: 8),
+              row('1', 'Recall last size (if available)'),
+              row('2..6',
+                  'Presets (1/4, 1/2, 2/3, 3/4, Pot) or Adaptive presets'),
+              row('L', 'All-in'),
+              row('- / +', '±1BB'),
+              row('[ / ]', '±0.5BB'),
+              row('Enter', 'Confirm size'),
+              row('Esc', 'Close dialog'),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+

--- a/lib/ui/session_player/mvs_player.dart
+++ b/lib/ui/session_player/mvs_player.dart
@@ -9,6 +9,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 import '../../widgets/active_timebar.dart';
+import 'hotkeys_sheet.dart';
 import 'mini_toast.dart';
 import 'models.dart';
 import 'result_summary.dart';
@@ -220,6 +221,17 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
     return Scaffold(
       appBar: AppBar(
         actions: [
+          IconButton(
+            icon: const Icon(Icons.help_outline),
+            onPressed: () {
+              showModalBottomSheet<void>(
+                context: context,
+                backgroundColor: Colors.black87,
+                isScrollControlled: false,
+                builder: (_) => const HotkeysSheet(),
+              );
+            },
+          ),
           IconButton(
             icon: const Icon(Icons.tune),
             onPressed: () async {


### PR DESCRIPTION
## Summary
- add HotkeysSheet widget that lists session and BetSizer shortcuts
- expose help icon in MvsSessionPlayer AppBar to show hotkeys

## Testing
- `dart format lib/ui/session_player/hotkeys_sheet.dart lib/ui/session_player/mvs_player.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f5858d3f0832a859768033416409c