### PR TITLE
feat: improve CSV import robustness

### DIFF
--- a/lib/screens/empty_training_screen.dart
+++ b/lib/screens/empty_training_screen.dart
@@ -38,14 +38,16 @@ class EmptyTrainingScreen extends StatelessWidget {
       final f = File('out/seed_spots.json');
       if (f.existsSync()) {
         final content = await f.readAsString();
-        final report = SpotImporter.parse(content, kind: 'json');
+        final report = SpotImporter.parse(content, format: 'json');
         spots = report.spots;
       }
     } catch (_) {}
     if (spots.isEmpty) {
       try {
         final result = await FilePicker.platform.pickFiles(
-            type: FileType.custom, allowedExtensions: ['csv', 'json']);
+          type: FileType.custom,
+          allowedExtensions: ['csv', 'json'],
+        );
         if (result == null || result.files.isEmpty) {
           showMiniToast(context, 'Import cancelled');
           return;
@@ -62,7 +64,7 @@ class EmptyTrainingScreen extends StatelessWidget {
           return;
         }
         final ext = (f.extension ?? '').toLowerCase();
-        final report = SpotImporter.parse(content, kind: ext);
+        final report = SpotImporter.parse(content, format: ext);
         spots = report.spots;
         for (final e in report.errors) {
           showMiniToast(context, e);

--- a/lib/ui/session_player/mvs_player.dart
+++ b/lib/ui/session_player/mvs_player.dart
@@ -54,12 +54,13 @@ class MvsSessionPlayer extends StatefulWidget {
   final int? initialIndex;
   final List<UiAnswer>? initialAnswers;
   final String? packId;
-  const MvsSessionPlayer(
-      {super.key,
-      required this.spots,
-      this.initialIndex,
-      this.initialAnswers,
-      this.packId});
+  const MvsSessionPlayer({
+    super.key,
+    required this.spots,
+    this.initialIndex,
+    this.initialAnswers,
+    this.packId,
+  });
 
   static Future<MvsSessionPlayer?> fromSaved() async {
     final prefs = await SharedPreferences.getInstance();
@@ -85,16 +86,18 @@ class MvsSessionPlayer extends StatefulWidget {
               p is String &&
               st is String &&
               act is String) {
-            spots.add(UiSpot(
-              kind: SpotKind.values[k],
-              hand: h,
-              pos: p,
-              stack: st,
-              action: act,
-              vsPos: e['v'] as String?,
-              limpers: e['l'] as String?,
-              explain: e['e'] as String?,
-            ));
+            spots.add(
+              UiSpot(
+                kind: SpotKind.values[k],
+                hand: h,
+                pos: p,
+                stack: st,
+                action: act,
+                vsPos: e['v'] as String?,
+                limpers: e['l'] as String?,
+                explain: e['e'] as String?,
+              ),
+            );
           } else {
             return null;
           }
@@ -110,12 +113,14 @@ class MvsSessionPlayer extends StatefulWidget {
           final ch = e['chosen'];
           final ms = e['elapsedMs'];
           if (c is bool && ex is String && ch is String && ms is int) {
-            answers.add(UiAnswer(
-              correct: c,
-              expected: ex,
-              chosen: ch,
-              elapsed: Duration(milliseconds: ms),
-            ));
+            answers.add(
+              UiAnswer(
+                correct: c,
+                expected: ex,
+                chosen: ch,
+                elapsed: Duration(milliseconds: ms),
+              ),
+            );
           } else {
             return null;
           }
@@ -125,7 +130,10 @@ class MvsSessionPlayer extends StatefulWidget {
       }
       if (i < 0 || i > spots.length) return null;
       return MvsSessionPlayer(
-          spots: spots, initialIndex: i, initialAnswers: answers);
+        spots: spots,
+        initialIndex: i,
+        initialAnswers: answers,
+      );
     } catch (_) {
       return null;
     }
@@ -149,14 +157,15 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
   String? _chosen;
   bool _showExplain = false;
   UiPrefs _prefs = const UiPrefs(
-      autoNext: false,
-      timeEnabled: true,
-      timeLimitMs: 10000,
-      sound: false,
-      haptics: true,
-      autoWhyOnWrong: true,
-      autoNextDelayMs: 600,
-      fontScale: 1.0);
+    autoNext: false,
+    timeEnabled: true,
+    timeLimitMs: 10000,
+    sound: false,
+    haptics: true,
+    autoWhyOnWrong: true,
+    autoNextDelayMs: 600,
+    fontScale: 1.0,
+  );
   bool _autoNext = false;
   int _timeLimitMs = 10000; // 10s default
   bool _timeEnabled = true; // can toggle
@@ -172,8 +181,11 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
 
   bool get _showHotkeys =>
       kIsWeb ||
-      const {TargetPlatform.macOS, TargetPlatform.windows, TargetPlatform.linux}
-          .contains(defaultTargetPlatform);
+      const {
+        TargetPlatform.macOS,
+        TargetPlatform.windows,
+        TargetPlatform.linux,
+      }.contains(defaultTargetPlatform);
 
   @override
   void initState() {
@@ -213,14 +225,16 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
                     }
                   }
                   if (kind == null) continue;
-                  loadedSpots.add(UiSpot(
-                    kind: kind,
-                    hand: h,
-                    pos: p,
-                    vsPos: v is String ? v : null,
-                    stack: st,
-                    action: a,
-                  ));
+                  loadedSpots.add(
+                    UiSpot(
+                      kind: kind,
+                      hand: h,
+                      pos: p,
+                      vsPos: v is String ? v : null,
+                      stack: st,
+                      action: a,
+                    ),
+                  );
                 }
               }
             }
