### PR TITLE
Add slash hotkey for Hotkeys help sheet

### DIFF
--- a/lib/ui/session_player/mvs_player.dart
+++ b/lib/ui/session_player/mvs_player.dart
@@ -994,6 +994,15 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
             }
             return;
           }
+          if (_showHotkeys && event.logicalKey == LogicalKeyboardKey.slash) {
+            showModalBottomSheet<void>(
+              context: context,
+              backgroundColor: Colors.black87,
+              isScrollControlled: false,
+              builder: (_) => const HotkeysSheet(),
+            );
+            return;
+          }
           if (event.logicalKey == LogicalKeyboardKey.keyA) {
             final v = !_autoNext;
             final p = _prefs.copyWith(autoNext: v);


### PR DESCRIPTION
## Summary
- open Hotkeys help sheet with slash key on desktop/web sessions

## Testing
- `dart format lib/ui/session_player/mvs_player.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0546a4b64832a99c3f3aa22ee9d02