### PR TITLE
refactor: use single auto replay set

### DIFF
--- a/lib/ui/session_player/mvs_player.dart
+++ b/lib/ui/session_player/mvs_player.dart
@@ -48,8 +48,8 @@ void _assertSpotKindIntegrity(Set<SpotKind> usedKinds) {
         throw StateError('subtitlePrefix missing for $k');
       }
     }
-    // 3) autoReplayKinds invariants.
-    for (final k in autoReplayKinds) {
+    // 3) _autoReplayKinds invariants.
+    for (final k in _autoReplayKinds) {
       final a = actionsMap[k];
       final p = subtitlePrefix[k];
       if (a == null || a.length != 2 || a[0] != 'jam' || a[1] != 'fold') {


### PR DESCRIPTION
## Summary
- rely exclusively on `_autoReplayKinds` for auto replay guard
- verify `_autoReplayKinds` entries in spot kind integrity checks

## Testing
- `dart format lib/ui/session_player/mvs_player.dart`
- `dart analyze`
- `flutter test` *(fails: missing generated localizations and unresolved types)*

------
https://chatgpt.com/codex/tasks/task_e_68a13d0cb9c0832ab2f86cf0db8a0d6a