### PR TITLE
feat: add L3 postflop jam spot

### DIFF
--- a/lib/ui/session_player/models.dart
+++ b/lib/ui/session_player/models.dart
@@ -1,4 +1,11 @@
-enum SpotKind { l2_open_fold, l2_threebet_push, l2_limped, l4_icm, callVsJam }
+enum SpotKind {
+  l2_open_fold,
+  l2_threebet_push,
+  l2_limped,
+  l4_icm,
+  callVsJam,
+  l3_postflop_jam
+}
 
 class UiSpot {
   final SpotKind kind;

--- a/lib/ui/session_player/mvs_player.dart
+++ b/lib/ui/session_player/mvs_player.dart
@@ -1054,6 +1054,9 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
     if (spot.kind == SpotKind.callVsJam) {
       return 'Call vs Jam • $core';
     }
+    if (spot.kind == SpotKind.l3_postflop_jam) {
+      return 'Postflop Jam • $core';
+    }
     return core;
   }
 
@@ -1069,6 +1072,8 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
         return ['jam', 'fold'];
       case SpotKind.callVsJam:
         return ['Call', 'Fold'];
+      case SpotKind.l3_postflop_jam:
+        return ['jam', 'fold'];
     }
   }
 


### PR DESCRIPTION
## Summary
- add L3 postflop jam spot kind to spot models
- show jam/fold actions and "Postflop Jam" subtitle

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fef4b16ec832abce27a450bba882f