### PR TITLE
test: cover river jam vs bet spot

### DIFF
--- a/test/ui/session_player/mvs_session_player_river_jam_vs_bet_test.dart
+++ b/test/ui/session_player/mvs_session_player_river_jam_vs_bet_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/ui/session_player/mvs_player.dart';
+import 'package:poker_analyzer/ui/session_player/models.dart';
+
+void main() {
+  testWidgets('renders River Jam vs Bet spot', (WidgetTester tester) async {
+    SharedPreferences.setMockInitialValues({});
+
+    final spot = UiSpot(
+      kind: SpotKind.l3_river_jam_vs_bet,
+      hand: 'A\u2660K\u2660',
+      pos: 'BTN',
+      stack: '20bb',
+      vsPos: 'BB',
+      action: 'jam',
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: MvsSessionPlayer(spots: [spot]),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('River Jam vs Bet'), findsOneWidget);
+    expect(find.text('jam'), findsOneWidget);
+    expect(find.text('fold'), findsOneWidget);
+  });
+}
+


### PR DESCRIPTION
## Summary
- add widget test ensuring MvsSessionPlayer handles River Jam vs Bet spots

## Testing
- `flutter test test/ui/session_player/mvs_session_player_river_jam_vs_bet_test.dart` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68a02ef8b3a8832a95a120795ad1a936