### PR TITLE
Add session history detail view

### DIFF
--- a/lib/ui/history/history_detail_screen.dart
+++ b/lib/ui/history/history_detail_screen.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+
+class HistoryDetailScreen extends StatelessWidget {
+  const HistoryDetailScreen({super.key, required this.entry});
+
+  final Map<String, dynamic> entry;
+
+  @override
+  Widget build(BuildContext context) {
+    final acc = (entry['acc'] ?? 0) as num;
+    final correct = entry['correct'] ?? 0;
+    final total = entry['total'] ?? 0;
+    final ts = entry['ts']?.toString() ?? '';
+    final dt = DateTime.tryParse(ts)?.toLocal();
+    final dateStr = dt?.toString() ?? ts;
+
+    void showNotAvailable() {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Not available (v1)')),
+      );
+    }
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Session')),
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          ListTile(
+            title: const Text('Date'),
+            subtitle: Text(dateStr),
+          ),
+          ListTile(
+            title: const Text('Accuracy'),
+            subtitle: Text('${(acc * 100).toStringAsFixed(0)}%'),
+          ),
+          ListTile(
+            title: const Text('Correct / Total'),
+            subtitle: Text('$correct / $total'),
+          ),
+          const Spacer(),
+          ButtonBar(
+            alignment: MainAxisAlignment.center,
+            children: [
+              ElevatedButton(
+                onPressed: total == 0 ? null : showNotAvailable,
+                child: const Text('Replay errors'),
+              ),
+              ElevatedButton(
+                onPressed: total == 0 ? null : showNotAvailable,
+                child: const Text('Replay all'),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/history/history_screen.dart
+++ b/lib/ui/history/history_screen.dart
@@ -3,6 +3,8 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 
+import 'history_detail_screen.dart';
+
 class HistoryScreen extends StatefulWidget {
   const HistoryScreen({super.key});
 
@@ -27,8 +29,10 @@ class _HistoryScreenState extends State<HistoryScreen> {
         final entries = <Map<String, dynamic>>[];
         for (final line in lines) {
           if (line.trim().isEmpty) continue;
-          final obj = jsonDecode(line);
-          if (obj is Map<String, dynamic>) entries.add(obj);
+          try {
+            final obj = jsonDecode(line);
+            if (obj is Map<String, dynamic>) entries.add(obj);
+          } catch (_) {}
         }
         setState(() {
           _items = entries.reversed.take(20).toList();
@@ -53,6 +57,13 @@ class _HistoryScreenState extends State<HistoryScreen> {
           return ListTile(
             title: Text(dateStr),
             subtitle: Text('$correct/$total (${(acc * 100).toStringAsFixed(0)}%)'),
+            onTap: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (_) => HistoryDetailScreen(entry: e),
+                ),
+              );
+            },
           );
         },
       ),


### PR DESCRIPTION
## Summary
- show session detail entries and stubbed replay actions
- handle malformed history lines and navigate to detail view

## Testing
- ⚠️ `dart format lib/ui/history/history_screen.dart lib/ui/history/history_detail_screen.dart` (command not found)
- ⚠️ `flutter test` (command not found)


------
https://chatgpt.com/codex/tasks/task_e_689f9aa51810832aac9e7e983498ebe8