### PR TITLE
feat: add L4 ICM bubble jam vs fold

### DIFF
--- a/lib/ui/session_player/models.dart
+++ b/lib/ui/session_player/models.dart
@@ -19,6 +19,7 @@ enum SpotKind {
   l3_flop_jam_vs_raise,
   l3_turn_jam_vs_raise,
   l3_river_jam_vs_raise,
+  l4_icm_bubble_jam_vs_fold,
 }
 
 class UiSpot {

--- a/lib/ui/session_player/mvs_player.dart
+++ b/lib/ui/session_player/mvs_player.dart
@@ -447,9 +447,10 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
       }
       if (!correct &&
           autoWhy &&
-          ((spot.kind == SpotKind.l3_flop_jam_vs_raise) ||
-              (spot.kind == SpotKind.l3_turn_jam_vs_raise) ||
-              (spot.kind == SpotKind.l3_river_jam_vs_raise)) &&
+          (spot.kind == SpotKind.l3_flop_jam_vs_raise ||
+              spot.kind == SpotKind.l3_turn_jam_vs_raise ||
+              spot.kind == SpotKind.l3_river_jam_vs_raise ||
+              spot.kind == SpotKind.l4_icm_bubble_jam_vs_fold) &&
           !_replayed.contains(spot)) {
         _spots.insert(_index + 1, spot);
         _replayed.add(spot);
@@ -1445,6 +1446,9 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
     if (spot.kind == SpotKind.l3_river_jam_vs_raise) {
       return 'River Jam vs Raise • ' + core;
     }
+    if (spot.kind == SpotKind.l4_icm_bubble_jam_vs_fold) {
+      return 'ICM Bubble Jam vs Fold • ' + core;
+    }
     return core;
   }
 
@@ -1489,6 +1493,8 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
       case SpotKind.l3_river_jam_vs_raise:
         return ['jam', 'fold'];
       case SpotKind.l3_turn_jam_vs_raise:
+        return ['jam', 'fold'];
+      case SpotKind.l4_icm_bubble_jam_vs_fold:
         return ['jam', 'fold'];
     }
   }


### PR DESCRIPTION
## Summary
- add SpotKind.l4_icm_bubble_jam_vs_fold
- handle ICM Bubble Jam vs Fold subtitle, actions, and replay guard

## Testing
- `dart format lib/ui/session_player/models.dart lib/ui/session_player/mvs_player.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0fdbd8c98832ab9e2fc01fd3bc80a