### PR TITLE
feat: add L3 turn jam vs raise spot kind

### DIFF
--- a/lib/ui/session_player/models.dart
+++ b/lib/ui/session_player/models.dart
@@ -15,7 +15,8 @@ enum SpotKind {
   l3_probe_jam_vs_raise,
   l3_river_jam_vs_bet,
   l3_turn_jam_vs_bet,
-  l3_river_jam_vs_raise
+  l3_river_jam_vs_raise,
+  l3_turn_jam_vs_raise
 }
 
 class UiSpot {

--- a/lib/ui/session_player/mvs_player.dart
+++ b/lib/ui/session_player/mvs_player.dart
@@ -1084,6 +1084,9 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
     if (spot.kind == SpotKind.l3_turn_jam_vs_bet) {
       return 'Turn Jam vs Bet • $core';
     }
+    if (spot.kind == SpotKind.l3_turn_jam_vs_raise) {
+      return 'Turn Jam vs Raise • $core';
+    }
     if (spot.kind == SpotKind.l3_river_jam_vs_bet) {
       return 'River Jam vs Bet • $core';
     }
@@ -1128,6 +1131,8 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
       case SpotKind.l3_turn_jam_vs_bet:
         return ['jam', 'fold'];
       case SpotKind.l3_river_jam_vs_raise:
+        return ['jam', 'fold'];
+      case SpotKind.l3_turn_jam_vs_raise:
         return ['jam', 'fold'];
     }
   }


### PR DESCRIPTION
## Summary
- support L3 turn jam vs raise spot kind
- show appropriate jam/fold actions and subtitle

## Testing
- `dart format lib/ui/session_player/models.dart lib/ui/session_player/mvs_player.dart` *(fails: command not found)*
- `flutter format lib/ui/session_player/models.dart lib/ui/session_player/mvs_player.dart` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0194cd06c832a974d7029146f37e9