### PR TITLE
Fix format handling in SpotImporter

### DIFF
--- a/lib/services/spot_importer.dart
+++ b/lib/services/spot_importer.dart
@@ -130,7 +130,7 @@ class SpotImporter {
         }
       }
     } else {
-      addError('Unsupported format $format');
+      addError('Unsupported format ${format ?? kind}');
     }
     return SpotImportReport(
       spots: spots,


### PR DESCRIPTION
## Summary
- Avoid redeclaring format/k in SpotImporter.parse and improve unsupported format error message

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c6a11d48832aa008eeb830976a58