### PR TITLE
Add privacy and terms screens

### DIFF
--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import '../services/user_preferences_service.dart';
 import 'tag_management_screen.dart';
@@ -18,6 +19,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter_colorpicker/flutter_colorpicker.dart';
 import 'lesson_track_library_screen.dart';
 import '../services/skill_tree_settings_service.dart';
+import '../ui/settings/privacy_terms.dart';
 
 class SettingsScreen extends StatefulWidget {
   const SettingsScreen({super.key});
@@ -298,6 +300,24 @@ class _SettingsScreenState extends State<SettingsScreen> {
               title: const Text('Accent Color'),
               leading: CircleAvatar(backgroundColor: _accentColor),
               onTap: _pickAccentColor,
+            ),
+            ListTile(
+              title: Text(AppLocalizations.of(context)!.privacy_title),
+              onTap: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => const PrivacyScreen()),
+                );
+              },
+            ),
+            ListTile(
+              title: Text(AppLocalizations.of(context)!.terms_title),
+              onTap: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => const TermsScreen()),
+                );
+              },
             ),
             Consumer<AuthService>(
               builder: (context, auth, child) {

--- a/lib/ui/settings/privacy_terms.dart
+++ b/lib/ui/settings/privacy_terms.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+class PrivacyScreen extends StatelessWidget {
+  const PrivacyScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    return Scaffold(
+      appBar: AppBar(title: Text(l10n.privacy_title)),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: SingleChildScrollView(
+            child: SelectableText(l10n.privacy_body),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class TermsScreen extends StatelessWidget {
+  const TermsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    return Scaffold(
+      appBar: AppBar(title: Text(l10n.terms_title)),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: SingleChildScrollView(
+            child: SelectableText(l10n.terms_body),
+          ),
+        ),
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- Add simple Privacy and Terms screens with localized content
- Link Privacy and Terms entries from Settings screen

## Testing
- ⚠️ `flutter analyze` *(missing: flutter)*
- ⚠️ `flutter test` *(missing: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68a097bf9bc8832ab45345f8b6475674