### PR TITLE
chore: add flutter ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: Flutter CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - uses: actions/cache@v4
+        with:
+          path: ~/.pub-cache
+          key: pub-${{ runner.os }}-${{ hashFiles('**/pubspec.lock') }}
+          restore-keys: |
+            pub-${{ runner.os }}-
+      - run: flutter pub get
+      - run: dart format --output=none --set-exit-if-changed .
+      - run: dart analyze
+      - run: flutter test -r expanded
+      - name: Validate training content
+        if: hashFiles('tools/validate_training_content.dart') != ''
+        run: dart tools/validate_training_content.dart --ci


### PR DESCRIPTION
## Summary
- add minimal GitHub Actions workflow for Flutter CI with formatting, analysis, tests, and optional training content validation

## Testing
- `flutter pub get`
- `dart format --output=none --set-exit-if-changed .` *(fails: source could not be parsed)*
- `dart analyze` *(582 issues found)*
- `flutter test -r expanded` *(fails: multiple compile errors)*
- `if [ -f tools/validate_training_content.dart ]; then echo exists; else echo 'validate script not found'; fi`

------
https://chatgpt.com/codex/tasks/task_e_68a093f762c0832abaf328e9d927908f