### PR TITLE
Add probe jam vs raise spot kind

### DIFF
--- a/lib/ui/session_player/models.dart
+++ b/lib/ui/session_player/models.dart
@@ -11,7 +11,8 @@ enum SpotKind {
   l3_overbet_jam,
   l3_raise_jam_vs_donk,
   l3_bet_jam_vs_raise,
-  l3_raise_jam_vs_cbet
+  l3_raise_jam_vs_cbet,
+  l3_probe_jam_vs_raise
 }
 
 class UiSpot {

--- a/lib/ui/session_player/mvs_player.dart
+++ b/lib/ui/session_player/mvs_player.dart
@@ -1078,6 +1078,9 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
     if (spot.kind == SpotKind.l3_raise_jam_vs_cbet) {
       return 'Raise Jam vs C-bet • $core';
     }
+    if (spot.kind == SpotKind.l3_probe_jam_vs_raise) {
+      return 'Probe Jam vs Raise • $core';
+    }
     return core;
   }
 
@@ -1108,6 +1111,8 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
       case SpotKind.l3_bet_jam_vs_raise:
         return ['jam', 'fold'];
       case SpotKind.l3_raise_jam_vs_cbet:
+        return ['jam', 'fold'];
+      case SpotKind.l3_probe_jam_vs_raise:
         return ['jam', 'fold'];
     }
   }


### PR DESCRIPTION
## Summary
- extend SpotKind enum with `l3_probe_jam_vs_raise`
- wire probe-jam-over-raise actions and subtitle

## Testing
- ⚠️ `dart format lib/ui/session_player/models.dart lib/ui/session_player/mvs_player.dart` (command not found: dart)
- ⚠️ `dart analyze` (command not found: dart)
- ⚠️ `flutter test` (command not found: flutter)


------
https://chatgpt.com/codex/tasks/task_e_68a0148ed998832a8a2a0cda5daa9de0