### PR TITLE
feat: centralize csv escaping

### DIFF
--- a/lib/ui/history/history_detail_screen.dart
+++ b/lib/ui/history/history_detail_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter/services.dart';
 
 import '../session_player/models.dart';
 import '../session_player/mvs_player.dart';
+import '../../utils/csv.dart';
 
 class HistoryDetailScreen extends StatelessWidget {
   const HistoryDetailScreen({super.key, required this.entry});
@@ -77,25 +78,24 @@ class HistoryDetailScreen extends StatelessWidget {
                 final dir = Directory('out');
                 await dir.create(recursive: true);
                 final file = File('${dir.path}/session_$stamp.csv');
-                String _csv(String v) => '"${v.replaceAll('"', '""')}"';
                 final buf = StringBuffer()..writeln('k,h,p,s,a,v,l,e');
                 for (final s in spots) {
                   buf
                     ..write(s.kind.index)
                     ..write(',')
-                    ..write(_csv(s.hand))
+                    ..write(csvEscape(s.hand))
                     ..write(',')
-                    ..write(_csv(s.pos))
+                    ..write(csvEscape(s.pos))
                     ..write(',')
-                    ..write(_csv(s.stack))
+                    ..write(csvEscape(s.stack))
                     ..write(',')
-                    ..write(_csv(s.action))
+                    ..write(csvEscape(s.action))
                     ..write(',')
-                    ..write(_csv(s.vsPos ?? ''))
+                    ..write(csvEscape(s.vsPos ?? ''))
                     ..write(',')
-                    ..write(_csv(s.limpers ?? ''))
+                    ..write(csvEscape(s.limpers ?? ''))
                     ..write(',')
-                    ..writeln(_csv(s.explain ?? ''));
+                    ..writeln(csvEscape(s.explain ?? ''));
                 }
                 await file.writeAsString(buf.toString());
                 final path = file.absolute.path;

--- a/lib/utils/csv.dart
+++ b/lib/utils/csv.dart
@@ -1,0 +1,9 @@
+/// Utility helpers for working with CSV data.
+///
+/// Wraps [v] in quotes and doubles any existing quotes so the value can be
+/// safely included in a CSV file.
+String csvEscape(String v) {
+  final escaped = v.replaceAll('"', '""');
+  return '"$escaped"';
+}
+


### PR DESCRIPTION
## Summary
- add reusable `csvEscape` helper for quoting CSV fields
- use `csvEscape` in session export instead of inline `_csv`

## Testing
- `dart format lib/utils/csv.dart lib/ui/history/history_detail_screen.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fe466afd8832a8dd73239b1219f64