### PR TITLE
feat: add ladder jam vs fold spot

### DIFF
--- a/lib/ui/session_player/models.dart
+++ b/lib/ui/session_player/models.dart
@@ -20,6 +20,7 @@ enum SpotKind {
   l3_turn_jam_vs_raise,
   l3_river_jam_vs_raise,
   l4_icm_bubble_jam_vs_fold,
+  l4_icm_ladder_jam_vs_fold,
 }
 
 class UiSpot {

--- a/lib/ui/session_player/mvs_player.dart
+++ b/lib/ui/session_player/mvs_player.dart
@@ -449,7 +449,8 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
           (spot.kind == SpotKind.l3_flop_jam_vs_raise ||
               spot.kind == SpotKind.l3_turn_jam_vs_raise ||
               spot.kind == SpotKind.l3_river_jam_vs_raise ||
-              spot.kind == SpotKind.l4_icm_bubble_jam_vs_fold) &&
+              spot.kind == SpotKind.l4_icm_bubble_jam_vs_fold ||
+              spot.kind == SpotKind.l4_icm_ladder_jam_vs_fold) &&
           !_replayed.contains(spot)) {
         _spots.insert(_index + 1, spot);
         _replayed.add(spot);
@@ -1448,6 +1449,9 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
     if (spot.kind == SpotKind.l4_icm_bubble_jam_vs_fold) {
       return 'ICM Bubble Jam vs Fold • ' + core;
     }
+    if (spot.kind == SpotKind.l4_icm_ladder_jam_vs_fold) {
+      return 'ICM FT Ladder Jam vs Fold • ' + core;
+    }
     return core;
   }
 
@@ -1494,6 +1498,8 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
       case SpotKind.l3_turn_jam_vs_raise:
         return ['jam', 'fold'];
       case SpotKind.l4_icm_bubble_jam_vs_fold:
+        return ['jam', 'fold'];
+      case SpotKind.l4_icm_ladder_jam_vs_fold:
         return ['jam', 'fold'];
     }
   }


### PR DESCRIPTION
## Summary
- extend SpotKind enum with l4 ICM final-table ladder jam vs fold
- support ladder jam vs fold in MvsSessionPlayer with jam/fold actions and replay logic

## Testing
- `dart format lib/ui/session_player/models.dart lib/ui/session_player/mvs_player.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a101e7f2ac832a96e6b1e2f9f2ca48