@@ -232,12 +246,14 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
                 final ch = a['chosen'];
                 final ms = a['elapsedMs'];
                 if (c is bool && e is String && ch is String && ms is int) {
-                  loadedAnswers.add(UiAnswer(
-                    correct: c,
-                    expected: e,
-                    chosen: ch,
-                    elapsed: Duration(milliseconds: ms),
-                  ));
+                  loadedAnswers.add(
+                    UiAnswer(
+                      correct: c,
+                      expected: e,
+                      chosen: ch,
+                      elapsed: Duration(milliseconds: ms),
+                    ),
+                  );
                 }
               }
             }
@@ -266,9 +282,10 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
       vsync: this,
       duration: const Duration(milliseconds: 220),
     );
-    _answerPulse = Tween(begin: 1.0, end: 1.05)
-        .chain(CurveTween(curve: Curves.easeOut))
-        .animate(_answerPulseCtrl);
+    _answerPulse = Tween(
+      begin: 1.0,
+      end: 1.05,
+    ).chain(CurveTween(curve: Curves.easeOut)).animate(_answerPulseCtrl);
     loadUiPrefs().then((p) {
       if (!mounted) return;
       setState(() {
@@ -296,7 +313,9 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
   void _startTicker() {
     _ticker?.cancel();
     _ticker = Timer.periodic(
-        const Duration(milliseconds: 200), (_) => setState(() {}));
+      const Duration(milliseconds: 200),
+      (_) => setState(() {}),
+    );
   }
 
   void _startTimebar() {
@@ -345,7 +364,7 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
               if (s.vsPos != null) 'vsPos': s.vsPos,
               'stack': s.stack,
               'action': s.action,
-            }
+            },
         ],
         'index': _index,
         'answers': [
@@ -355,7 +374,7 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
               'expected': a.expected,
               'chosen': a.chosen,
               'elapsedMs': a.elapsed.inMilliseconds,
-            }
+            },
         ],
       };
       file.writeAsStringSync(jsonEncode(obj));
