### PR TITLE
Add coverage dashboard

### DIFF
--- a/lib/ui/session_player/mvs_player.dart
+++ b/lib/ui/session_player/mvs_player.dart
@@ -22,6 +22,7 @@ import 'result_summary.dart';
 import 'ui_prefs.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../../services/spot_importer.dart';
+import '../coverage/coverage_dashboard.dart';
 
 extension _UiPrefsCopy on UiPrefs {
   UiPrefs copyWith({
@@ -776,6 +777,20 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
               onPressed:
                   (_index >= _spots.length || _chosen != null) ? null : _skip,
             ),
+            if (kDebugMode)
+              IconButton(
+                icon: const Icon(Icons.insights),
+                tooltip: 'Coverage',
+                onPressed: () {
+                  final s = _lastLoadedSpots ?? _spots;
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => CoverageDashboard(spots: s),
+                    ),
+                  );
+                },
+              ),
             IconButton(
               icon: Icon(_paused ? Icons.play_arrow : Icons.pause),
               tooltip: _paused ? 'Resume' : 'Pause',


### PR DESCRIPTION
## Summary
- add coverage dashboard showing position/stack grid and baseline coverage
- hook up dev-only insights button to open coverage dashboard

## Testing
- `flutter analyze` *(fails: command not found: flutter)*
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b73d7b90832aa417881773bd0e86