### PR TITLE
Clarify SpotImporter format precedence

### DIFF
--- a/lib/services/spot_importer.dart
+++ b/lib/services/spot_importer.dart
@@ -21,11 +21,12 @@ class SpotImporter {
   /// Parses [content] and returns an import report.
   ///
   /// [format] takes precedence over [kind] and defaults to `'json'`.
+  /// If both are provided, [format] is used and [kind] is ignored.
   static SpotImportReport parse(
     String content, {
-    String? format,
-    String? kind,
-  }) {
+      String? format,
+      String? kind,
+    }) {
     final fmt = (format ?? kind ?? 'json').toLowerCase();
     final spots = <UiSpot>[];
     final errors = <String>[];

--- a/test/spot_importer_test.dart
+++ b/test/spot_importer_test.dart
@@ -111,4 +111,11 @@ void main() {
     expect(report.added, 1);
     expect(report.errors, isEmpty);
   });
+
+  test('format overrides kind when both provided', () {
+    const csv = 'kind,hand,pos,stack,action\ncallVsJam,AKo,BTN,10bb,push';
+    final r = SpotImporter.parse(csv, format: 'csv', kind: 'json');
+    expect(r.added, 1);
+    expect(r.errors, isEmpty);
+  });
 }


### PR DESCRIPTION
## Summary
- document SpotImporter.format precedence more clearly
- test that format overrides kind

## Testing
- `flutter pub get` *(fails: The current Dart SDK version is 3.5.0 ... lottie ^3.3.1 is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c8c8f6c8832a8759c133d95457eb