### PR TITLE
feat: replay individual spot from summary

### DIFF
--- a/lib/ui/session_player/mvs_player.dart
+++ b/lib/ui/session_player/mvs_player.dart
@@ -312,6 +312,10 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
         answers: _answers,
         onReplayErrors: _replayErrors,
         onRestart: () => _restart(widget.spots),
+        onReplayOne: (i) {
+          if (i < 0 || i >= _spots.length) return;
+          _restart([_spots[i]]);
+        },
       );
     } else {
       child = _buildSpotCard(_spots[_index]);

--- a/lib/ui/session_player/result_summary.dart
+++ b/lib/ui/session_player/result_summary.dart
@@ -10,6 +10,7 @@ class ResultSummaryView extends StatefulWidget {
   final List<UiAnswer> answers;
   final VoidCallback onReplayErrors;
   final VoidCallback onRestart;
+  final ValueChanged<int>? onReplayOne; // index in [0..spots.length)
 
   const ResultSummaryView({
     super.key,
@@ -17,6 +18,7 @@ class ResultSummaryView extends StatefulWidget {
     required this.answers,
     required this.onReplayErrors,
     required this.onRestart,
+    this.onReplayOne,
   });
 
   @override
@@ -135,6 +137,13 @@ class _ResultSummaryViewState extends State<ResultSummaryView> {
                       ),
                     );
                   },
+                  trailing: IconButton(
+                    tooltip: 'Replay',
+                    icon: const Icon(Icons.play_arrow),
+                    onPressed: widget.onReplayOne == null
+                        ? null
+                        : () => widget.onReplayOne!(i),
+                  ),
                 );
               },
             ),


### PR DESCRIPTION
## Summary
- add optional per-spot replay callback to result summary rows
- wire up mvs player to restart with a single spot when replaying

## Testing
- `flutter format lib/ui/session_player/result_summary.dart lib/ui/session_player/mvs_player.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f84cbeed0832a92b7d0797c2ba8d3