### PR TITLE
feat: add raise jam vs c-bet spot

### DIFF
--- a/lib/ui/session_player/models.dart
+++ b/lib/ui/session_player/models.dart
@@ -10,7 +10,8 @@ enum SpotKind {
   l3_donk_jam,
   l3_overbet_jam,
   l3_raise_jam_vs_donk,
-  l3_bet_jam_vs_raise
+  l3_bet_jam_vs_raise,
+  l3_raise_jam_vs_cbet
 }
 
 class UiSpot {

--- a/lib/ui/session_player/mvs_player.dart
+++ b/lib/ui/session_player/mvs_player.dart
@@ -1075,6 +1075,9 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
     if (spot.kind == SpotKind.l3_bet_jam_vs_raise) {
       return 'Bet Jam vs Raise • $core';
     }
+    if (spot.kind == SpotKind.l3_raise_jam_vs_cbet) {
+      return 'Raise Jam vs C-bet • $core';
+    }
     return core;
   }
 
@@ -1103,6 +1106,8 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
       case SpotKind.l3_raise_jam_vs_donk:
         return ['jam', 'fold'];
       case SpotKind.l3_bet_jam_vs_raise:
+        return ['jam', 'fold'];
+      case SpotKind.l3_raise_jam_vs_cbet:
         return ['jam', 'fold'];
     }
   }


### PR DESCRIPTION
## Summary
- support L3 raise jam vs c-bet spot kind
- expose jam/fold actions and contextual subtitle

## Testing
- `dart format lib/ui/session_player/models.dart lib/ui/session_player/mvs_player.dart` *(fails: command not found: dart)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `dart test` *(fails: command not found: dart)*

------
https://chatgpt.com/codex/tasks/task_e_68a01366c1a4832a8abdf1663c1ae66e