### PR TITLE
test: add JSONL spot importer tests

### DIFF
--- a/test/spot_importer_jsonl_test.dart
+++ b/test/spot_importer_jsonl_test.dart
@@ -1,0 +1,32 @@
+import 'package:test/test.dart';
+import '../lib/ui/session_player/models.dart';
+import '../lib/services/spot_importer.dart';
+
+void main() {
+  test('parse JSONL jam/fold spots and skip duplicates', () {
+    final jsonl = [
+      '{"kind":"l3_flop_jam_vs_raise","hand":"AhKd","pos":"BTN","stack":"20bb","action":"jam"}',
+      '{"kind":"l3_flop_jam_vs_raise","hand":"AhKd","pos":"BTN","stack":"20bb","action":"jam"}', // dup
+      '{"kind":"l3_turn_jam_vs_raise","hand":"QsQc","pos":"SB","stack":"15bb","action":"fold"}',
+    ].join('\n');
+
+    final report = SpotImporter.parse(jsonl, format: 'json');
+    expect(report.errors, isEmpty);
+    expect(report.added, 2);                 // 3 lines, 1 duplicate
+    expect(report.skippedDuplicates, 1);
+    expect(report.spots.length, 2);
+    expect(report.spots.first.kind, SpotKind.l3_flop_jam_vs_raise);
+  });
+
+  test('ignores extra export fields: expected/chosen/elapsedMs', () {
+    final jsonl = [
+      '{"kind":"l3_river_jam_vs_raise","hand":"T9s","pos":"BB","stack":"12bb","action":"fold","expected":"fold","chosen":"jam","elapsedMs":840}',
+    ].join('\n');
+
+    final report = SpotImporter.parse(jsonl, format: 'json');
+    expect(report.errors, isEmpty);
+    expect(report.added, 1);
+    expect(report.spots.single.kind, SpotKind.l3_river_jam_vs_raise);
+    expect(report.spots.single.action, anyOf('jam','fold')); // parser keeps canonical 'action'
+  });
+}


### PR DESCRIPTION
## Summary
- add tests for JSONL spot import to ensure deduplication and ignore extra fields

## Testing
- `dart test test/spot_importer_jsonl_test.dart` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a1b6b7f0cc832a8608c6e54f94a334