### PR TITLE
test: ensure flop jam vs bet renders action buttons

### DIFF
--- a/test/ui/session_player/mvs_session_player_flop_jam_vs_bet_test.dart
+++ b/test/ui/session_player/mvs_session_player_flop_jam_vs_bet_test.dart
@@ -31,5 +31,6 @@ void main() {
     expect(find.textContaining('Flop Jam vs Bet'), findsOneWidget);
     expect(find.text('jam'), findsOneWidget);
     expect(find.text('fold'), findsOneWidget);
+    expect(find.byType(ElevatedButton), findsNWidgets(2));
   });
 }


### PR DESCRIPTION
## Summary
- extend flop jam vs bet widget test to verify jam and fold buttons are rendered

## Testing
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a03e4b1858832ab08e172f39572d16