### PR TITLE
feat: add auto why on wrong preference

### DIFF
--- a/lib/ui/session_player/mvs_player.dart
+++ b/lib/ui/session_player/mvs_player.dart
@@ -112,7 +112,7 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
       timeEnabled: true,
       timeLimitMs: 10000,
       sound: false,
-      autoExplainOnWrong: false,
+      autoWhyOnWrong: true,
       autoNextDelayMs: 600);
   bool _autoNext = false;
   int _timeLimitMs = 10000; // 10s default
@@ -281,7 +281,7 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
         chosen: action,
         elapsed: _timer.elapsed,
       ));
-      if (!correct && _prefs.autoExplainOnWrong) {
+      if (!correct && _prefs.autoWhyOnWrong) {
         _showExplain = true;
       }
     });
@@ -518,7 +518,7 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
                   bool timeEnabled = _timeEnabled;
                   int limit = _timeLimitMs;
                   bool sound = _prefs.sound;
-                  bool autoWhy = _prefs.autoExplainOnWrong;
+                  bool autoWhy = _prefs.autoWhyOnWrong;
                   final ctrl =
                       TextEditingController(text: limit.toString());
                   return Padding(
@@ -596,7 +596,7 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
                                   "timeEnabled": timeEnabled,
                                   "timeLimitMs": limit,
                                   "sound": sound,
-                                  "autoExplainOnWrong": autoWhy,
+                                  "autoWhyOnWrong": autoWhy,
                                 });
                               },
                               child: const Text('Save'),
@@ -616,7 +616,7 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
                       ? r["timeLimitMs"] as int
                       : _timeLimitMs,
                   sound: r["sound"] == true,
-                  autoExplainOnWrong: r["autoExplainOnWrong"] == true,
+                  autoWhyOnWrong: r["autoWhyOnWrong"] == true,
                   autoNextDelayMs: _prefs.autoNextDelayMs,
                 );
                 await saveUiPrefs(p);

--- a/lib/ui/session_player/ui_prefs.dart
+++ b/lib/ui/session_player/ui_prefs.dart
@@ -7,14 +7,14 @@ class UiPrefs {
   final bool timeEnabled;
   final int timeLimitMs;
   final bool sound;
-  final bool autoExplainOnWrong;
+  final bool autoWhyOnWrong;
   final int autoNextDelayMs;
   const UiPrefs({
     required this.autoNext,
     required this.timeEnabled,
     required this.timeLimitMs,
     required this.sound,
-    required this.autoExplainOnWrong,
+    required this.autoWhyOnWrong,
     required this.autoNextDelayMs,
   });
 
@@ -24,7 +24,7 @@ class UiPrefs {
     "timeEnabled": timeEnabled,
     "timeLimitMs": timeLimitMs,
     "sound": sound,
-    "autoExplainOnWrong": autoExplainOnWrong,
+    "autoWhyOnWrong": autoWhyOnWrong,
   };
 
   static UiPrefs fromJson(Map m, {required int autoNextDelayMs}) {
@@ -35,7 +35,8 @@ class UiPrefs {
       timeEnabled: b(m["timeEnabled"], true),
       timeLimitMs: i(m["timeLimitMs"], 10000),
       sound: b(m["sound"], false),
-      autoExplainOnWrong: b(m["autoExplainOnWrong"], false),
+      autoWhyOnWrong:
+          b(m["autoWhyOnWrong"], b(m["autoExplainOnWrong"], true)),
       autoNextDelayMs: autoNextDelayMs,
     );
   }
@@ -51,7 +52,7 @@ Future<UiPrefs> loadUiPrefs({String path = 'out/ui_prefs_v1.json'}) async {
         timeEnabled: true,
         timeLimitMs: 10000,
         sound: false,
-        autoExplainOnWrong: false,
+        autoWhyOnWrong: true,
         autoNextDelayMs: delay as int);
   }
   try {
@@ -63,7 +64,7 @@ Future<UiPrefs> loadUiPrefs({String path = 'out/ui_prefs_v1.json'}) async {
       timeEnabled: true,
       timeLimitMs: 10000,
       sound: false,
-      autoExplainOnWrong: false,
+      autoWhyOnWrong: true,
       autoNextDelayMs: delay as int);
 }
 


### PR DESCRIPTION
## Summary
- add `autoWhyOnWrong` preference with default `true`
- auto-show explanation on incorrect answer when preference is enabled

## Testing
- `dart format lib/ui/session_player/ui_prefs.dart lib/ui/session_player/mvs_player.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f92b78a94832abf147b7104ab02e0