### PR TITLE
feat: add auto why preference for jam spots

### DIFF
--- a/lib/ui/session_player/mvs_player.dart
+++ b/lib/ui/session_player/mvs_player.dart
@@ -137,7 +137,7 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
       timeLimitMs: 10000,
       sound: false,
       haptics: true,
-      autoWhyOnWrong: true,
+      autoWhyOnWrong: false,
       autoNextDelayMs: 600,
       fontScale: 1.0);
   bool _autoNext = false;
@@ -307,6 +307,8 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
     _ticker?.cancel();
     _timebarTicker?.cancel();
     final spot = _spots[_index];
+    final autoWhy = _prefs.autoWhyOnWrong;
+    final jam = spot.kind.name.contains('_jam_vs_');
     final correct = action == spot.action;
     // mobile haptics
     if (_prefs.haptics) {
@@ -330,7 +332,7 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
         chosen: action,
         elapsed: _timer.elapsed,
       ));
-      if (!correct && _prefs.autoWhyOnWrong) {
+      if (!correct && autoWhy && jam) {
         _showExplain = true;
       }
     });

--- a/lib/ui/session_player/ui_prefs.dart
+++ b/lib/ui/session_player/ui_prefs.dart
@@ -46,7 +46,7 @@ class UiPrefs {
       sound: b(m["sound"], false),
       haptics: b(m["haptics"], true),
       autoWhyOnWrong:
-          b(m["autoWhyOnWrong"], b(m["autoExplainOnWrong"], true)),
+          b(m["autoWhyOnWrong"], b(m["autoExplainOnWrong"], false)),
       autoNextDelayMs: autoNextDelayMs,
       fontScale: fs as double,
     );
@@ -65,7 +65,7 @@ Future<UiPrefs> loadUiPrefs({String path = 'out/ui_prefs_v1.json'}) async {
         timeLimitMs: 10000,
         sound: false,
         haptics: true,
-        autoWhyOnWrong: true,
+        autoWhyOnWrong: false,
         autoNextDelayMs: delay as int,
         fontScale: (fsOverride ?? 1.0).clamp(0.9, 1.3),
         );
@@ -94,7 +94,7 @@ Future<UiPrefs> loadUiPrefs({String path = 'out/ui_prefs_v1.json'}) async {
       timeLimitMs: 10000,
       sound: false,
       haptics: true,
-      autoWhyOnWrong: true,
+      autoWhyOnWrong: false,
       autoNextDelayMs: delay as int,
       fontScale: (fsOverride ?? 1.0).clamp(0.9, 1.3),
       );


### PR DESCRIPTION
## Summary
- add `autoWhyOnWrong` preference defaulting off
- auto-show "Why?" explanation on wrong answers for L3 jam spots

## Testing
- `dart format lib/ui/session_player/ui_prefs.dart lib/ui/session_player/mvs_player.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0486a72c4832a9400f904a6349fe4