### PR TITLE
test: cover L4 ICM jam-vs-fold SSOT

### DIFF
--- a/test/spot_specs_icm_ssot_test.dart
+++ b/test/spot_specs_icm_ssot_test.dart
@@ -1,0 +1,35 @@
+import 'package:test/test.dart';
+
+import '../lib/ui/session_player/spot_specs.dart';
+import '../lib/ui/session_player/models.dart';
+
+void main() {
+  group('L4 ICM jam vs fold SSOT', () {
+    test('Enum tail stays L4 ICM SB', () {
+      expect(SpotKind.values.last, SpotKind.l4_icm_sb_jam_vs_fold);
+    });
+
+    test('Actions invariant', () {
+      for (final k in {
+        SpotKind.l4_icm_bubble_jam_vs_fold,
+        SpotKind.l4_icm_ladder_jam_vs_fold,
+        SpotKind.l4_icm_sb_jam_vs_fold,
+      }) {
+        expect(actionsMap[k], ['jam', 'fold']);
+      }
+    });
+
+    test('Subtitle invariant', () {
+      for (final k in {
+        SpotKind.l4_icm_bubble_jam_vs_fold,
+        SpotKind.l4_icm_ladder_jam_vs_fold,
+        SpotKind.l4_icm_sb_jam_vs_fold,
+      }) {
+        final prefix = subtitlePrefix[k];
+        expect(prefix, isNotNull);
+        expect(prefix!.isNotEmpty, true);
+        expect(prefix.startsWith('ICM '), true);
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add Dart-only smoke test locking L4 ICM jam-vs-fold SpotKind mappings

## Testing
- `dart format test/spot_specs_icm_ssot_test.dart`
- `dart analyze test/spot_specs_icm_ssot_test.dart`
- `dart test test/spot_specs_icm_ssot_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_68a15c362410832a9a473366baf26e87