### PR TITLE
feat: add Y hotkey for auto why

### DIFF
--- a/lib/ui/session_player/mvs_player.dart
+++ b/lib/ui/session_player/mvs_player.dart
@@ -1016,6 +1016,15 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
             saveUiPrefs(p);
             return;
           }
+          if (_showHotkeys && event.logicalKey == LogicalKeyboardKey.keyY) {
+            final p =
+                _prefs.copyWith(autoWhyOnWrong: !_prefs.autoWhyOnWrong);
+            setState(() {
+              _prefs = p;
+            });
+            saveUiPrefs(p);
+            return;
+          }
           if (_chosen == null) {
             if (event.logicalKey == LogicalKeyboardKey.digit1 &&
                 actions.length > 0) {


### PR DESCRIPTION
## Summary
- add desktop/web Y hotkey to toggle Auto Why preference during sessions

## Testing
- `flutter format lib/ui/session_player/mvs_player.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0529fa190832a930fb3a8fd0f6fa2