@@ -371,8 +390,13 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
   void _persistResume() {
     final packId = widget.packId;
     if (packId != null) {
-      unawaited(SessionResume.save(
-          packId: packId, index: _index, sessionId: _sessionId));
+      unawaited(
+        SessionResume.save(
+          packId: packId,
+          index: _index,
+          sessionId: _sessionId,
+        ),
+      );
     }
   }
 
@@ -413,14 +437,13 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
     final jam = spot.kind.name.contains('_jam_vs_');
     final correct = action == spot.action;
     final stackBB = int.tryParse(spot.stack.replaceAll(RegExp(r'[^0-9]'), ''));
-    unawaited(Telemetry.logEvent(
-      correct ? 'answer_correct' : 'answer_wrong',
-      {
+    unawaited(
+      Telemetry.logEvent(correct ? 'answer_correct' : 'answer_wrong', {
         'sessionId': _sessionId,
         'spotKind': spot.kind.name,
         if (stackBB != null) 'stackBB': stackBB,
-      },
-    ));
+      }),
+    );
     // mobile haptics
     if (_prefs.haptics) {
       try {
@@ -436,12 +459,14 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
     }
     setState(() {
       _chosen = action;
-      _answers.add(UiAnswer(
-        correct: correct,
-        expected: spot.action,
-        chosen: action,
-        elapsed: _timer.elapsed,
-      ));
+      _answers.add(
+        UiAnswer(
+          correct: correct,
+          expected: spot.action,
+          chosen: action,
+          elapsed: _timer.elapsed,
+        ),
+      );
       if (!correct && autoWhy && jam) {
         _showExplain = true;
       }
@@ -451,8 +476,9 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
     unawaited(showMiniToast(context, correct ? 'Correct' : 'Wrong'));
     _answerPulseCtrl.forward(from: 0.0);
     setState(() {
-      _answerFlashColor =
-          (correct ? Colors.green : Colors.red).withOpacity(0.12);
+      _answerFlashColor = (correct ? Colors.green : Colors.red).withOpacity(
+        0.12,
+      );
     });
     _answerFlashTimer?.cancel();
     _answerFlashTimer = Timer(const Duration(milliseconds: 250), () {
@@ -508,26 +534,27 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
     if (_index >= _spots.length || _chosen != null) return;
     final spot = _spots[_index];
     final stackBB = int.tryParse(spot.stack.replaceAll(RegExp(r'[^0-9]'), ''));
-    unawaited(Telemetry.logEvent(
-      'answer_skip',
-      {
+    unawaited(
+      Telemetry.logEvent('answer_skip', {
         'sessionId': _sessionId,
         'spotKind': spot.kind.name,
         if (stackBB != null) 'stackBB': stackBB,
-      },
-    ));
+      }),
+    );
     _autoNextTimer?.cancel();
     _cancelAutoNextAnim();
     _timebarTicker?.cancel();
     setState(() {
       // считаем пропуск как неправильный ответ,
       // чтобы длины spots/answers оставались согласованы
-      _answers.add(UiAnswer(
-        correct: false,
-        expected: spot.action,
-        chosen: '(skip)',
-        elapsed: _timer.elapsed,
-      ));
+      _answers.add(
+        UiAnswer(
+          correct: false,
+          expected: spot.action,
+          chosen: '(skip)',
+          elapsed: _timer.elapsed,
+        ),
+      );
       _index++;
       _chosen = null;
       _showExplain = false;
@@ -616,19 +643,22 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
             if (s.vsPos != null) 'v': s.vsPos,
             if (s.limpers != null) 'l': s.limpers,
             if (s.explain != null) 'e': s.explain,
-          }
+          },
       ],
       'wrongIdx': [
         for (var i = 0; i < _answers.length; i++)
-          if (!_answers[i].correct) i
+          if (!_answers[i].correct) i,
       ],
     };
     try {
       final dir = Directory('out');
       if (!dir.existsSync()) dir.createSync(recursive: true);
       final file = File('${dir.path}/sessions_history.jsonl');
-      file.writeAsStringSync('${jsonEncode(obj)}\n',
-          mode: FileMode.append, flush: true);
+      file.writeAsStringSync(
+        '${jsonEncode(obj)}\n',
+        mode: FileMode.append,
+        flush: true,
+      );
     } catch (_) {}
   }
 
@@ -676,14 +706,16 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
       if (_answers[i].correct) continue;
       final s = _spots[i];
       if (!listEquals(_actionsFor(s.kind), const ['jam', 'fold'])) continue;
-      lines.add(jsonEncode({
-        'kind': s.kind.name,
-        'hand': s.hand,
-        'pos': s.pos,
-        if (s.vsPos != null) 'vsPos': s.vsPos,
-        'stack': s.stack,
-        'action': s.action,
-      }));
+      lines.add(
+        jsonEncode({
+          'kind': s.kind.name,
+          'hand': s.hand,
+          'pos': s.pos,
+          if (s.vsPos != null) 'vsPos': s.vsPos,
+          'stack': s.stack,
+          'action': s.action,
+        }),
+      );
     }
     if (lines.isEmpty) {
       showMiniToast(context, 'No errors to export');
@@ -694,15 +726,19 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
       if (!dir.existsSync()) dir.createSync(recursive: true);
       final file = File('${dir.path}/l3_jam_errors.jsonl');
       file.writeAsStringSync(lines.join('\n') + '\n');
-      showMiniToast(context,
-          'Exported ${lines.length} spots to out/packs/l3_jam_errors.jsonl');
+      showMiniToast(
+        context,
+        'Exported ${lines.length} spots to out/packs/l3_jam_errors.jsonl',
+      );
     } catch (_) {}
   }
 
   Future<void> _importSpots() async {
     try {
-      final result = await FilePicker.platform
-          .pickFiles(type: FileType.custom, allowedExtensions: ['csv', 'json']);
+      final result = await FilePicker.platform.pickFiles(
+        type: FileType.custom,
+        allowedExtensions: ['csv', 'json'],
+      );
       if (result == null || result.files.isEmpty) return;
       final f = result.files.first;
       String? content;
@@ -713,9 +749,11 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
       }
       if (content == null) return;
       final ext = (f.extension ?? '').toLowerCase();
-      final report = SpotImporter.parse(content, kind: ext);
+      final report = SpotImporter.parse(content, format: ext);
       showMiniToast(
-          context, 'Imported ${report.added} (skipped ${report.skipped})');
+        context,
+        'Imported ${report.added} (skipped ${report.skipped})',
+      );
       for (final e in report.errors) {
         showMiniToast(context, e);
       }
