### PR TITLE
feat: add haptics preference toggle

### DIFF
--- a/lib/ui/session_player/mvs_player.dart
+++ b/lib/ui/session_player/mvs_player.dart
@@ -112,6 +112,7 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
       timeEnabled: true,
       timeLimitMs: 10000,
       sound: false,
+      haptics: true,
       autoWhyOnWrong: true,
       autoNextDelayMs: 600);
   bool _autoNext = false;
@@ -192,7 +193,11 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
           ScaffoldMessenger.of(context).showSnackBar(
             const SnackBar(content: Text('Time up')),
           );
-          try { HapticFeedback.vibrate(); } catch (_) {}
+          if (_prefs.haptics) {
+            try {
+              HapticFeedback.vibrate();
+            } catch (_) {}
+          }
         }
       });
     });
@@ -243,14 +248,22 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
       _startTicker();
       if (_chosen == null && _timeEnabled) _startTimebar();
       unawaited(showMiniToast(context, 'Resumed'));
-      try { HapticFeedback.selectionClick(); } catch (_) {}
+      if (_prefs.haptics) {
+        try {
+          HapticFeedback.selectionClick();
+        } catch (_) {}
+      }
     } else {
       _ticker?.cancel();
       _timebarTicker?.cancel();
       _timer.stop();
       setState(() => _paused = true);
       unawaited(showMiniToast(context, 'Paused'));
-      try { HapticFeedback.selectionClick(); } catch (_) {}
+      if (_prefs.haptics) {
+        try {
+          HapticFeedback.selectionClick();
+        } catch (_) {}
+      }
     }
   }
 
@@ -262,13 +275,15 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
     final spot = _spots[_index];
     final correct = action == spot.action;
     // mobile haptics
-    try {
-      if (correct) {
-        HapticFeedback.lightImpact();
-      } else {
-        HapticFeedback.mediumImpact();
-      }
-    } catch (_) {}
+    if (_prefs.haptics) {
+      try {
+        if (correct) {
+          HapticFeedback.lightImpact();
+        } else {
+          HapticFeedback.mediumImpact();
+        }
+      } catch (_) {}
+    }
     if (_prefs.sound) {
       SystemSound.play(
           correct ? SystemSoundType.click : SystemSoundType.alert);
@@ -325,7 +340,11 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
     _startTicker();
     _startTimebar();
     unawaited(_saveProgress());
-    try { HapticFeedback.selectionClick(); } catch (_) {}
+    if (_prefs.haptics) {
+      try {
+        HapticFeedback.selectionClick();
+      } catch (_) {}
+    }
     unawaited(showMiniToast(context, 'Undo'));
   }
 
@@ -357,7 +376,11 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
       _focusNode.requestFocus();
     }
     unawaited(_saveProgress());
-    try { HapticFeedback.selectionClick(); } catch (_) {}
+    if (_prefs.haptics) {
+      try {
+        HapticFeedback.selectionClick();
+      } catch (_) {}
+    }
     unawaited(showMiniToast(context, 'Skipped'));
   }
 
@@ -518,6 +541,7 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
                   bool timeEnabled = _timeEnabled;
                   int limit = _timeLimitMs;
                   bool sound = _prefs.sound;
+                  bool haptics = _prefs.haptics;
                   bool autoWhy = _prefs.autoWhyOnWrong;
                   final ctrl =
                       TextEditingController(text: limit.toString());
@@ -572,6 +596,17 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
                         ]),
                         const SizedBox(height: 8),
                         Row(children: [
+                          const Text('Haptics'),
+                          const Spacer(),
+                          Switch(
+                              value: haptics,
+                              onChanged: (v) {
+                                haptics = v;
+                                (ctx as Element).markNeedsBuild();
+                              })
+                        ]),
+                        const SizedBox(height: 8),
+                        Row(children: [
                           const Text('Auto Why on wrong'),
                           const Spacer(),
                           Switch(
@@ -596,6 +631,7 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
                                   "timeEnabled": timeEnabled,
                                   "timeLimitMs": limit,
                                   "sound": sound,
+                                  "haptics": haptics,
                                   "autoWhyOnWrong": autoWhy,
                                 });
                               },
@@ -616,6 +652,7 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
                       ? r["timeLimitMs"] as int
                       : _timeLimitMs,
                   sound: r["sound"] == true,
+                  haptics: r["haptics"] == true,
                   autoWhyOnWrong: r["autoWhyOnWrong"] == true,
                   autoNextDelayMs: _prefs.autoNextDelayMs,
                 );

--- a/lib/ui/session_player/ui_prefs.dart
+++ b/lib/ui/session_player/ui_prefs.dart
@@ -7,6 +7,7 @@ class UiPrefs {
   final bool timeEnabled;
   final int timeLimitMs;
   final bool sound;
+  final bool haptics;
   final bool autoWhyOnWrong;
   final int autoNextDelayMs;
   const UiPrefs({
@@ -14,6 +15,7 @@ class UiPrefs {
     required this.timeEnabled,
     required this.timeLimitMs,
     required this.sound,
+    required this.haptics,
     required this.autoWhyOnWrong,
     required this.autoNextDelayMs,
   });
@@ -24,6 +26,7 @@ class UiPrefs {
     "timeEnabled": timeEnabled,
     "timeLimitMs": timeLimitMs,
     "sound": sound,
+    "haptics": haptics,
     "autoWhyOnWrong": autoWhyOnWrong,
   };
 
@@ -35,6 +38,7 @@ class UiPrefs {
       timeEnabled: b(m["timeEnabled"], true),
       timeLimitMs: i(m["timeLimitMs"], 10000),
       sound: b(m["sound"], false),
+      haptics: b(m["haptics"], true),
       autoWhyOnWrong:
           b(m["autoWhyOnWrong"], b(m["autoExplainOnWrong"], true)),
       autoNextDelayMs: autoNextDelayMs,
@@ -52,6 +56,7 @@ Future<UiPrefs> loadUiPrefs({String path = 'out/ui_prefs_v1.json'}) async {
         timeEnabled: true,
         timeLimitMs: 10000,
         sound: false,
+        haptics: true,
         autoWhyOnWrong: true,
         autoNextDelayMs: delay as int);
   }
@@ -64,6 +69,7 @@ Future<UiPrefs> loadUiPrefs({String path = 'out/ui_prefs_v1.json'}) async {
       timeEnabled: true,
       timeLimitMs: 10000,
       sound: false,
+      haptics: true,
       autoWhyOnWrong: true,
       autoNextDelayMs: delay as int);
 }


### PR DESCRIPTION
## Summary
- add `haptics` to `UiPrefs` with default enabled
- allow toggling haptic feedback in session player settings
- respect haptics setting before triggering `HapticFeedback`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f93ed3d3c832aae0c7ea5b78c304f