### PR TITLE
feat: add flop jam vs bet spot kind

### DIFF
--- a/lib/ui/session_player/models.dart
+++ b/lib/ui/session_player/models.dart
@@ -16,7 +16,8 @@ enum SpotKind {
   l3_river_jam_vs_bet,
   l3_turn_jam_vs_bet,
   l3_river_jam_vs_raise,
-  l3_turn_jam_vs_raise
+  l3_turn_jam_vs_raise,
+  l3_flop_jam_vs_bet
 }
 
 class UiSpot {

--- a/lib/ui/session_player/mvs_player.dart
+++ b/lib/ui/session_player/mvs_player.dart
@@ -1081,6 +1081,9 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
     if (spot.kind == SpotKind.l3_probe_jam_vs_raise) {
       return 'Probe Jam vs Raise • $core';
     }
+    if (spot.kind == SpotKind.l3_flop_jam_vs_bet) {
+      return 'Flop Jam vs Bet • $core';
+    }
     if (spot.kind == SpotKind.l3_turn_jam_vs_bet) {
       return 'Turn Jam vs Bet • $core';
     }
@@ -1125,6 +1128,8 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
       case SpotKind.l3_raise_jam_vs_cbet:
         return ['jam', 'fold'];
       case SpotKind.l3_probe_jam_vs_raise:
+        return ['jam', 'fold'];
+      case SpotKind.l3_flop_jam_vs_bet:
         return ['jam', 'fold'];
       case SpotKind.l3_river_jam_vs_bet:
         return ['jam', 'fold'];


### PR DESCRIPTION
## Summary
- support new L3 flop jam vs bet spot kind
- show correct subtitle and jam/fold actions

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a01a8f4638832aa783f3defe5cf7f4