@@ -726,9 +764,6 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
       showMiniToast(context, 'Import failed');
     }
   }
-
-
-
 
   @override
   Widget build(BuildContext context) {
@@ -775,8 +810,9 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
             IconButton(
               icon: const Icon(Icons.skip_next),
               tooltip: 'Skip',
-              onPressed:
-                  (_index >= _spots.length || _chosen != null) ? null : _skip,
+              onPressed: (_index >= _spots.length || _chosen != null)
+                  ? null
+                  : _skip,
             ),
             if (kDebugMode) ...[
               IconButton(
@@ -799,9 +835,7 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
                   final s = _lastLoadedSpots ?? _spots;
                   Navigator.push(
                     context,
-                    MaterialPageRoute(
-                      builder: (_) => ModulesScreen(spots: s),
-                    ),
+                    MaterialPageRoute(builder: (_) => ModulesScreen(spots: s)),
                   );
                 },
               ),
@@ -820,7 +854,8 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
                   setState(() => _prefs = p);
                   saveUiPrefs(p);
                   unawaited(
-                      showMiniToast(context, v > 1.0 ? 'Font: XL' : 'Font: L'));
+                    showMiniToast(context, v > 1.0 ? 'Font: XL' : 'Font: L'),
+                  );
                 },
               ),
               IconButton(
@@ -830,8 +865,9 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
                   final p = _prefs.copyWith(haptics: v);
                   setState(() => _prefs = p);
                   saveUiPrefs(p);
-                  unawaited(showMiniToast(
-                      context, v ? 'Haptics: ON' : 'Haptics: OFF'));
+                  unawaited(
+                    showMiniToast(context, v ? 'Haptics: ON' : 'Haptics: OFF'),
+                  );
                 },
               ),
             ],
