### PR TITLE
feat: add quick replay L3 jam errors

### DIFF
--- a/lib/ui/session_player/mvs_player.dart
+++ b/lib/ui/session_player/mvs_player.dart
@@ -816,6 +816,25 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
     }
   }
 
+  void _replayL3JamErrors() {
+    final seen = <String>{};
+    final picks = <UiSpot>[];
+    for (var i = 0; i < _answers.length; i++) {
+      final a = _answers[i];
+      if (a.correct) continue;
+      final s = _spots[i];
+      if (!isJamFold(s.kind)) continue;
+      if (!isAutoReplayKind(s.kind)) continue; // L3-only
+      final key = '${s.kind.name}|${s.hand}|${s.pos}|${s.vsPos ?? ''}|${s.stack}';
+      if (seen.add(key)) picks.add(s);
+    }
+    if (picks.isEmpty) {
+      showMiniToast(context, 'No L3 jam errors to replay');
+      return;
+    }
+    _restart(picks);
+  }
+
   void _exportErrors() {
     final lines = <String>[];
     final seen = <String>{};
@@ -939,6 +958,7 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
         spots: _spots,
         answers: _answers,
         onReplayErrors: _replayErrors,
+        onReplayL3JamErrors: _replayL3JamErrors,
         onRestart: () => _restart(widget.spots),
         onReplayOne: (i) {
           if (i < 0 || i >= _spots.length) return;

--- a/lib/ui/session_player/result_summary.dart
+++ b/lib/ui/session_player/result_summary.dart
@@ -9,6 +9,7 @@ class ResultSummaryView extends StatefulWidget {
   final List<UiSpot> spots;
   final List<UiAnswer> answers;
   final VoidCallback onReplayErrors;
+  final VoidCallback? onReplayL3JamErrors;
   final VoidCallback onRestart;
   final ValueChanged<int>? onReplayOne; // index in [0..spots.length)
   final void Function(List<int> indices)?
@@ -19,6 +20,7 @@ class ResultSummaryView extends StatefulWidget {
     required this.spots,
     required this.answers,
     required this.onReplayErrors,
+    this.onReplayL3JamErrors,
     required this.onRestart,
     this.onReplayOne,
     this.onReplayMarked,
@@ -115,6 +117,14 @@ class _ResultSummaryViewState extends State<ResultSummaryView> {
               ),
             ],
           ),
+          if (widget.onReplayL3JamErrors != null)
+            Padding(
+              padding: const EdgeInsets.only(top: 8),
+              child: ElevatedButton(
+                onPressed: widget.onReplayL3JamErrors,
+                child: const Text('Replay L3 jam errors'),
+              ),
+            ),
           const SizedBox(height: 12),
           Expanded(
             child: ListView.separated(


### PR DESCRIPTION
## Summary
- add helper to replay L3 jam errors deduped
- surface new "Replay L3 jam errors" button on summary screen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1de811d0c832abca31886347f66eb