### PR TITLE
ci: add autoformat fixer workflow

### DIFF
--- a/.github/workflows/ci-autoformat.yml
+++ b/.github/workflows/ci-autoformat.yml
@@ -1,0 +1,22 @@
+name: autoformat-fix
+on:
+  pull_request:
+    branches: [main]
+permissions:
+  contents: write
+jobs:
+  autoformat-fix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.head_ref }}
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - run: dart format --output=none --set-exit-if-changed .
+        continue-on-error: true
+      - uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "ci: autoformat"


### PR DESCRIPTION
## Summary
- add autoformat-fix workflow to reformat Dart code and auto-commit

## Testing
- `flutter pub get`
- `dart format --output=none --set-exit-if-changed .` *(fails: source could not be parsed)*
- `dart analyze` *(fails: 581 issues found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1eefbaeac832ab0e9215a263f11dc