### PR TITLE
feat: track wrong answer metadata

### DIFF
--- a/lib/ui/session_player/mvs_player.dart
+++ b/lib/ui/session_player/mvs_player.dart
@@ -725,6 +725,21 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
     final total = _spots.length;
     final correct = _answers.where((a) => a.correct).length;
     final acc = total == 0 ? 0.0 : correct / total;
+    final wrongMeta = <Map<String, dynamic>>[];
+    for (var i = 0; i < _answers.length; i++) {
+      final a = _answers[i];
+      if (!a.correct) {
+        final reason = a.chosen == '(skip)'
+            ? 'skip'
+            : (a.chosen == '(timeout)' ? 'timeout' : 'wrong');
+        wrongMeta.add({
+          'i': i,
+          'chosen': a.chosen,
+          'elapsedMs': a.elapsed.inMilliseconds,
+          'reason': reason,
+        });
+      }
+    }
     final obj = {
       'ts': DateTime.now().toUtc().toIso8601String(),
       'acc': acc,
@@ -747,6 +762,7 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
         for (var i = 0; i < _answers.length; i++)
           if (!_answers[i].correct) i,
       ],
+      'wrongMeta': wrongMeta,
     };
     try {
       final dir = Directory('out');


### PR DESCRIPTION
## Summary
- enrich session history with per-wrong answer metadata including choice, timing, and reason

## Testing
- `dart format lib/ui/session_player/mvs_player.dart` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1d8b04ee8832a84192dff53080a7d