### PR TITLE
Escape action field in history CSV export

### DIFF
--- a/lib/ui/history/history_detail_screen.dart
+++ b/lib/ui/history/history_detail_screen.dart
@@ -89,7 +89,7 @@ class HistoryDetailScreen extends StatelessWidget {
                     ..write(',')
                     ..write(_csv(s.stack))
                     ..write(',')
-                    ..write(s.action)
+                    ..write(_csv(s.action))
                     ..write(',')
                     ..write(_csv(s.vsPos ?? ''))
                     ..write(',')


### PR DESCRIPTION
## Summary
- escape the `action` field when exporting history CSV so commas and quotes are properly handled

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fe1677924832aac53288ca85cbde6