### PR TITLE
Enable auto-explanations on wrong answers by default

### DIFF
--- a/lib/ui/session_player/mvs_player.dart
+++ b/lib/ui/session_player/mvs_player.dart
@@ -139,7 +139,7 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
       timeLimitMs: 10000,
       sound: false,
       haptics: true,
-      autoWhyOnWrong: false,
+      autoWhyOnWrong: true,
       autoNextDelayMs: 600,
       fontScale: 1.0);
   bool _autoNext = false;

--- a/lib/ui/session_player/ui_prefs.dart
+++ b/lib/ui/session_player/ui_prefs.dart
@@ -46,7 +46,7 @@ class UiPrefs {
       sound: b(m["sound"], false),
       haptics: b(m["haptics"], true),
       autoWhyOnWrong:
-          b(m["autoWhyOnWrong"], b(m["autoExplainOnWrong"], false)),
+          b(m["autoWhyOnWrong"], b(m["autoExplainOnWrong"], true)),
       autoNextDelayMs: autoNextDelayMs,
       fontScale: fs as double,
     );
@@ -65,7 +65,7 @@ Future<UiPrefs> loadUiPrefs({String path = 'out/ui_prefs_v1.json'}) async {
         timeLimitMs: 10000,
         sound: false,
         haptics: true,
-        autoWhyOnWrong: false,
+        autoWhyOnWrong: true,
         autoNextDelayMs: delay as int,
         fontScale: (fsOverride ?? 1.0).clamp(0.9, 1.3),
         );
@@ -94,7 +94,7 @@ Future<UiPrefs> loadUiPrefs({String path = 'out/ui_prefs_v1.json'}) async {
       timeLimitMs: 10000,
       sound: false,
       haptics: true,
-      autoWhyOnWrong: false,
+      autoWhyOnWrong: true,
       autoNextDelayMs: delay as int,
       fontScale: (fsOverride ?? 1.0).clamp(0.9, 1.3),
       );


### PR DESCRIPTION
## Summary
- default to showing explanations when no user preference is stored
- initialize session player prefs with auto Why enabled

## Testing
- `dart format lib/ui/session_player/ui_prefs.dart lib/ui/session_player/mvs_player.dart` *(fails: command not found)*
- `flutter format lib/ui/session_player/ui_prefs.dart lib/ui/session_player/mvs_player.dart` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package)*
- `apt-get install -y flutter` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68a086c71c10832ab105a4e0cd44209f