### PR TITLE
feat: guard SpotKind enum order

### DIFF
--- a/lib/ui/session_player/models.dart
+++ b/lib/ui/session_player/models.dart
@@ -24,6 +24,47 @@ enum SpotKind {
   l4_icm_sb_jam_vs_fold,
 }
 
+const _spotKindBaseline = [
+  'l2_open_fold',
+  'l2_threebet_push',
+  'l2_limped',
+  'l4_icm',
+  'callVsJam',
+  'l3_postflop_jam',
+  'l3_checkraise_jam',
+  'l3_check_jam_vs_cbet',
+  'l3_donk_jam',
+  'l3_overbet_jam',
+  'l3_raise_jam_vs_donk',
+  'l3_bet_jam_vs_raise',
+  'l3_raise_jam_vs_cbet',
+  'l3_probe_jam_vs_raise',
+  'l3_river_jam_vs_bet',
+  'l3_turn_jam_vs_bet',
+  'l3_flop_jam_vs_bet',
+  'l3_flop_jam_vs_raise',
+  'l3_turn_jam_vs_raise',
+  'l3_river_jam_vs_raise',
+  'l4_icm_bubble_jam_vs_fold',
+  'l4_icm_ladder_jam_vs_fold',
+  'l4_icm_sb_jam_vs_fold',
+];
+
+final _spotKindGuard = () {
+  assert(() {
+    final names = SpotKind.values.map((e) => e.name).toList();
+    if (names.length < _spotKindBaseline.length) {
+      throw 'SpotKind must be append-only: do not rename/reorder; only append at the end (with trailing comma).';
+    }
+    for (var i = 0; i < _spotKindBaseline.length; i++) {
+      if (names[i] != _spotKindBaseline[i]) {
+        throw 'SpotKind must be append-only: do not rename/reorder; only append at the end (with trailing comma).';
+      }
+    }
+    return true;
+  }());
+}();
+
 class UiSpot {
   final SpotKind kind;
   final String hand;


### PR DESCRIPTION
## Summary
- add debug guard enforcing SpotKind enum stays append-only

## Quality
- [x] enum append-only (last + comma, no duplicates)
- [x] dart format (no diffs)
- [ ] dart analyze (clean) *(fails: 9113 issues; missing Flutter dependencies)*
- [x] actions/subtitle aligned with this task
- [x] canonical guard: !correct && autoWhy && (spot.kind == SpotKind.l3_flop_jam_vs_raise || spot.kind == SpotKind.l3_turn_jam_vs_raise || spot.kind == SpotKind.l3_river_jam_vs_raise) && !_replayed.contains(spot)


------
https://chatgpt.com/codex/tasks/task_e_68a121825798832ab018bca265346e05