### PR TITLE
Add SpotImporter tests and coverage/module filters

### DIFF
--- a/lib/ui/modules/modules_screen.dart
+++ b/lib/ui/modules/modules_screen.dart
@@ -44,6 +44,9 @@ class ModulesScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final pre = _preflopCore();
+    final flop = _flopJam();
+    final mix = _mixed();
     return Scaffold(
       appBar: AppBar(title: const Text('Modules')),
       body: ListView(
@@ -51,13 +54,13 @@ class ModulesScreen extends StatelessWidget {
           ListTile(
             title: const Text('Preflop Core'),
             subtitle: const Text('10/20/40/100bb × positions'),
+            trailing: Chip(label: Text('${pre.length} spots')),
             onTap: () {
-              final subset = _preflopCore();
               Navigator.push(
                 context,
                 MaterialPageRoute(
-                  builder: (_) => MvsSessionPlayer(
-                      spots: subset, packId: 'mod:preflop'),
+                  builder: (_) =>
+                      MvsSessionPlayer(spots: pre, packId: 'mod:preflop'),
                 ),
               );
             },
@@ -65,13 +68,13 @@ class ModulesScreen extends StatelessWidget {
           ListTile(
             title: const Text('Flop Jam'),
             subtitle: const Text('SPR<3'),
+            trailing: Chip(label: Text('${flop.length} spots')),
             onTap: () {
-              final subset = _flopJam();
               Navigator.push(
                 context,
                 MaterialPageRoute(
-                  builder: (_) => MvsSessionPlayer(
-                      spots: subset, packId: 'mod:flopjam'),
+                  builder: (_) =>
+                      MvsSessionPlayer(spots: flop, packId: 'mod:flopjam'),
                 ),
               );
             },
@@ -79,13 +82,13 @@ class ModulesScreen extends StatelessWidget {
           ListTile(
             title: const Text('Mixed Drill'),
             subtitle: const Text('random 20 from current pool'),
+            trailing: Chip(label: Text('${mix.length} spots')),
             onTap: () {
-              final subset = _mixed();
               Navigator.push(
                 context,
                 MaterialPageRoute(
                   builder: (_) =>
-                      MvsSessionPlayer(spots: subset, packId: 'mod:mixed'),
+                      MvsSessionPlayer(spots: mix, packId: 'mod:mixed'),
                 ),
               );
             },

--- a/test/spot_importer_test.dart
+++ b/test/spot_importer_test.dart
@@ -1,0 +1,52 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/services/spot_importer.dart';
+import 'package:poker_analyzer/ui/session_player/models.dart';
+
+void main() {
+  test('case-insensitive kind and field trimming', () {
+    const json =
+        '[{"kind":"CALLVSJAM","hand":" AKo ","pos":" BTN ","stack":" 10bb ","action":" push "}]';
+    final report = SpotImporter.parse(json, kind: 'Json');
+    expect(report.added, 1);
+    expect(report.skipped, 0);
+    expect(report.errors, isEmpty);
+    final spot = report.spots.single;
+    expect(spot.kind, SpotKind.callVsJam);
+    expect(spot.hand, 'AKo');
+    expect(spot.pos, 'BTN');
+    expect(spot.stack, '10bb');
+    expect(spot.action, 'push');
+  });
+
+  test('duplicate detection JSON', () {
+    const json =
+        '[{"kind":"callVsJam","hand":"AKo","pos":"BTN","stack":"10bb","action":"push"}, {"kind":"callVsJam","hand":"AKo","pos":"BTN","stack":"10bb","action":"push"}]';
+    final report = SpotImporter.parse(json, kind: 'json');
+    expect(report.added, 1);
+    expect(report.skipped, 1);
+    expect(report.errors.length, 1);
+    expect(report.errors.first.startsWith('Duplicate spot:'), isTrue);
+  });
+
+  test('duplicate detection CSV', () {
+    const csv =
+        'kind,hand,pos,stack,action\ncallVsJam,AKo,BTN,10bb,push\ncallVsJam,AKo,BTN,10bb,push';
+    final report = SpotImporter.parse(csv, kind: 'CSV');
+    expect(report.added, 1);
+    expect(report.skipped, 1);
+    expect(report.errors.length, 1);
+    expect(report.errors.first.startsWith('Duplicate spot:'), isTrue);
+  });
+
+  test('error cap at five messages', () {
+    final items = List.generate(
+      7,
+      (i) => '{"kind":"x","hand":"h","pos":"p","stack":"s","action":"a"}',
+    );
+    final json = '[${items.join(',')}]';
+    final report = SpotImporter.parse(json, kind: 'json');
+    expect(report.added, 0);
+    expect(report.skipped, 7);
+    expect(report.errors.length, 5);
+  });
+}


### PR DESCRIPTION
## Summary
- add unit tests for SpotImporter covering casing, trimming, dedup and error cap
- allow coverage dashboard to filter preflop/postflop spots via choice chips
- show spot counts on module tiles before starting

## Testing
- `dart analyze lib/ui/coverage/coverage_dashboard.dart lib/ui/modules/modules_screen.dart`
- `dart analyze test/spot_importer_test.dart`
- `dart test -r expanded test/spot_importer_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_68a0bd731f0c832a98962be908b1c5a1