### PR TITLE
feat: add l3 bet jam vs raise spot kind

### DIFF
--- a/lib/ui/session_player/models.dart
+++ b/lib/ui/session_player/models.dart
@@ -9,7 +9,8 @@ enum SpotKind {
   l3_check_jam_vs_cbet,
   l3_donk_jam,
   l3_overbet_jam,
-  l3_raise_jam_vs_donk
+  l3_raise_jam_vs_donk,
+  l3_bet_jam_vs_raise
 }
 
 class UiSpot {

--- a/lib/ui/session_player/mvs_player.dart
+++ b/lib/ui/session_player/mvs_player.dart
@@ -1072,6 +1072,9 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
     if (spot.kind == SpotKind.l3_raise_jam_vs_donk) {
       return 'Raise Jam vs Donk • $core';
     }
+    if (spot.kind == SpotKind.l3_bet_jam_vs_raise) {
+      return 'Bet Jam vs Raise • $core';
+    }
     return core;
   }
 
@@ -1098,6 +1101,8 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
       case SpotKind.l3_overbet_jam:
         return ['jam', 'fold'];
       case SpotKind.l3_raise_jam_vs_donk:
+        return ['jam', 'fold'];
+      case SpotKind.l3_bet_jam_vs_raise:
         return ['jam', 'fold'];
     }
   }


### PR DESCRIPTION
## Summary
- add `l3_bet_jam_vs_raise` to `SpotKind`
- show jam/fold actions for `l3_bet_jam_vs_raise`
- subtitle prefix `Bet Jam vs Raise` for new spot kind

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a012510194832a8367863a29e0ff9c