### PR TITLE
chore: refresh replay spots after resume

### DIFF
--- a/lib/screens/main_menu_screen.dart
+++ b/lib/screens/main_menu_screen.dart
@@ -436,6 +436,7 @@ Widget build(BuildContext context) {
                         final player = await MvsSessionPlayer.fromSaved();
                         if (player == null) {
                           await _discardResume();
+                          if (mounted) _loadReplaySpots();
                           return;
                         }
                         await Navigator.push(


### PR DESCRIPTION
## Summary
- reload replay data when failing to resume a session so main menu stays up to date

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fd62acbe0832a9089ac07d8903bd5