@@ -864,125 +900,154 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
                     double fontScale = _prefs.fontScale;
                     final ctrl = TextEditingController(text: limit.toString());
                     return Padding(
-                      padding: MediaQuery.of(ctx).viewInsets +
+                      padding:
+                          MediaQuery.of(ctx).viewInsets +
                           const EdgeInsets.all(16),
                       child: Column(
                         mainAxisSize: MainAxisSize.min,
                         children: [
-                          Row(children: [
-                            const Text('Auto-next'),
-                            const Spacer(),
-                            Switch(
+                          Row(
+                            children: [
+                              const Text('Auto-next'),
+                              const Spacer(),
+                              Switch(
                                 value: autoNext,
                                 onChanged: (v) {
                                   autoNext = v;
                                   (ctx as Element).markNeedsBuild();
-                                })
-                          ]),
-                          Row(children: [
-                            const Text('Auto-next delay'),
-                            Expanded(
-                              child: Slider(
-                                value: delayMs.toDouble(),
-                                min: 300,
-                                max: 800,
-                                divisions: 10,
-                                label: '${delayMs} ms',
-                                onChanged: autoNext
-                                    ? (v) {
-                                        delayMs = v.round().clamp(300, 800);
-                                        (ctx as Element).markNeedsBuild();
-                                      }
-                                    : null,
+                                },
                               ),
-                            ),
-                            SizedBox(
+                            ],
+                          ),
+                          Row(
+                            children: [
+                              const Text('Auto-next delay'),
+                              Expanded(
+                                child: Slider(
+                                  value: delayMs.toDouble(),
+                                  min: 300,
+                                  max: 800,
+                                  divisions: 10,
+                                  label: '${delayMs} ms',
+                                  onChanged: autoNext
+                                      ? (v) {
+                                          delayMs = v.round().clamp(300, 800);
+                                          (ctx as Element).markNeedsBuild();
+                                        }
+                                      : null,
+                                ),
+                              ),
+                              SizedBox(
                                 width: 56,
-                                child: Text('${delayMs} ms',
-                                    textAlign: TextAlign.end)),
-                          ]),
-                          Row(children: [
-                            const Text('Answer timer'),
-                            const Spacer(),
-                            Switch(
+                                child: Text(
+                                  '${delayMs} ms',
+                                  textAlign: TextAlign.end,
+                                ),
+                              ),
+                            ],
+                          ),
+                          Row(
+                            children: [
+                              const Text('Answer timer'),
+                              const Spacer(),
+                              Switch(
                                 value: timeEnabled,
                                 onChanged: (v) {
                                   timeEnabled = v;
                                   (ctx as Element).markNeedsBuild();
-                                })
-                          ]),
+                                },
+                              ),
+                            ],
+                          ),
                           const SizedBox(height: 8),
                           TextField(
                             controller: ctrl,
                             keyboardType: const TextInputType.numberWithOptions(
-                                signed: false, decimal: false),
+                              signed: false,
+                              decimal: false,
+                            ),
                             decoration: const InputDecoration(
-                                labelText: 'Time limit ms'),
+                              labelText: 'Time limit ms',
+                            ),
                             onChanged: (_) {
                               final t = int.tryParse(ctrl.text);
                               if (t != null) limit = t;
                             },
                           ),
                           const SizedBox(height: 8),
