### PR TITLE
feat: add flop jam vs raise

### DIFF
--- a/lib/ui/session_player/models.dart
+++ b/lib/ui/session_player/models.dart
@@ -17,7 +17,8 @@ enum SpotKind {
   l3_turn_jam_vs_bet,
   l3_river_jam_vs_raise,
   l3_turn_jam_vs_raise,
-  l3_flop_jam_vs_bet
+  l3_flop_jam_vs_bet,
+  l3_flop_jam_vs_raise
 }
 
 class UiSpot {

--- a/lib/ui/session_player/mvs_player.dart
+++ b/lib/ui/session_player/mvs_player.dart
@@ -1084,6 +1084,9 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
     if (spot.kind == SpotKind.l3_flop_jam_vs_bet) {
       return 'Flop Jam vs Bet • $core';
     }
+    if (spot.kind == SpotKind.l3_flop_jam_vs_raise) {
+      return 'Flop Jam vs Raise • $core';
+    }
     if (spot.kind == SpotKind.l3_turn_jam_vs_bet) {
       return 'Turn Jam vs Bet • $core';
     }
@@ -1130,6 +1133,8 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
       case SpotKind.l3_probe_jam_vs_raise:
         return ['jam', 'fold'];
       case SpotKind.l3_flop_jam_vs_bet:
+        return ['jam', 'fold'];
+      case SpotKind.l3_flop_jam_vs_raise:
         return ['jam', 'fold'];
       case SpotKind.l3_river_jam_vs_bet:
         return ['jam', 'fold'];


### PR DESCRIPTION
## Summary
- add `l3_flop_jam_vs_raise` spot kind
- show Flop Jam vs Raise subtitle and jam/fold actions

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a01bb77e94832ab38f7e1d466092f7