### PR TITLE
feat: add auto explain option for wrong answers

### DIFF
--- a/lib/ui/session_player/mvs_player.dart
+++ b/lib/ui/session_player/mvs_player.dart
@@ -36,7 +36,11 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
   String? _chosen;
   bool _showExplain = false;
   UiPrefs _prefs = const UiPrefs(
-      autoNext: false, timeEnabled: true, timeLimitMs: 10000, sound: false);
+      autoNext: false,
+      timeEnabled: true,
+      timeLimitMs: 10000,
+      sound: false,
+      autoExplainOnWrong: false);
   bool _autoNext = false;
   int _timeLimitMs = 10000; // 10s default
   bool _timeEnabled = true; // can toggle
@@ -164,6 +168,9 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
         chosen: action,
         elapsed: _timer.elapsed,
       ));
+      if (!correct && _prefs.autoExplainOnWrong) {
+        _showExplain = true;
+      }
     });
     // micro-feedback: toast + pulse + flash tint
     unawaited(showMiniToast(context, correct ? 'Correct' : 'Wrong'));
@@ -362,6 +369,7 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
                   bool timeEnabled = _timeEnabled;
                   int limit = _timeLimitMs;
                   bool sound = _prefs.sound;
+                  bool autoWhy = _prefs.autoExplainOnWrong;
                   final ctrl =
                       TextEditingController(text: limit.toString());
                   return Padding(
@@ -413,6 +421,17 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
                                 (ctx as Element).markNeedsBuild();
                               })
                         ]),
+                        const SizedBox(height: 8),
+                        Row(children: [
+                          const Text('Auto Why on wrong'),
+                          const Spacer(),
+                          Switch(
+                              value: autoWhy,
+                              onChanged: (v) {
+                                autoWhy = v;
+                                (ctx as Element).markNeedsBuild();
+                              })
+                        ]),
                         const SizedBox(height: 12),
                         Row(
                           mainAxisAlignment: MainAxisAlignment.end,
@@ -427,7 +446,8 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
                                   "autoNext": autoNext,
                                   "timeEnabled": timeEnabled,
                                   "timeLimitMs": limit,
-                                  "sound": sound
+                                  "sound": sound,
+                                  "autoExplainOnWrong": autoWhy,
                                 });
                               },
                               child: const Text('Save'),
@@ -447,6 +467,7 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
                       ? r["timeLimitMs"] as int
                       : _timeLimitMs,
                   sound: r["sound"] == true,
+                  autoExplainOnWrong: r["autoExplainOnWrong"] == true,
                 );
                 await saveUiPrefs(p);
                 if (!mounted) return;

--- a/lib/ui/session_player/ui_prefs.dart
+++ b/lib/ui/session_player/ui_prefs.dart
@@ -6,11 +6,13 @@ class UiPrefs {
   final bool timeEnabled;
   final int timeLimitMs;
   final bool sound;
+  final bool autoExplainOnWrong;
   const UiPrefs({
     required this.autoNext,
     required this.timeEnabled,
     required this.timeLimitMs,
     required this.sound,
+    required this.autoExplainOnWrong,
   });
 
   Map<String, dynamic> toJson() => {
@@ -19,6 +21,7 @@ class UiPrefs {
     "timeEnabled": timeEnabled,
     "timeLimitMs": timeLimitMs,
     "sound": sound,
+    "autoExplainOnWrong": autoExplainOnWrong,
   };
 
   static UiPrefs fromJson(Map m) {
@@ -29,6 +32,7 @@ class UiPrefs {
       timeEnabled: b(m["timeEnabled"], true),
       timeLimitMs: i(m["timeLimitMs"], 10000),
       sound: b(m["sound"], false),
+      autoExplainOnWrong: b(m["autoExplainOnWrong"], false),
     );
   }
 }
@@ -36,13 +40,13 @@ class UiPrefs {
 Future<UiPrefs> loadUiPrefs({String path = 'out/ui_prefs_v1.json'}) async {
   final f = File(path);
   if (!await f.exists()) {
-    return const UiPrefs(autoNext: false, timeEnabled: true, timeLimitMs: 10000, sound: false);
+    return const UiPrefs(autoNext: false, timeEnabled: true, timeLimitMs: 10000, sound: false, autoExplainOnWrong: false);
   }
   try {
     final root = jsonDecode(await f.readAsString());
     if (root is Map) return UiPrefs.fromJson(root);
   } catch (_) {}
-  return const UiPrefs(autoNext: false, timeEnabled: true, timeLimitMs: 10000, sound: false);
+  return const UiPrefs(autoNext: false, timeEnabled: true, timeLimitMs: 10000, sound: false, autoExplainOnWrong: false);
 }
 
 Future<void> saveUiPrefs(UiPrefs p, {String path = 'out/ui_prefs_v1.json'}) async {


### PR DESCRIPTION
## Summary
- expand UI prefs model with `autoExplainOnWrong`
- auto-open explanation panel on wrong answers when enabled
- expose new "Auto Why on wrong" toggle in session player settings

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f861d71ec832a90cb88850757b780