### PR TITLE
refactor: extract spot specs for pure Dart tests

### DIFF
--- a/lib/ui/session_player/mvs_player.dart
+++ b/lib/ui/session_player/mvs_player.dart
@@ -18,6 +18,7 @@ import '../../services/session_resume.dart';
 import 'hotkeys_sheet.dart';
 import 'mini_toast.dart';
 import 'models.dart';
+import 'spot_specs.dart';
 import 'result_summary.dart';
 import 'ui_prefs.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -25,43 +26,16 @@ import '../../services/spot_importer.dart';
 import '../coverage/coverage_dashboard.dart';
 import '../modules/modules_screen.dart';
 
-const _autoReplayKinds = {
-  SpotKind.l3_flop_jam_vs_raise,
-  SpotKind.l3_turn_jam_vs_raise,
-  SpotKind.l3_river_jam_vs_raise,
-  SpotKind.l4_icm_bubble_jam_vs_fold,
-  SpotKind.l4_icm_ladder_jam_vs_fold,
-  SpotKind.l4_icm_sb_jam_vs_fold,
-};
-
-const _actionsMap = <SpotKind, List<String>>{
-  SpotKind.l3_flop_jam_vs_raise: ['jam', 'fold'],
-  SpotKind.l3_turn_jam_vs_raise: ['jam', 'fold'],
-  SpotKind.l3_river_jam_vs_raise: ['jam', 'fold'],
-  SpotKind.l4_icm_bubble_jam_vs_fold: ['jam', 'fold'],
-  SpotKind.l4_icm_ladder_jam_vs_fold: ['jam', 'fold'],
-  SpotKind.l4_icm_sb_jam_vs_fold: ['jam', 'fold'],
-};
-
-const _subtitlePrefix = <SpotKind, String>{
-  SpotKind.l3_flop_jam_vs_raise: 'Flop Jam vs Raise • ',
-  SpotKind.l3_turn_jam_vs_raise: 'Turn Jam vs Raise • ',
-  SpotKind.l3_river_jam_vs_raise: 'River Jam vs Raise • ',
-  SpotKind.l4_icm_bubble_jam_vs_fold: 'ICM Bubble Jam vs Fold • ',
-  SpotKind.l4_icm_ladder_jam_vs_fold: 'ICM FT Ladder Jam vs Fold • ',
-  SpotKind.l4_icm_sb_jam_vs_fold: 'ICM SB Jam vs Fold • ',
-};
-
 void _assertSpotKindIntegrity() {
   assert(() {
     // 1) Append-only discipline: latest known value must remain last.
     if (SpotKind.values.last != SpotKind.l4_icm_sb_jam_vs_fold) {
       throw StateError('SpotKind append-only violated: last is not l4_icm_sb_jam_vs_fold');
     }
-    // 2) _autoReplayKinds covered by data-driven maps.
-    for (final k in _autoReplayKinds) {
-      final a = _actionsMap[k];
-      final p = _subtitlePrefix[k];
+    // 2) autoReplayKinds covered by data-driven maps.
+    for (final k in autoReplayKinds) {
+      final a = actionsMap[k];
+      final p = subtitlePrefix[k];
       if (a == null || a.length != 2 || a[0] != 'jam' || a[1] != 'fold') {
         throw StateError('actionsMap missing or invalid for $k');
       }
@@ -496,7 +470,7 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
       }
       if (!correct &&
           autoWhy &&
-          _autoReplayKinds.contains(spot.kind) &&
+          autoReplayKinds.contains(spot.kind) &&
           !_replayed.contains(spot)) {
         _spots.insert(_index + 1, spot);
         _replayed.add(spot);
@@ -1441,7 +1415,7 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
     if (spot.limpers != null) parts.add('limpers ${spot.limpers}');
     parts.add(spot.stack);
     final core = parts.join(' • ');
-    final prefix = _subtitlePrefix[spot.kind];
+    final prefix = subtitlePrefix[spot.kind];
     if (prefix != null) return prefix + core;
     if (spot.kind == SpotKind.callVsJam) {
       return 'Call vs Jam • $core';
@@ -1504,7 +1478,7 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
   }
 
   List<String> _actionsFor(SpotKind kind) {
-    final mapped = _actionsMap[kind];
+    final mapped = actionsMap[kind];
     if (mapped != null) return mapped;
     switch (kind) {
       case SpotKind.l2_open_fold:

--- a/lib/ui/session_player/spot_specs.dart
+++ b/lib/ui/session_player/spot_specs.dart
@@ -1,0 +1,28 @@
+import 'models.dart';
+
+const autoReplayKinds = {
+  SpotKind.l3_flop_jam_vs_raise,
+  SpotKind.l3_turn_jam_vs_raise,
+  SpotKind.l3_river_jam_vs_raise,
+  SpotKind.l4_icm_bubble_jam_vs_fold,
+  SpotKind.l4_icm_ladder_jam_vs_fold,
+  SpotKind.l4_icm_sb_jam_vs_fold,
+};
+
+const actionsMap = <SpotKind, List<String>>{
+  SpotKind.l3_flop_jam_vs_raise: ['jam', 'fold'],
+  SpotKind.l3_turn_jam_vs_raise: ['jam', 'fold'],
+  SpotKind.l3_river_jam_vs_raise: ['jam', 'fold'],
+  SpotKind.l4_icm_bubble_jam_vs_fold: ['jam', 'fold'],
+  SpotKind.l4_icm_ladder_jam_vs_fold: ['jam', 'fold'],
+  SpotKind.l4_icm_sb_jam_vs_fold: ['jam', 'fold'],
+};
+
+const subtitlePrefix = <SpotKind, String>{
+  SpotKind.l3_flop_jam_vs_raise: 'Flop Jam vs Raise • ',
+  SpotKind.l3_turn_jam_vs_raise: 'Turn Jam vs Raise • ',
+  SpotKind.l3_river_jam_vs_raise: 'River Jam vs Raise • ',
+  SpotKind.l4_icm_bubble_jam_vs_fold: 'ICM Bubble Jam vs Fold • ',
+  SpotKind.l4_icm_ladder_jam_vs_fold: 'ICM FT Ladder Jam vs Fold • ',
+  SpotKind.l4_icm_sb_jam_vs_fold: 'ICM SB Jam vs Fold • ',
+};

--- a/test/mvs_player_smoke_test.dart
+++ b/test/mvs_player_smoke_test.dart
@@ -1,41 +1,24 @@
-import 'dart:io';
 import 'package:test/test.dart';
+import 'package:poker_analyzer/ui/session_player/spot_specs.dart';
+import 'package:poker_analyzer/ui/session_player/models.dart';
 
 void main() {
-  final src = File('lib/ui/session_player/mvs_player.dart').readAsStringSync();
-  const kinds = [
-    'l3_flop_jam_vs_raise',
-    'l3_turn_jam_vs_raise',
-    'l3_river_jam_vs_raise',
-    'l4_icm_bubble_jam_vs_fold',
-    'l4_icm_ladder_jam_vs_fold',
-    'l4_icm_sb_jam_vs_fold',
-  ];
-  test('_autoReplayKinds enums', () {
-    final m = RegExp(r'const _autoReplayKinds = {([^}]+)};').firstMatch(src)!;
-    final found = RegExp(r'SpotKind\.(\w+)')
-        .allMatches(m.group(1)!)
-        .map((e) => e.group(1)!)
-        .toList();
-    expect(found, kinds);
-  });
-  test('_actionsFor jam/fold', () {
-    for (final k in kinds) {
-      expect(
-          RegExp("case SpotKind\\.$k:\\n\\s+return \\[\'jam\', \'fold\'\\];")
-              .hasMatch(src),
-          true);
-    }
-  });
-  test('subtitle prefixes', () {
-    const pref = {
-      'l3_flop_jam_vs_raise': 'Flop Jam vs Raise •',
-      'l3_turn_jam_vs_raise': 'Turn Jam vs Raise •',
-      'l3_river_jam_vs_raise': 'River Jam vs Raise •',
-      'l4_icm_bubble_jam_vs_fold': 'ICM Bubble Jam vs Fold •',
-      'l4_icm_ladder_jam_vs_fold': 'ICM FT Ladder Jam vs Fold •',
-      'l4_icm_sb_jam_vs_fold': 'ICM SB Jam vs Fold •',
+  test('autoReplayKinds specs', () {
+    const expectedPrefixes = {
+      SpotKind.l3_flop_jam_vs_raise: 'Flop Jam vs Raise • ',
+      SpotKind.l3_turn_jam_vs_raise: 'Turn Jam vs Raise • ',
+      SpotKind.l3_river_jam_vs_raise: 'River Jam vs Raise • ',
+      SpotKind.l4_icm_bubble_jam_vs_fold: 'ICM Bubble Jam vs Fold • ',
+      SpotKind.l4_icm_ladder_jam_vs_fold: 'ICM FT Ladder Jam vs Fold • ',
+      SpotKind.l4_icm_sb_jam_vs_fold: 'ICM SB Jam vs Fold • ',
     };
-    pref.forEach((k, p) => expect(src.contains(p), true));
+    for (final kind in autoReplayKinds) {
+      expect(actionsMap[kind], ['jam', 'fold']);
+      final prefix = subtitlePrefix[kind];
+      expect(prefix, isNotNull);
+      expect(prefix!.startsWith(expectedPrefixes[kind]!), true);
+    }
+    expect(actionsMap.keys.toSet().containsAll(autoReplayKinds), true);
+    expect(subtitlePrefix.keys.toSet().containsAll(autoReplayKinds), true);
   });
 }

--- a/test/spotkind_integrity_smoke_test.dart
+++ b/test/spotkind_integrity_smoke_test.dart
@@ -1,74 +1,30 @@
-import 'dart:io';
 import 'package:test/test.dart';
+import 'package:poker_analyzer/ui/session_player/spot_specs.dart';
+import 'package:poker_analyzer/ui/session_player/models.dart';
 
 void main() {
-  final src = File('lib/ui/session_player/mvs_player.dart').readAsStringSync();
-
   group('SpotKind integrity', () {
-    test('jam_vs actions map', () {
-      final m = RegExp(
-        r'const _actionsMap = <SpotKind, List<String>>{([^}]+)};',
-      ).firstMatch(src)!;
-      final entries = RegExp(
-        r"SpotKind\\.(\\w+): \['([^']+)', '([^']+)'\]",
-      ).allMatches(m.group(1)!);
-      for (final e in entries) {
-        final name = e.group(1)!;
-        final a = e.group(2)!;
-        final b = e.group(3)!;
-        if (name.contains('jam_vs_')) {
-          expect([a, b], ['jam', 'fold']);
-        }
-      }
-    });
-
-    test('subtitle prefixes', () {
-      final m = RegExp(
-        r'const _subtitlePrefix = <SpotKind, String>{([^}]+)};',
-      ).firstMatch(src)!;
-      final entries = RegExp(
-        r"SpotKind\\.(\\w+): '([^']+)'\,",
-      ).allMatches(m.group(1)!);
-      for (final e in entries) {
-        final name = e.group(1)!;
-        final prefix = e.group(2)!;
-        expect(prefix.isNotEmpty, true);
-        if (name.contains('flop')) {
-          expect(prefix.startsWith('Flop Jam'), true);
-        } else if (name.contains('turn')) {
-          expect(prefix.startsWith('Turn Jam'), true);
-        } else if (name.contains('river')) {
-          expect(prefix.startsWith('River Jam'), true);
-        } else if (name.contains('icm')) {
-          expect(prefix.startsWith('ICM'), true);
-        }
+    test('jam_vs actions and prefixes', () {
+      const expectedPrefixes = {
+        SpotKind.l3_flop_jam_vs_raise: 'Flop Jam vs Raise • ',
+        SpotKind.l3_turn_jam_vs_raise: 'Turn Jam vs Raise • ',
+        SpotKind.l3_river_jam_vs_raise: 'River Jam vs Raise • ',
+        SpotKind.l4_icm_bubble_jam_vs_fold: 'ICM Bubble Jam vs Fold • ',
+        SpotKind.l4_icm_ladder_jam_vs_fold: 'ICM FT Ladder Jam vs Fold • ',
+        SpotKind.l4_icm_sb_jam_vs_fold: 'ICM SB Jam vs Fold • ',
+      };
+      for (final kind in autoReplayKinds) {
+        expect(actionsMap[kind], ['jam', 'fold']);
+        final prefix = subtitlePrefix[kind];
+        expect(prefix, isNotNull);
+        expect(prefix!.isNotEmpty, true);
+        expect(prefix.startsWith(expectedPrefixes[kind]!), true);
       }
     });
 
     test('autoReplayKinds covered', () {
-      final auto = RegExp(
-        r'const _autoReplayKinds = {([^}]+)};',
-      ).firstMatch(src)!;
-      final autoKinds = RegExp(
-        r'SpotKind\\.(\\w+)',
-      ).allMatches(auto.group(1)!).map((e) => e.group(1)!).toSet();
-
-      final act = RegExp(
-        r'const _actionsMap = <SpotKind, List<String>>{([^}]+)};',
-      ).firstMatch(src)!;
-      final actionKinds = RegExp(
-        r'SpotKind\\.(\\w+)',
-      ).allMatches(act.group(1)!).map((e) => e.group(1)!).toSet();
-
-      final sub = RegExp(
-        r'const _subtitlePrefix = <SpotKind, String>{([^}]+)};',
-      ).firstMatch(src)!;
-      final subtitleKinds = RegExp(
-        r'SpotKind\\.(\\w+)',
-      ).allMatches(sub.group(1)!).map((e) => e.group(1)!).toSet();
-
-      expect(actionKinds.containsAll(autoKinds), true);
-      expect(subtitleKinds.containsAll(autoKinds), true);
+      expect(actionsMap.keys.toSet().containsAll(autoReplayKinds), true);
+      expect(subtitlePrefix.keys.toSet().containsAll(autoReplayKinds), true);
     });
   });
 }


### PR DESCRIPTION
## Summary
- move session player specs to new pure Dart module
- switch mvs player and tests to import the shared specs

## Testing
- `dart format lib/ui/session_player/mvs_player.dart lib/ui/session_player/spot_specs.dart test/mvs_player_smoke_test.dart test/spotkind_integrity_smoke_test.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `dart test -r expanded` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1160bf510832aa3f49ed026a48bf6