### PR TITLE
test: enforce single-site canonical guard

### DIFF
--- a/test/guard_single_site_test.dart
+++ b/test/guard_single_site_test.dart
@@ -1,0 +1,19 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+void main() {
+  test('canonical guard occurs exactly once', () {
+    final source = File(
+      'lib/ui/session_player/mvs_player.dart',
+    ).readAsStringSync();
+    final pattern = RegExp(r'\bautoReplayKinds\.contains\(\s*spot\.kind\s*\)');
+    final count = pattern.allMatches(source).length;
+    expect(
+      count,
+      1,
+      reason:
+          'Canonical guard must exist exactly once (centralized). Found $count occurrences.',
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- add test ensuring `autoReplayKinds.contains(spot.kind)` appears only once in `mvs_player.dart`

## Testing
- [ ] `flutter test`
- [ ] `dart tools/validate_training_content.dart --ci`
- [ ] `dart analyze`
- [ ] `dart test test/guard_single_site_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_68a128344168832aa75f435a55265c42