### PR TITLE
Add L3 river jam vs raise spot kind

### DIFF
--- a/lib/ui/session_player/models.dart
+++ b/lib/ui/session_player/models.dart
@@ -14,7 +14,8 @@ enum SpotKind {
   l3_raise_jam_vs_cbet,
   l3_probe_jam_vs_raise,
   l3_river_jam_vs_bet,
-  l3_turn_jam_vs_bet
+  l3_turn_jam_vs_bet,
+  l3_river_jam_vs_raise
 }
 
 class UiSpot {

--- a/lib/ui/session_player/mvs_player.dart
+++ b/lib/ui/session_player/mvs_player.dart
@@ -1087,6 +1087,9 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
     if (spot.kind == SpotKind.l3_river_jam_vs_bet) {
       return 'River Jam vs Bet • $core';
     }
+    if (spot.kind == SpotKind.l3_river_jam_vs_raise) {
+      return 'River Jam vs Raise • $core';
+    }
     return core;
   }
 
@@ -1123,6 +1126,8 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
       case SpotKind.l3_river_jam_vs_bet:
         return ['jam', 'fold'];
       case SpotKind.l3_turn_jam_vs_bet:
+        return ['jam', 'fold'];
+      case SpotKind.l3_river_jam_vs_raise:
         return ['jam', 'fold'];
     }
   }


### PR DESCRIPTION
## Summary
- extend `SpotKind` with `l3_river_jam_vs_raise`
- handle jam/fold actions and subtitle for river jam over raise

## Testing
- `dart format lib/ui/session_player/models.dart lib/ui/session_player/mvs_player.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a017f230b0832abba2f9972f4f8f1a