### PR TITLE
Fix replay loader list type and remove stray brace

### DIFF
--- a/lib/screens/main_menu_screen.dart
+++ b/lib/screens/main_menu_screen.dart
@@ -107,8 +107,6 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
       ),
     );
   }
-}
-
   @override
   void initState() {
     super.initState();
@@ -162,7 +160,7 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
       if (!await file.exists()) return;
       final lines = await file.readAsLines();
       // iterate from newest to oldest
-      List<UiSpot> latest = const [];
+      List<UiSpot> latest = <UiSpot>[];
       for (var i = lines.length - 1; i >= 0; i--) {
         final line = lines[i].trim();
         if (line.isEmpty) continue;


### PR DESCRIPTION
## Summary
- use typed growable list in `_loadReplaySpots`
- remove stray closing brace so `initState` and other methods belong to the state class

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fd4c0e0c4832ab44bd2ef98fdda66