### PR TITLE
test: add turn jam vs raise mvs player test

### DIFF
--- a/test/ui/session_player/mvs_session_player_turn_jam_vs_raise_test.dart
+++ b/test/ui/session_player/mvs_session_player_turn_jam_vs_raise_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:poker_analyzer/ui/session_player/mvs_player.dart';
+import 'package:poker_analyzer/ui/session_player/models.dart';
+
+void main() {
+  testWidgets('renders Turn Jam vs Raise spot', (WidgetTester tester) async {
+    SharedPreferences.setMockInitialValues({});
+
+    final spot = UiSpot(
+      kind: SpotKind.l3_turn_jam_vs_raise,
+      hand: 'A\\u2660K\\u2660',
+      pos: 'BTN',
+      stack: '20bb',
+      vsPos: 'BB',
+      action: 'jam',
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: MvsSessionPlayer(spots: [spot]),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('Turn Jam vs Raise'), findsOneWidget);
+    expect(find.text('jam'), findsOneWidget);
+    expect(find.text('fold'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add widget test covering Turn Jam vs Raise scenario in MvsSessionPlayer

## Testing
- `flutter test test/ui/session_player/mvs_session_player_turn_jam_vs_raise_test.dart` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68a03340f6b0832aa209c265b5f25bbc