### PR TITLE
feat: add call vs jam spot kind

### DIFF
--- a/lib/ui/session_player/models.dart
+++ b/lib/ui/session_player/models.dart
@@ -1,4 +1,4 @@
-enum SpotKind { l2_open_fold, l2_threebet_push, l2_limped, l4_icm }
+enum SpotKind { l2_open_fold, l2_threebet_push, l2_limped, l4_icm, callVsJam }
 
 class UiSpot {
   final SpotKind kind;

--- a/lib/ui/session_player/mvs_player.dart
+++ b/lib/ui/session_player/mvs_player.dart
@@ -1050,7 +1050,11 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
     if (spot.vsPos != null) parts.add('vs ${spot.vsPos}');
     if (spot.limpers != null) parts.add('limpers ${spot.limpers}');
     parts.add(spot.stack);
-    return parts.join(' • ');
+    final core = parts.join(' • ');
+    if (spot.kind == SpotKind.callVsJam) {
+      return 'Call vs Jam • $core';
+    }
+    return core;
   }
 
   List<String> _actionsFor(SpotKind kind) {
@@ -1063,6 +1067,8 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
         return ['iso', 'overlimp', 'fold'];
       case SpotKind.l4_icm:
         return ['jam', 'fold'];
+      case SpotKind.callVsJam:
+        return ['Call', 'Fold'];
     }
   }
 


### PR DESCRIPTION
## Summary
- append `callVsJam` to `SpotKind`
- handle Call vs Jam actions and subtitle in session player

## Testing
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689face37998832a87d390865dada75c