### PR TITLE
feat: include packId in answer telemetry

### DIFF
--- a/lib/ui/session_player/mvs_player.dart
+++ b/lib/ui/session_player/mvs_player.dart
@@ -480,6 +480,7 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
         'expected': spot.action,
         'chosen': action,
         'elapsedMs': _timer.elapsed.inMilliseconds,
+        if (widget.packId != null) 'packId': widget.packId,
       }),
     );
     // mobile haptics
@@ -589,6 +590,7 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
         'expected': spot.action,
         'chosen': '(skip)',
         'elapsedMs': _timer.elapsed.inMilliseconds,
+        if (widget.packId != null) 'packId': widget.packId,
       }),
     );
     _autoNextTimer?.cancel();
@@ -647,6 +649,7 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
       'expected': spot.action,
       'chosen': '(timeout)',
       'elapsedMs': _timer.elapsed.inMilliseconds,
+      if (widget.packId != null) 'packId': widget.packId,
     }));
 
     setState(() {

--- a/lib/ui/session_player/mvs_player.dart
+++ b/lib/ui/session_player/mvs_player.dart
@@ -828,7 +828,8 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
       final s = _spots[i];
       if (!isJamFold(s.kind)) continue;
       if (!isAutoReplayKind(s.kind)) continue; // L3-only
-      final key = '${s.kind.name}|${s.hand}|${s.pos}|${s.vsPos ?? ''}|${s.stack}';
+      final key =
+          '${s.kind.name}|${s.hand}|${s.pos}|${s.vsPos ?? ''}|${s.stack}';
       if (seen.add(key)) picks.add(s);
     }
     if (picks.isEmpty) {


### PR DESCRIPTION
## Summary
- include packId in answer_correct/answer_wrong telemetry
- include packId in answer_skip telemetry
- include packId in answer_timeout telemetry

## Testing
- `dart format lib/ui/session_player/mvs_player.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1dfb0ec34832a973f63192cd91509