### PR TITLE
Document jam/fold hotkeys

### DIFF
--- a/lib/ui/session_player/hotkeys_sheet.dart
+++ b/lib/ui/session_player/hotkeys_sheet.dart
@@ -42,6 +42,8 @@ class HotkeysSheet extends StatelessWidget {
               row('H', 'Toggle "Why?"'),
               row('A', 'Toggle Auto-next'),
               row('T', 'Toggle Answer timer'),
+              row('J', 'Jam (jam/fold spots)'),
+              row('F', 'Fold (jam/fold spots)'),
               const Divider(height: 24),
               const Text('BetSizer',
                   style: TextStyle(fontWeight: FontWeight.bold)),


### PR DESCRIPTION
## Summary
- Document J and F hotkeys for jam/fold spots in the session player hotkeys sheet.

## Testing
- `flutter test` *(fails: command not found `flutter`)*

------
https://chatgpt.com/codex/tasks/task_e_68a1b3cda9c8832a8871b27e64de8f95