-                          Row(children: [
-                            const Text('Sound'),
-                            const Spacer(),
-                            Switch(
+                          Row(
+                            children: [
+                              const Text('Sound'),
+                              const Spacer(),
+                              Switch(
                                 value: sound,
                                 onChanged: (v) {
                                   sound = v;
                                   (ctx as Element).markNeedsBuild();
-                                })
-                          ]),
+                                },
+                              ),
+                            ],
+                          ),
                           const SizedBox(height: 8),
-                          Row(children: [
-                            const Text('Haptics'),
-                            const Spacer(),
-                            Switch(
+                          Row(
+                            children: [
+                              const Text('Haptics'),
+                              const Spacer(),
+                              Switch(
                                 value: haptics,
                                 onChanged: (v) {
                                   haptics = v;
                                   (ctx as Element).markNeedsBuild();
-                                })
-                          ]),
+                                },
+                              ),
+                            ],
+                          ),
                           const SizedBox(height: 8),
-                          Row(children: [
-                            const Text('Font size'),
-                            const Spacer(),
-                            ChoiceChip(
+                          Row(
+                            children: [
+                              const Text('Font size'),
+                              const Spacer(),
+                              ChoiceChip(
                                 label: const Text('L'),
                                 selected: fontScale <= 1.0,
                                 onSelected: (_) {
                                   fontScale = 1.0;
                                   (ctx as Element).markNeedsBuild();
-                                }),
-                            const SizedBox(width: 8),
-                            ChoiceChip(
+                                },
+                              ),
+                              const SizedBox(width: 8),
+                              ChoiceChip(
                                 label: const Text('XL'),
                                 selected: fontScale > 1.0,
                                 onSelected: (_) {
                                   fontScale = 1.15;
                                   (ctx as Element).markNeedsBuild();
-                                }),
-                          ]),
+                                },
+                              ),
+                            ],
+                          ),
                           const SizedBox(height: 8),
-                          Row(children: [
-                            const Text('Auto Why on wrong'),
-                            const Spacer(),
-                            Switch(
+                          Row(
+                            children: [
+                              const Text('Auto Why on wrong'),
+                              const Spacer(),
+                              Switch(
                                 value: autoWhy,
                                 onChanged: (v) {
                                   autoWhy = v;
                                   (ctx as Element).markNeedsBuild();
-                                })
-                          ]),
+                                },
+                              ),
+                            ],
+                          ),
                           const SizedBox(height: 12),
                           Row(
                             mainAxisAlignment: MainAxisAlignment.end,
                             children: [
                               TextButton(
-                                  onPressed: () => Navigator.pop(ctx),
-                                  child: const Text('Cancel')),
+                                onPressed: () => Navigator.pop(ctx),
+                                child: const Text('Cancel'),
+                              ),
                               const SizedBox(width: 8),
                               ElevatedButton(
                                 onPressed: () {
@@ -1067,8 +1132,11 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
                       child: Column(
                         mainAxisSize: MainAxisSize.min,
                         children: [
-                          Icon(Icons.pause_circle_filled,
-                              size: 56, color: Colors.white70),
+                          Icon(
+                            Icons.pause_circle_filled,
+                            size: 56,
+                            color: Colors.white70,
+                          ),
                           SizedBox(height: 8),
                           Text('Paused', style: TextStyle(color: Colors.white)),
                         ],
@@ -1085,7 +1153,8 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
 
   Widget _buildSpotCard(UiSpot spot) {
     final actions = _actionsFor(spot.kind);
-    final jamFoldHotkeys = _showHotkeys &&
+    final jamFoldHotkeys =
+        _showHotkeys &&
         spot.kind.name.contains('_jam_vs_') &&
         listEquals(actions, const ['jam', 'fold']);
     final correctCnt = _answers.where((a) => a.correct).length;
@@ -1156,7 +1225,9 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
             });
             saveUiPrefs(p);
             showMiniToast(
-                context, p.autoWhyOnWrong ? 'Auto Why: ON' : 'Auto Why: OFF');
+              context,
+              p.autoWhyOnWrong ? 'Auto Why: ON' : 'Auto Why: OFF',
+            );
             return;
           }
           if (_showHotkeys && event.logicalKey == LogicalKeyboardKey.keyS) {
@@ -1210,7 +1281,8 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
                   Row(
                     children: [
                       Text(
-                          't=${(_timer.elapsedMilliseconds / 1000).toStringAsFixed(1)}s'),
+                        't=${(_timer.elapsedMilliseconds / 1000).toStringAsFixed(1)}s',
+                      ),
                       if (!_showHotkeys) ...[
                         const SizedBox(width: 4),
                         IconButton(
@@ -1225,16 +1297,18 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
                           icon: const Icon(Icons.psychology_alt),
                           onPressed: () {
                             final p = _prefs.copyWith(
-                                autoWhyOnWrong: !_prefs.autoWhyOnWrong);
+                              autoWhyOnWrong: !_prefs.autoWhyOnWrong,
+                            );
                             setState(() {
                               _prefs = p;
                             });
                             saveUiPrefs(p);
                             showMiniToast(
-                                context,
-                                p.autoWhyOnWrong
-                                    ? 'Auto Why: ON'
-                                    : 'Auto Why: OFF');
+                              context,
+                              p.autoWhyOnWrong
+                                  ? 'Auto Why: ON'
+                                  : 'Auto Why: OFF',
+                            );
                           },
                         ),
                       ],
@@ -1243,9 +1317,7 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
                 ],
               ),
               const SizedBox(height: 4),
