### PR TITLE
refactor: canonical jam/fold helper

### DIFF
--- a/lib/ui/session_player/mvs_player.dart
+++ b/lib/ui/session_player/mvs_player.dart
@@ -746,7 +746,7 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
     for (var i = 0; i < _answers.length; i++) {
       if (_answers[i].correct) continue;
       final s = _spots[i];
-      if (!listEquals(_actionsFor(s.kind), const ['jam', 'fold'])) continue;
+      if (!isJamFold(s.kind)) continue;
       lines.add(
         jsonEncode({
           'kind': s.kind.name,
@@ -1197,10 +1197,7 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
 
   Widget _buildSpotCard(UiSpot spot) {
     final actions = _actionsFor(spot.kind);
-    final jamFoldHotkeys =
-        _showHotkeys &&
-        spot.kind.name.contains('_jam_vs_') &&
-        listEquals(actions, const ['jam', 'fold']);
+    final jamFoldHotkeys = _showHotkeys && isJamFold(spot.kind);
     final correctCnt = _answers.where((a) => a.correct).length;
     final acc = _answers.isEmpty ? 0.0 : correctCnt / _answers.length;
     return GestureDetector(

--- a/lib/ui/session_player/spot_specs.dart
+++ b/lib/ui/session_player/spot_specs.dart
@@ -15,6 +15,11 @@ const actionsMap = <SpotKind, List<String>>{
   SpotKind.l4_icm_sb_jam_vs_fold: ['jam', 'fold'],
 };
 
+bool isJamFold(SpotKind k) {
+  final a = actionsMap[k];
+  return a != null && a.length == 2 && a[0] == 'jam' && a[1] == 'fold';
+}
+
 const subtitlePrefix = <SpotKind, String>{
   SpotKind.l3_flop_jam_vs_raise: 'Flop Jam vs Raise • ',
   SpotKind.l3_turn_jam_vs_raise: 'Turn Jam vs Raise • ',


### PR DESCRIPTION
## Summary
- add `isJamFold` helper for detecting jam/fold spots via `actionsMap`
- use helper to gate hotkeys and export jam/fold errors

## Testing
- `dart format lib/ui/session_player/spot_specs.dart lib/ui/session_player/mvs_player.dart` *(fails: command not found: dart)*
- `dart analyze` *(fails: command not found: dart)*
- `dart test` *(fails: command not found: dart)*

------
https://chatgpt.com/codex/tasks/task_e_68a1712b1af4832a87fa54e9fa6183ce