### PR TITLE
chore: use flutter toolchain in cli workflows

### DIFF
--- a/.github/workflows/cli-dart.yml
+++ b/.github/workflows/cli-dart.yml
@@ -29,13 +29,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Dart
-        uses: dart-lang/setup-dart@v1
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
         with:
-          sdk: stable
-
-      - name: Dart version
-        run: dart --version
+          channel: stable
+          cache: true
 
       - name: Cache Pub dependencies
         uses: actions/cache@v4
@@ -46,7 +44,7 @@ jobs:
             ${{ runner.os }}-pub-
 
       - name: Pub get
-        run: dart pub get
+        run: flutter pub get
 
       # ASCII-пунктуация только в CLI-области
       - name: Fail on smart quotes / punctuation (CLI scope)
@@ -68,7 +66,7 @@ jobs:
         run: dart format --output=none --set-exit-if-changed bin test/ev
 
       - name: Analyze (CLI only)
-        run: dart analyze bin test/ev
+        run: flutter analyze bin test/ev
 
       # 🔧 Фикс: динамический поиск тестов, скип если нет ни одного
       - name: Unit tests (CLI only)

--- a/.github/workflows/presubmit_codex.yml
+++ b/.github/workflows/presubmit_codex.yml
@@ -16,57 +16,58 @@ jobs:
     if: ${{ startsWith(github.head_ref, 'codex/') }}
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          persist-credentials: false
+        - name: Checkout
+          uses: actions/checkout@v4
+          with:
+            fetch-depth: 0
+            persist-credentials: false
 
-      - name: Set up Dart
-        uses: dart-lang/setup-dart@v1
-        with:
-          sdk: stable
+        - name: Set up Flutter
+          uses: subosito/flutter-action@v2
+          with:
+            channel: stable
+            cache: true
 
-      - name: Cache Pub dependencies
-        uses: actions/cache@v4
-        with:
-          path: ~/.pub-cache
-          key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-pub-
+        - name: Cache Pub dependencies
+          uses: actions/cache@v4
+          with:
+            path: ~/.pub-cache
+            key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
+            restore-keys: |
+              ${{ runner.os }}-pub-
 
-      - name: Pub get
-        run: dart pub get
+        - name: Pub get
+          run: flutter pub get
 
       # Формат — ТОЛЬКО проверка и ТОЛЬКО нужные пути (без lib/l10n/**)
       - name: Format check (scoped)
         run: dart format --output=none --set-exit-if-changed bin lib/l3 tool/l3 test/ev
 
       # Анализируем релевантные файлы и не "красним" PR
-      - name: Collect relevant Dart files
-        id: collect
-        shell: bash
-        run: |
-          FILES=$(git ls-files \
-            'tool/**/*.dart' \
-            'lib/services/**/*.dart' \
-            'lib/l3/**/*.dart' \
-            'test/l2_*.dart' \
-            'test/l3_*.dart' \
-            'test/l3_demo_*.dart' || true)
-          echo "$FILES" > dart_files.txt
-          if [ -s dart_files.txt ]; then
-            echo "has_files=true" >> $GITHUB_OUTPUT
-          else
-            echo "has_files=false" >> $GITHUB_OUTPUT
-          fi
+        - name: Collect relevant Dart files
+          id: collect
+          shell: bash
+          run: |
+            FILES=$(git ls-files \
+              'tool/**/*.dart' \
+              'lib/services/**/*.dart' \
+              'lib/l3/**/*.dart' \
+              'test/l2_*.dart' \
+              'test/l3_*.dart' \
+              'test/l3_demo_*.dart' || true)
+            echo "$FILES" > dart_files.txt
+            if [ -s dart_files.txt ]; then
+              echo "has_files=true" >> $GITHUB_OUTPUT
+            else
+              echo "has_files=false" >> $GITHUB_OUTPUT
+            fi
 
-      - name: Dart analyze (limited scope)
-        if: steps.collect.outputs.has_files == 'true'
-        continue-on-error: true
-        shell: bash
-        run: |
-          xargs -a dart_files.txt dart analyze --no-fatal-warnings --no-fatal-infos || true
+        - name: Analyze (limited scope)
+          if: steps.collect.outputs.has_files == 'true'
+          continue-on-error: true
+          shell: bash
+          run: |
+            xargs -a dart_files.txt flutter analyze --no-fatal-warnings --no-fatal-infos || true
 
       - name: Skip analyze (no relevant files)
         if: steps.collect.outputs.has_files != 'true'


### PR DESCRIPTION
## Summary
- consolidate CLI workflows to subosito/flutter-action with stable channel and caching
- use `flutter pub get` and `flutter analyze` for CLI checks

## Testing
- `flutter pub get`
- `dart format --output=none --set-exit-if-changed $(git ls-files '*.dart')` *(fails: could not format due to parse errors)*
- `flutter analyze --no-fatal-warnings --no-fatal-infos` *(585 issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a111ced87c832a9ec0be261e495d19