### PR TITLE
Add L3 raise jam vs donk spot kind

### DIFF
--- a/lib/ui/session_player/models.dart
+++ b/lib/ui/session_player/models.dart
@@ -8,7 +8,8 @@ enum SpotKind {
   l3_checkraise_jam,
   l3_check_jam_vs_cbet,
   l3_donk_jam,
-  l3_overbet_jam
+  l3_overbet_jam,
+  l3_raise_jam_vs_donk
 }
 
 class UiSpot {

--- a/lib/ui/session_player/mvs_player.dart
+++ b/lib/ui/session_player/mvs_player.dart
@@ -1069,6 +1069,9 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
     if (spot.kind == SpotKind.l3_overbet_jam) {
       return 'Overbet Jam • $core';
     }
+    if (spot.kind == SpotKind.l3_raise_jam_vs_donk) {
+      return 'Raise Jam vs Donk • $core';
+    }
     return core;
   }
 
@@ -1093,6 +1096,8 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
       case SpotKind.l3_donk_jam:
         return ['jam', 'fold'];
       case SpotKind.l3_overbet_jam:
+        return ['jam', 'fold'];
+      case SpotKind.l3_raise_jam_vs_donk:
         return ['jam', 'fold'];
     }
   }


### PR DESCRIPTION
## Summary
- add `l3_raise_jam_vs_donk` to `SpotKind`
- handle `Raise Jam vs Donk` subtitle and `jam`/`fold` actions

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a00c14f6c4832a812d3c0ffb80ff5e