### PR TITLE
ci: switch CLI workflows to setup-dart

### DIFF
--- a/.github/workflows/cli-dart.yml
+++ b/.github/workflows/cli-dart.yml
@@ -29,15 +29,13 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Flutter
-        uses: subosito/flutter-action@v2
+      - name: Set up Dart
+        uses: dart-lang/setup-dart@v1
         with:
-          channel: stable
-          flutter-version: '3.27.0'
-          cache: true
+          sdk: stable
 
-      - name: Flutter version
-        run: flutter --version
+      - name: Dart version
+        run: dart --version
 
       - name: Cache Pub dependencies
         uses: actions/cache@v4
@@ -47,8 +45,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pub-
 
-      - name: Pub get (via Flutter)
-        run: flutter pub get
+      - name: Pub get
+        run: dart pub get
 
       # ASCII-пунктуация только в CLI-области
       - name: Fail on smart quotes / punctuation (CLI scope)
@@ -70,7 +68,7 @@ jobs:
         run: dart format --output=none --set-exit-if-changed bin test/ev
 
       - name: Analyze (CLI only)
-        run: flutter analyze bin test/ev
+        run: dart analyze bin test/ev
 
       # 🔧 Фикс: динамический поиск тестов, скип если нет ни одного
       - name: Unit tests (CLI only)

--- a/.github/workflows/presubmit_codex.yml
+++ b/.github/workflows/presubmit_codex.yml
@@ -22,12 +22,21 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Setup Flutter (Dart toolchain)
-        uses: subosito/flutter-action@v2
+      - name: Set up Dart
+        uses: dart-lang/setup-dart@v1
         with:
-          channel: 'stable'
-          flutter-version: '3.27.0'
-          cache: true
+          sdk: stable
+
+      - name: Cache Pub dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.pub-cache
+          key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pub-
+
+      - name: Pub get
+        run: dart pub get
 
       # Формат — ТОЛЬКО проверка и ТОЛЬКО нужные пути (без lib/l10n/**)
       - name: Format check (scoped)


### PR DESCRIPTION
## Summary
- use dart-lang/setup-dart for CLI-only workflows
- keep pub-cache caching and run Dart commands

## Testing
- `dart pub get` *(fails: Flutter SDK is not available)*
- `dart format --output=none --set-exit-if-changed bin test/ev` *(fails: unformatted files)*
- `dart analyze bin test/ev` *(fails: missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_68a110494fb8832a95ef2fb6c159094a