### PR TITLE
refactor: dedupe mvs session player

### DIFF
--- a/lib/ui/session_player/mvs_player.dart
+++ b/lib/ui/session_player/mvs_player.dart
@@ -57,6 +57,8 @@ void _assertSpotKindIntegrity(Set<SpotKind> usedKinds) {
   }());
 }
 
+bool isAutoReplayKind(SpotKind kind) => autoReplayKinds.contains(kind);
+
 extension _UiPrefsCopy on UiPrefs {
   UiPrefs copyWith({
     bool? autoNext,
@@ -480,7 +482,7 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
       }
       if (!correct &&
           autoWhy &&
-          autoReplayKinds.contains(spot.kind) &&
+          isAutoReplayKind(spot.kind) &&
           !_replayed.contains(spot)) {
         _spots.insert(_index + 1, spot);
         _replayed.add(spot);


### PR DESCRIPTION
## Summary
- centralize auto-replay kind check via `isAutoReplayKind`
- use helper in action handler to avoid direct set lookup

## Testing
- `dart format lib/ui/session_player/mvs_player.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a16a2e4654832aacd0601caab402a5