### PR TITLE
feat: add skip/undo hotkeys

### DIFF
--- a/lib/ui/session_player/mvs_player.dart
+++ b/lib/ui/session_player/mvs_player.dart
@@ -1036,6 +1036,14 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
                 context, p.autoWhyOnWrong ? 'Auto Why: ON' : 'Auto Why: OFF');
             return;
           }
+          if (_showHotkeys && event.logicalKey == LogicalKeyboardKey.keyS) {
+            if (_chosen == null) _skip();
+            return;
+          }
+          if (_showHotkeys && event.logicalKey == LogicalKeyboardKey.keyU) {
+            if (_answers.isNotEmpty) _undo();
+            return;
+          }
           if (_chosen == null) {
             if (event.logicalKey == LogicalKeyboardKey.digit1 &&
                 actions.length > 0) {


### PR DESCRIPTION
## Summary
- Add keyboard shortcut S to skip unanswered spots when hotkeys are enabled
- Add keyboard shortcut U to undo last answered spot when hotkeys are enabled

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a05596c0e0832a8184074a7c1e4ebc