### PR TITLE
feat: add turn jam vs bet spot

### DIFF
--- a/lib/ui/session_player/models.dart
+++ b/lib/ui/session_player/models.dart
@@ -13,7 +13,8 @@ enum SpotKind {
   l3_bet_jam_vs_raise,
   l3_raise_jam_vs_cbet,
   l3_probe_jam_vs_raise,
-  l3_river_jam_vs_bet
+  l3_river_jam_vs_bet,
+  l3_turn_jam_vs_bet
 }
 
 class UiSpot {

--- a/lib/ui/session_player/mvs_player.dart
+++ b/lib/ui/session_player/mvs_player.dart
@@ -1081,6 +1081,9 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
     if (spot.kind == SpotKind.l3_probe_jam_vs_raise) {
       return 'Probe Jam vs Raise • $core';
     }
+    if (spot.kind == SpotKind.l3_turn_jam_vs_bet) {
+      return 'Turn Jam vs Bet • $core';
+    }
     if (spot.kind == SpotKind.l3_river_jam_vs_bet) {
       return 'River Jam vs Bet • $core';
     }
@@ -1118,6 +1121,8 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
       case SpotKind.l3_probe_jam_vs_raise:
         return ['jam', 'fold'];
       case SpotKind.l3_river_jam_vs_bet:
+        return ['jam', 'fold'];
+      case SpotKind.l3_turn_jam_vs_bet:
         return ['jam', 'fold'];
     }
   }


### PR DESCRIPTION
## Summary
- extend SpotKind with `l3_turn_jam_vs_bet`
- wire subtitle and actions for turn jam vs bet spots

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a016dd5958832aa1cbf196c0997e8a