### PR TITLE
Add L3 overbet jam spot kind

### DIFF
--- a/lib/ui/session_player/models.dart
+++ b/lib/ui/session_player/models.dart
@@ -7,7 +7,8 @@ enum SpotKind {
   l3_postflop_jam,
   l3_checkraise_jam,
   l3_check_jam_vs_cbet,
-  l3_donk_jam
+  l3_donk_jam,
+  l3_overbet_jam
 }
 
 class UiSpot {

--- a/lib/ui/session_player/mvs_player.dart
+++ b/lib/ui/session_player/mvs_player.dart
@@ -1066,6 +1066,9 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
     if (spot.kind == SpotKind.l3_donk_jam) {
       return 'Donk Jam • $core';
     }
+    if (spot.kind == SpotKind.l3_overbet_jam) {
+      return 'Overbet Jam • $core';
+    }
     return core;
   }
 
@@ -1088,6 +1091,8 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
       case SpotKind.l3_check_jam_vs_cbet:
         return ['jam', 'fold'];
       case SpotKind.l3_donk_jam:
+        return ['jam', 'fold'];
+      case SpotKind.l3_overbet_jam:
         return ['jam', 'fold'];
     }
   }


### PR DESCRIPTION
## Summary
- extend SpotKind enum with l3_overbet_jam
- show jam/fold actions and subtitle prefix for L3 overbet jams

## Testing
- `dart format lib/ui/session_player/models.dart lib/ui/session_player/mvs_player.dart` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a00184a144832a808a5e02eb15cfd5