### PR TITLE
feat: persist pack id in session resume

### DIFF
--- a/lib/ui/session_player/mvs_player.dart
+++ b/lib/ui/session_player/mvs_player.dart
@@ -101,6 +101,7 @@ class MvsSessionPlayer extends StatefulWidget {
     final s = prefs.getString('resume_spots');
     final i = prefs.getInt('resume_index');
     final a = prefs.getString('resume_answers');
+    final packId = prefs.getString('resume_packId');
     if (s == null || i == null || a == null) return null;
     try {
       final spotsData = jsonDecode(s);
@@ -166,6 +167,7 @@ class MvsSessionPlayer extends StatefulWidget {
         spots: spots,
         initialIndex: i,
         initialAnswers: answers,
+        packId: packId,
       );
     } catch (_) {
       return null;
@@ -412,6 +414,7 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
               'elapsedMs': a.elapsed.inMilliseconds,
             },
         ],
+        if (widget.packId != null) 'packId': widget.packId,
       };
       file.writeAsStringSync(jsonEncode(obj));
     } catch (_) {}
@@ -424,11 +427,10 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
   }
 
   void _persistResume() {
-    final packId = widget.packId;
-    if (packId != null) {
+    if (widget.packId != null) {
       unawaited(
         SessionResume.save(
-          packId: packId,
+          packId: widget.packId!,
           index: _index,
           sessionId: _sessionId,
         ),
@@ -825,7 +827,8 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
       final s = _spots[i];
       if (!isJamFold(s.kind)) continue;
       if (!isAutoReplayKind(s.kind)) continue; // L3-only
-      final key = '${s.kind.name}|${s.hand}|${s.pos}|${s.vsPos ?? ''}|${s.stack}';
+      final key =
+          '${s.kind.name}|${s.hand}|${s.pos}|${s.vsPos ?? ''}|${s.stack}';
       if (seen.add(key)) picks.add(s);
     }
     if (picks.isEmpty) {


### PR DESCRIPTION
## Summary
- include packId in session autosave data
- carry packId through resume save path
- restore packId when rebuilding session from saved data

## Testing
- `dart format lib/ui/session_player/mvs_player.dart`
- `dart analyze` *(fails: 581 issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a1e102d6d0832aac7da9cd6fdebff0