### PR TITLE
test: add SSOT consistency tests for spot specs

### DIFF
--- a/test/spot_specs_ssot_consistency_test.dart
+++ b/test/spot_specs_ssot_consistency_test.dart
@@ -1,0 +1,23 @@
+import 'package:test/test.dart';
+
+import '../lib/ui/session_player/spot_specs.dart';
+import '../lib/ui/session_player/models.dart';
+
+void main() {
+  test('isAutoReplayKind <=> autoReplayKinds.contains', () {
+    for (final k in SpotKind.values) {
+      expect(isAutoReplayKind(k), autoReplayKinds.contains(k));
+    }
+  });
+
+  test('actionsMap and subtitlePrefix have identical key sets', () {
+    expect(actionsMap.keys.toSet(), subtitlePrefix.keys.toSet());
+  });
+
+  test('All subtitle prefixes end with " • "', () {
+    for (final p in subtitlePrefix.values) {
+      expect(p.isNotEmpty, true);
+      expect(p.endsWith(' • '), true);
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- add pure Dart SSOT consistency tests for spot specs

## Testing
- `dart format test/spot_specs_ssot_consistency_test.dart`
- `dart analyze` *(fails: 9113 issues)*
- `dart test test/spot_specs_ssot_consistency_test.dart` *(fails: Flutter SDK not available)*
- `flutter test test/spot_specs_ssot_consistency_test.dart` *(hangs during tool build)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a9b1db34832a8768f68f2fccc975