### PR TITLE
test: cover L3 jam auto-replay invariants

### DIFF
--- a/test/auto_replay_invariants_test.dart
+++ b/test/auto_replay_invariants_test.dart
@@ -1,0 +1,28 @@
+import 'package:test/test.dart';
+
+import '../lib/ui/session_player/models.dart';
+import '../lib/ui/session_player/spot_specs.dart';
+
+void main() {
+  test('L3 jam_vs_raise kinds are jam/fold & auto-replay', () {
+    const kinds = [
+      SpotKind.l3_flop_jam_vs_raise,
+      SpotKind.l3_turn_jam_vs_raise,
+      SpotKind.l3_river_jam_vs_raise,
+    ];
+    for (final k in kinds) {
+      expect(isJamFold(k), isTrue);
+      expect(isAutoReplayKind(k), isTrue);
+    }
+  });
+
+  test('Non-L3 kind is not auto-replay', () {
+    final nonL3 = SpotKind.values.firstWhere(
+      (k) => k != SpotKind.l3_flop_jam_vs_raise &&
+          k != SpotKind.l3_turn_jam_vs_raise &&
+          k != SpotKind.l3_river_jam_vs_raise,
+    );
+    expect(isAutoReplayKind(nonL3), isFalse);
+  });
+}
+


### PR DESCRIPTION
## Summary
- add pure Dart test checking L3 jam-vs-raise kinds are jam/fold & auto-replay
- ensure a non-L3 kind does not auto-replay

## Testing
- `dart format test/auto_replay_invariants_test.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `dart test test/auto_replay_invariants_test.dart` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a1f2fb4a60832aa396513effcf46ee