### PR TITLE
feat: add turn jam vs raise

### DIFF
--- a/lib/ui/session_player/models.dart
+++ b/lib/ui/session_player/models.dart
@@ -16,9 +16,9 @@ enum SpotKind {
   l3_river_jam_vs_bet,
   l3_turn_jam_vs_bet,
   l3_river_jam_vs_raise,
-  l3_turn_jam_vs_raise,
   l3_flop_jam_vs_bet,
-  l3_flop_jam_vs_raise
+  l3_flop_jam_vs_raise,
+  l3_turn_jam_vs_raise
 }
 
 class UiSpot {

--- a/lib/ui/session_player/mvs_player.dart
+++ b/lib/ui/session_player/mvs_player.dart
@@ -447,7 +447,8 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
       }
       if (!correct &&
           autoWhy &&
-          spot.kind == SpotKind.l3_flop_jam_vs_raise &&
+          (spot.kind == SpotKind.l3_flop_jam_vs_raise ||
+              spot.kind == SpotKind.l3_turn_jam_vs_raise) &&
           !_replayed.contains(spot)) {
         _spots.insert(_index + 1, spot);
         _replayed.add(spot);


### PR DESCRIPTION
## Summary
- append `l3_turn_jam_vs_raise` spot kind
- allow turn jam vs raise subtitles, jam/fold actions, and single auto-replay on wrong answers

## Testing
- `flutter test test/ui/session_player/mvs_session_player_turn_jam_vs_raise_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ed58aa78832aa6d3b8964d1ee2e0