### PR TITLE
Add L3 JSONL exporter utility and test

### DIFF
--- a/lib/ui/session_player/l3_jsonl_export.dart
+++ b/lib/ui/session_player/l3_jsonl_export.dart
@@ -1,0 +1,25 @@
+import 'dart:convert';
+
+Map<String, dynamic> toL3ExportRow({
+  required String expected,
+  required String chosen,
+  required int elapsedMs,
+  required String sessionId,
+  required int ts,
+  required String reason,
+  required String packId,
+}) {
+  return {
+    'expected': expected,
+    'chosen': chosen,
+    'elapsedMs': elapsedMs,
+    'sessionId': sessionId,
+    'ts': ts,
+    'reason': reason,
+    'packId': packId,
+  };
+}
+
+String encodeJsonl(Iterable<Map<String, dynamic>> rows) {
+  return rows.map(json.encode).join('\n');
+}

--- a/test/l3_jsonl_export_test.dart
+++ b/test/l3_jsonl_export_test.dart
@@ -1,0 +1,46 @@
+import 'dart:convert';
+
+import 'package:test/test.dart';
+
+import 'package:poker_analyzer/ui/session_player/l3_jsonl_export.dart';
+
+void main() {
+  test('encode and decode JSONL rows', () {
+    final row1 = toL3ExportRow(
+      expected: 'fold',
+      chosen: 'jam',
+      elapsedMs: 1234,
+      sessionId: 's1',
+      ts: 1111,
+      reason: 'demo',
+      packId: 'p1',
+    );
+    final row2 = toL3ExportRow(
+      expected: 'jam',
+      chosen: 'fold',
+      elapsedMs: 5678,
+      sessionId: 's2',
+      ts: 2222,
+      reason: 'prod',
+      packId: 'p2',
+    );
+
+    final encoded = encodeJsonl([row1, row2]);
+    final lines = encoded.split('\n');
+    expect(lines.length, 2);
+    expect(lines.contains(''), isFalse);
+
+    final decoded1 = json.decode(lines[0]) as Map<String, dynamic>;
+    final decoded2 = json.decode(lines[1]) as Map<String, dynamic>;
+    expect(decoded1, row1);
+    expect(decoded2, row2);
+
+    for (final decoded in [decoded1, decoded2]) {
+      for (final key in decoded.keys) {
+        for (final code in key.codeUnits) {
+          expect(code < 128, isTrue, reason: 'Non-ASCII key: $key');
+        }
+      }
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- add pure Dart helpers for building and encoding L3 JSONL rows
- cover JSONL encoding and decoding with unit test

## Testing
- `dart analyze`
- `flutter test test/l3_jsonl_export_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_68a1ef0cf400832a840f211369d90ef5