### PR TITLE
feat(session_player): add L3 check-jam vs c-bet

### DIFF
--- a/lib/ui/session_player/models.dart
+++ b/lib/ui/session_player/models.dart
@@ -5,7 +5,8 @@ enum SpotKind {
   l4_icm,
   callVsJam,
   l3_postflop_jam,
-  l3_checkraise_jam
+  l3_checkraise_jam,
+  l3_check_jam_vs_cbet
 }
 
 class UiSpot {

--- a/lib/ui/session_player/mvs_player.dart
+++ b/lib/ui/session_player/mvs_player.dart
@@ -1060,6 +1060,9 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
     if (spot.kind == SpotKind.l3_checkraise_jam) {
       return 'Check-Raise Jam • $core';
     }
+    if (spot.kind == SpotKind.l3_check_jam_vs_cbet) {
+      return 'Check-Jam vs C-bet • $core';
+    }
     return core;
   }
 
@@ -1078,6 +1081,8 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
       case SpotKind.l3_postflop_jam:
         return ['jam', 'fold'];
       case SpotKind.l3_checkraise_jam:
+        return ['jam', 'fold'];
+      case SpotKind.l3_check_jam_vs_cbet:
         return ['jam', 'fold'];
     }
   }


### PR DESCRIPTION
## Summary
- add new SpotKind `l3_check_jam_vs_cbet`
- display "Check-Jam vs C-bet" subtitle with jam/fold actions

## Testing
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ff765a794832a8d092ff711a00dc0