### PR TITLE
test: add L3 auto-replay SSOT smoke test

### DIFF
--- a/test/spot_specs_autoreplay_ssot_test.dart
+++ b/test/spot_specs_autoreplay_ssot_test.dart
@@ -1,0 +1,34 @@
+import 'package:test/test.dart';
+
+import '../lib/ui/session_player/spot_specs.dart';
+import '../lib/ui/session_player/models.dart';
+
+void main() {
+  group('L3 auto-replay SSOT', () {
+    test('Exact set match', () {
+      expect(
+        autoReplayKinds,
+        unorderedEquals({
+          SpotKind.l3_flop_jam_vs_raise,
+          SpotKind.l3_turn_jam_vs_raise,
+          SpotKind.l3_river_jam_vs_raise,
+        }),
+      );
+    });
+
+    test('Actions invariant', () {
+      for (final kind in autoReplayKinds) {
+        expect(actionsMap[kind], ['jam', 'fold']);
+      }
+    });
+
+    test('Subtitle invariant', () {
+      for (final kind in autoReplayKinds) {
+        final prefix = subtitlePrefix[kind];
+        expect(prefix, isNotNull);
+        expect(prefix!.isNotEmpty, true);
+        expect(prefix.contains('Jam vs Raise • '), true);
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add Dart-only smoke test locking L3 auto-replay spot specs

## Testing
- `flutter test test/spot_specs_autoreplay_ssot_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_68a14fb6fe00832a827f208efe5a5e39