### PR TITLE
fix: remove duplicate subtitle tail

### DIFF
--- a/lib/ui/session_player/mvs_player.dart
+++ b/lib/ui/session_player/mvs_player.dart
@@ -1477,9 +1477,9 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
     }
     if (spot.kind == SpotKind.l4_icm_sb_jam_vs_fold) {
       return 'ICM SB Jam vs Fold • ' + core;
+    }
+    return core;
   }
-  return core;
-}
 
   List<String> _actionsFor(SpotKind kind) {
     final mapped = _actionsMap[kind];


### PR DESCRIPTION
## Summary
- fix stray duplicate return/brace in session player's `_buildSubTitle`

## Testing
- `dart format -o show lib/ui/session_player/mvs_player.dart`
- `dart analyze lib/ui/session_player/mvs_player.dart` *(fails: Target of URI doesn't exist: 'package:flutter/material.dart')*


------
https://chatgpt.com/codex/tasks/task_e_68a1100ead8c832aa80a0234300d3001