### PR TITLE
Add pure-Dart JSONL decoder with round-trip test

### DIFF
--- a/lib/ui/session_player/l3_jsonl_decode.dart
+++ b/lib/ui/session_player/l3_jsonl_decode.dart
@@ -1,0 +1,12 @@
+import 'dart:convert';
+
+Iterable<Map<String, dynamic>> decodeJsonl(String src) sync* {
+  for (final line in src.split('\n')) {
+    if (line.trim().isEmpty) continue;
+    final decoded = json.decode(line);
+    if (decoded is! Map<String, dynamic>) {
+      throw FormatException('Expected JSON object');
+    }
+    yield Map<String, dynamic>.from(decoded);
+  }
+}

--- a/test/l3_jsonl_decode_test.dart
+++ b/test/l3_jsonl_decode_test.dart
@@ -1,0 +1,64 @@
+import 'package:test/test.dart';
+
+import 'package:poker_analyzer/ui/session_player/l3_jsonl_export.dart';
+import 'package:poker_analyzer/ui/session_player/l3_jsonl_decode.dart';
+
+bool _isAscii(String s) => s.codeUnits.every((c) => c < 128);
+
+void main() {
+  test('round-trip decodeJsonl', () {
+    final row1 = toL3ExportRow(
+      expected: 'fold',
+      chosen: 'jam',
+      elapsedMs: 1234,
+      sessionId: 's1',
+      ts: 1111,
+      reason: 'demo',
+      packId: 'p1',
+    );
+    final row2 = toL3ExportRow(
+      expected: 'jam',
+      chosen: 'fold',
+      elapsedMs: 5678,
+      sessionId: 's2',
+      ts: 2222,
+      reason: 'prod',
+      packId: 'p2',
+    );
+    final jsonl = encodeJsonl([row1, row2]);
+    final extraLine =
+        '{"expected":"jam","chosen":"fold","elapsedMs":1,"sessionId":"s3","ts":3333,"reason":"test","packId":"p3","extra":"x"}';
+    final src = '$jsonl\n\n$extraLine\n\n';
+    final decoded = decodeJsonl(src).toList();
+
+    expect(decoded.length, 3);
+    expect(decoded[0], row1);
+    expect(decoded[1], row2);
+
+    final third = decoded[2];
+    expect(
+      third.keys.toSet().containsAll([
+        'expected',
+        'chosen',
+        'elapsedMs',
+        'sessionId',
+        'ts',
+        'reason',
+        'packId',
+      ]),
+      isTrue,
+    );
+    expect(third['extra'], 'x');
+
+    for (final map in decoded) {
+      for (final key in map.keys) {
+        expect(_isAscii(key), isTrue);
+      }
+    }
+
+    expect(
+      () => decodeJsonl('{"expected":"jam"}\nnot-json'),
+      throwsFormatException,
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- add decodeJsonl utility to parse L3 JSONL exports
- test round-trip decoding, preservation of extra fields, ASCII keys, and error handling

## Testing
- `/tmp/dart-sdk/dart-sdk/bin/dart format lib/ui/session_player/l3_jsonl_decode.dart test/l3_jsonl_decode_test.dart`
- `/tmp/dart-sdk/dart-sdk/bin/dart analyze` *(fails: Target of URI doesn't exist: 'package:flutter/material.dart')*
- `/tmp/dart-sdk/dart-sdk/bin/dart test test/l3_jsonl_decode_test.dart` *(fails: Because poker_analyzer depends on flutter_test from sdk which doesn't exist)*


------
https://chatgpt.com/codex/tasks/task_e_68a1f5bf0390832a80fa41e05c8bac64