### PR TITLE
refactor: centralize auto-replay guard

### DIFF
--- a/lib/services/spot_importer.dart
+++ b/lib/services/spot_importer.dart
@@ -126,10 +126,8 @@ class SpotImporter {
       if (rawLines.isNotEmpty) {
         final headerLine = rawLines.first.replaceFirst('\uFEFF', '');
         final sep = headerLine.contains(';') ? ';' : ',';
-        final headers = headerLine
-            .split(sep)
-            .map((h) => h.trim().toLowerCase())
-            .toList();
+        final headers =
+            headerLine.split(sep).map((h) => h.trim().toLowerCase()).toList();
         final requiredHeaders = ['kind', 'hand', 'pos', 'stack', 'action'];
         var headerOk = true;
         for (final h in requiredHeaders) {

--- a/lib/ui/session_player/mvs_player.dart
+++ b/lib/ui/session_player/mvs_player.dart
@@ -867,9 +867,8 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
             IconButton(
               icon: const Icon(Icons.skip_next),
               tooltip: 'Skip',
-              onPressed: (_index >= _spots.length || _chosen != null)
-                  ? null
-                  : _skip,
+              onPressed:
+                  (_index >= _spots.length || _chosen != null) ? null : _skip,
             ),
             if (kDebugMode) ...[
               IconButton(
@@ -957,8 +956,7 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
                     double fontScale = _prefs.fontScale;
                     final ctrl = TextEditingController(text: limit.toString());
                     return Padding(
-                      padding:
-                          MediaQuery.of(ctx).viewInsets +
+                      padding: MediaQuery.of(ctx).viewInsets +
                           const EdgeInsets.all(16),
                       child: Column(
                         mainAxisSize: MainAxisSize.min,

--- a/lib/ui/session_player/mvs_player.dart
+++ b/lib/ui/session_player/mvs_player.dart
@@ -504,10 +504,12 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
       if (!correct && autoWhy) {
         _showExplain = true;
       }
-      if (!correct &&
-          autoWhy &&
-          isAutoReplayKind(spot.kind) &&
-          !_replayed.contains(spot)) {
+      if (shouldAutoReplay(
+        correct: correct,
+        autoWhy: autoWhy,
+        kind: spot.kind,
+        alreadyReplayed: _replayed.contains(spot),
+      )) {
         _spots.insert(_index + 1, spot);
         _replayed.add(spot);
       }
@@ -865,8 +867,9 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
             IconButton(
               icon: const Icon(Icons.skip_next),
               tooltip: 'Skip',
-              onPressed:
-                  (_index >= _spots.length || _chosen != null) ? null : _skip,
+              onPressed: (_index >= _spots.length || _chosen != null)
+                  ? null
+                  : _skip,
             ),
             if (kDebugMode) ...[
               IconButton(
@@ -954,7 +957,8 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
                     double fontScale = _prefs.fontScale;
                     final ctrl = TextEditingController(text: limit.toString());
                     return Padding(
-                      padding: MediaQuery.of(ctx).viewInsets +
+                      padding:
+                          MediaQuery.of(ctx).viewInsets +
                           const EdgeInsets.all(16),
                       child: Column(
                         mainAxisSize: MainAxisSize.min,

--- a/lib/ui/session_player/spot_specs.dart
+++ b/lib/ui/session_player/spot_specs.dart
@@ -8,6 +8,15 @@ const Set<SpotKind> autoReplayKinds = {
 
 bool isAutoReplayKind(SpotKind k) => autoReplayKinds.contains(k);
 
+bool shouldAutoReplay({
+  required bool correct,
+  required bool autoWhy,
+  required SpotKind kind,
+  required bool alreadyReplayed,
+}) {
+  return !correct && autoWhy && isAutoReplayKind(kind) && !alreadyReplayed;
+}
+
 const actionsMap = <SpotKind, List<String>>{
   SpotKind.l3_flop_jam_vs_raise: ['jam', 'fold'],
   SpotKind.l3_turn_jam_vs_raise: ['jam', 'fold'],

--- a/test/spot_importer_jsonl_test.dart
+++ b/test/spot_importer_jsonl_test.dart
@@ -12,7 +12,7 @@ void main() {
 
     final report = SpotImporter.parse(jsonl, format: 'json');
     expect(report.errors, isEmpty);
-    expect(report.added, 2);                 // 3 lines, 1 duplicate
+    expect(report.added, 2); // 3 lines, 1 duplicate
     expect(report.skippedDuplicates, 1);
     expect(report.spots.length, 2);
     expect(report.spots.first.kind, SpotKind.l3_flop_jam_vs_raise);
@@ -27,6 +27,7 @@ void main() {
     expect(report.errors, isEmpty);
     expect(report.added, 1);
     expect(report.spots.single.kind, SpotKind.l3_river_jam_vs_raise);
-    expect(report.spots.single.action, anyOf('jam','fold')); // parser keeps canonical 'action'
+    expect(report.spots.single.action,
+        anyOf('jam', 'fold')); // parser keeps canonical 'action'
   });
 }

--- a/test/spot_specs_should_auto_replay_test.dart
+++ b/test/spot_specs_should_auto_replay_test.dart
@@ -1,0 +1,116 @@
+import 'package:test/test.dart';
+import '../lib/ui/session_player/spot_specs.dart';
+import '../lib/ui/session_player/models.dart';
+
+void main() {
+  group('shouldAutoReplay', () {
+    final l3 = [
+      SpotKind.l3_flop_jam_vs_raise,
+      SpotKind.l3_turn_jam_vs_raise,
+      SpotKind.l3_river_jam_vs_raise,
+    ];
+    final l4 = [
+      SpotKind.l4_icm_bubble_jam_vs_fold,
+      SpotKind.l4_icm_ladder_jam_vs_fold,
+      SpotKind.l4_icm_sb_jam_vs_fold,
+    ];
+
+    test('fires only when all conditions are met (L3 kinds)', () {
+      for (final k in l3) {
+        expect(
+          shouldAutoReplay(
+            correct: false,
+            autoWhy: true,
+            kind: k,
+            alreadyReplayed: false,
+          ),
+          isTrue,
+        );
+        expect(
+          shouldAutoReplay(
+            correct: true,
+            autoWhy: true,
+            kind: k,
+            alreadyReplayed: false,
+          ),
+          isFalse,
+        );
+        expect(
+          shouldAutoReplay(
+            correct: false,
+            autoWhy: false,
+            kind: k,
+            alreadyReplayed: false,
+          ),
+          isFalse,
+        );
+        expect(
+          shouldAutoReplay(
+            correct: false,
+            autoWhy: true,
+            kind: k,
+            alreadyReplayed: true,
+          ),
+          isFalse,
+        );
+      }
+    });
+
+    test('never fires for non-L3 kinds even with other flags true', () {
+      for (final k in l4) {
+        expect(
+          shouldAutoReplay(
+            correct: false,
+            autoWhy: true,
+            kind: k,
+            alreadyReplayed: false,
+          ),
+          isFalse,
+        );
+      }
+    });
+
+    test('helper parity with canonical guard set', () {
+      for (final k in SpotKind.values) {
+        final expected = isAutoReplayKind(k);
+        // Only correct=false, autoWhy=true, not yet replayed should yield expected.
+        expect(
+          shouldAutoReplay(
+            correct: false,
+            autoWhy: true,
+            kind: k,
+            alreadyReplayed: false,
+          ),
+          expected,
+        );
+        expect(
+          shouldAutoReplay(
+            correct: true,
+            autoWhy: true,
+            kind: k,
+            alreadyReplayed: false,
+          ),
+          isFalse,
+        );
+        expect(
+          shouldAutoReplay(
+            correct: false,
+            autoWhy: false,
+            kind: k,
+            alreadyReplayed: false,
+          ),
+          isFalse,
+        );
+        expect(
+          shouldAutoReplay(
+            correct: false,
+            autoWhy: true,
+            kind: k,
+            alreadyReplayed: true,
+          ),
+          isFalse,
+        );
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add `shouldAutoReplay` helper to lock the auto-replay guard
- call the helper from session player instead of duplicating logic
- cover helper with unit tests across spot kinds

## Testing
- `dart analyze lib/ui/session_player/spot_specs.dart lib/ui/session_player/mvs_player.dart test/spot_specs_should_auto_replay_test.dart test/spot_specs_auto_replay_invariants_test.dart test/spot_specs_autoreplay_ssot_test.dart test/mvs_player_smoke_test.dart`
- `dart test test/spot_specs_should_auto_replay_test.dart test/spot_specs_auto_replay_invariants_test.dart test/spot_specs_autoreplay_ssot_test.dart test/mvs_player_smoke_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_68a1cae60b70832a9d406b105514e72d