### PR TITLE
feat: add history replay snapshot

### DIFF
--- a/lib/ui/session_player/mvs_player.dart
+++ b/lib/ui/session_player/mvs_player.dart
@@ -451,6 +451,23 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
       'acc': acc,
       'total': total,
       'correct': correct,
+      'spots': [
+        for (final s in _spots)
+          {
+            'k': s.kind.index,
+            'h': s.hand,
+            'p': s.pos,
+            's': s.stack,
+            'a': s.action,
+            if (s.vsPos != null) 'v': s.vsPos,
+            if (s.limpers != null) 'l': s.limpers,
+            if (s.explain != null) 'e': s.explain,
+          }
+      ],
+      'wrongIdx': [
+        for (var i = 0; i < _answers.length; i++)
+          if (!_answers[i].correct) i
+      ],
     };
     try {
       final dir = Directory('out');


### PR DESCRIPTION
## Summary
- embed session spots snapshot and wrong indices in `sessions_history.jsonl`
- enable replaying stored sessions or only mistakes from history entries

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f9be50244832abb072f428214faf3