### PR TITLE
refactor: drop local auto replay helper

### DIFF
--- a/lib/ui/session_player/mvs_player.dart
+++ b/lib/ui/session_player/mvs_player.dart
@@ -57,8 +57,6 @@ void _assertSpotKindIntegrity(Set<SpotKind> usedKinds) {
   }());
 }
 
-bool isAutoReplayKind(SpotKind kind) => autoReplayKinds.contains(kind);
-
 extension _UiPrefsCopy on UiPrefs {
   UiPrefs copyWith({
     bool? autoNext,


### PR DESCRIPTION
## Summary
- remove local isAutoReplayKind helper
- rely on shared spot_specs helper for replay guard

## Testing
- `dart format lib/ui/session_player/mvs_player.dart` (fails: command not found)
- `dart analyze` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68a16bf39ae0832a8c2b2b13fca3f412