### PR TITLE
refactor: use mini toast for timeout

### DIFF
--- a/lib/ui/session_player/mvs_player.dart
+++ b/lib/ui/session_player/mvs_player.dart
@@ -301,9 +301,7 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
         if (_timeLeftMs <= 0) {
           _timeLeftMs = 0;
           _timebarTicker?.cancel();
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('Time up')),
-          );
+          unawaited(showMiniToast(context, 'Time limit reached'));
           if (_prefs.haptics) {
             try {
               HapticFeedback.vibrate();


### PR DESCRIPTION
## Summary
- replace timeout SnackBar with mini toast for smoother toast-based alert

## Testing
- `dart format lib/ui/session_player/mvs_player.dart` *(parse error: Expected to find ')')*
- `flutter analyze lib/ui/session_player/mvs_player.dart` *(plugin warning: file_picker default_package missing inline implementation)*
- `flutter test` *(plugin warning: file_picker default_package missing inline implementation, tests did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ac94dac8832ab3b1316aafcbff3a