### PR TITLE
chore: add pre-commit hook installer

### DIFF
--- a/tool/dev/install_precommit.sh
+++ b/tool/dev/install_precommit.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+
+mkdir -p .git/hooks
+cat > .git/hooks/pre-commit <<'H'
+#!/usr/bin/env bash
+exec bash tool/dev/precommit_sanity.sh
+H
+chmod +x .git/hooks/pre-commit tool/dev/precommit_sanity.sh
+echo "pre-commit hook installed"


### PR DESCRIPTION
## Summary
- add a tiny script to install the pre-commit hook that runs `tool/dev/precommit_sanity.sh`

## Testing
- `bash tool/dev/precommit_sanity.sh` *(fails: `dart: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68a1eda21f64832aaf16c975f9b18059