-              LinearProgressIndicator(
-                value: (_index + 1) / _spots.length,
-              ),
+              LinearProgressIndicator(value: (_index + 1) / _spots.length),
               const SizedBox(height: 4),
               Row(
                 children: [
@@ -1322,13 +1394,11 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
                           style: Theme.of(context).textTheme.headlineSmall,
                         ),
                         const SizedBox(height: 8),
-                        Text(
-                          _buildSubTitle(spot),
-                          textAlign: TextAlign.center,
-                        ),
+                        Text(_buildSubTitle(spot), textAlign: TextAlign.center),
                         const SizedBox(height: 24),
                         ...actions.map(
-                            (a) => _buildActionButton(a, spot, jamFoldHotkeys)),
+                          (a) => _buildActionButton(a, spot, jamFoldHotkeys),
+                        ),
                         if (_chosen != null) ...[
                           const SizedBox(height: 16),
                           Text(

--- a/test/spot_importer_test.dart
+++ b/test/spot_importer_test.dart
@@ -6,7 +6,7 @@ void main() {
   test('case-insensitive kind and field trimming', () {
     const json =
         '[{"kind":"CALLVSJAM","hand":" AKo ","pos":" BTN ","stack":" 10bb ","action":" push "}]';
-    final report = SpotImporter.parse(json, kind: 'Json');
+    final report = SpotImporter.parse(json, format: 'Json');
     expect(report.added, 1);
     expect(report.skipped, 0);
     expect(report.errors, isEmpty);
@@ -21,9 +21,10 @@ void main() {
   test('duplicate detection JSON', () {
     const json =
         '[{"kind":"callVsJam","hand":"AKo","pos":"BTN","stack":"10bb","action":"push"}, {"kind":"callVsJam","hand":"AKo","pos":"BTN","stack":"10bb","action":"push"}]';
-    final report = SpotImporter.parse(json, kind: 'json');
+    final report = SpotImporter.parse(json, format: 'json');
     expect(report.added, 1);
     expect(report.skipped, 1);
+    expect(report.skippedDuplicates, 1);
     expect(report.errors.length, 1);
     expect(report.errors.first.startsWith('Duplicate spot:'), isTrue);
   });
@@ -31,9 +32,10 @@ void main() {
   test('duplicate detection CSV', () {
     const csv =
         'kind,hand,pos,stack,action\ncallVsJam,AKo,BTN,10bb,push\ncallVsJam,AKo,BTN,10bb,push';
-    final report = SpotImporter.parse(csv, kind: 'CSV');
+    final report = SpotImporter.parse(csv, format: 'CSV');
     expect(report.added, 1);
     expect(report.skipped, 1);
+    expect(report.skippedDuplicates, 1);
     expect(report.errors.length, 1);
     expect(report.errors.first.startsWith('Duplicate spot:'), isTrue);
   });
@@ -44,7 +46,7 @@ void main() {
       (i) => '{"kind":"x","hand":"h","pos":"p","stack":"s","action":"a"}',
     );
     final json = '[${items.join(',')}]';
-    final report = SpotImporter.parse(json, kind: 'json');
+    final report = SpotImporter.parse(json, format: 'json');
     expect(report.added, 0);
     expect(report.skipped, 7);
     expect(report.errors.length, 5);
@@ -53,7 +55,7 @@ void main() {
   test('CSV tolerates column order and extra headers', () {
     const csv =
         'pos,kind,action,stack,hand,extra\nBTN,callVsJam,push,10bb,AKo,foo';
-    final report = SpotImporter.parse(csv, kind: 'csv');
+    final report = SpotImporter.parse(csv, format: 'csv');
     expect(report.added, 1);
     expect(report.errors, isEmpty);
     final spot = report.spots.single;
@@ -67,7 +69,7 @@ void main() {
   test('JSON unknown kind is skipped', () {
     const json =
         '[{"kind":"UnKnOwN","hand":"AKo","pos":"BTN","stack":"10bb","action":"push"}]';
-    final report = SpotImporter.parse(json, kind: 'json');
+    final report = SpotImporter.parse(json, format: 'json');
     expect(report.added, 0);
     expect(report.skipped, 1);
     expect(report.errors.single.contains('unknown kind'), isTrue);
@@ -75,9 +77,31 @@ void main() {
 
   test('CSV row with empty required field is skipped', () {
     const csv = 'kind,hand,pos,stack,action\ncallVsJam,,BTN,10bb,push';
-    final report = SpotImporter.parse(csv, kind: 'csv');
+    final report = SpotImporter.parse(csv, format: 'csv');
     expect(report.added, 0);
     expect(report.skipped, 1);
     expect(report.errors.single.contains('missing field'), isTrue);
+  });
+
+  test('CSV with BOM and semicolon delimiter', () {
+    const csv = '\uFEFFPos;Kind;Action;Stack;Hand\nBTN;callVsJam;push;10bb;AKo';
+    final report = SpotImporter.parse(csv, format: 'csv');
+    expect(report.added, 1);
+    expect(report.errors, isEmpty);
+    final spot = report.spots.single;
+    expect(spot.kind, SpotKind.callVsJam);
+    expect(spot.hand, 'AKo');
+    expect(spot.pos, 'BTN');
+    expect(spot.stack, '10bb');
+    expect(spot.action, 'push');
+  });
+
+  test('CSV quoted value with comma', () {
+    const csv =
+        'kind;hand;pos;stack;action;explain\ncallVsJam;AKo;BTN;10bb;push;"reason,detail"';
+    final report = SpotImporter.parse(csv, format: 'csv');
+    expect(report.added, 1);
+    final spot = report.spots.single;
+    expect(spot.explain, 'reason,detail');
   });
 }


### PR DESCRIPTION
## Summary
- handle BOM, semicolon delimiter, quotes and case-insensitive headers in SpotImporter
- expose parseStack helper and use it in CoverageDashboard with clearer no-filter state and richer packId
- add tests for CSV edge cases and duplicate counts

## Testing
- `dart test test/spot_importer_test.dart` *(fails: Because poker_analyzer depends on flutter_test from sdk which doesn't exist (the Flutter SDK is not available), version solving failed.)*
- `dart analyze` *(fails: Target of URI doesn't exist: 'package:flutter/material.dart'.)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c2698950832ab678f915670d453d