### PR TITLE
feat: add telemetry payload builder

### DIFF
--- a/lib/infra/telemetry_builder.dart
+++ b/lib/infra/telemetry_builder.dart
@@ -1,0 +1,18 @@
+Map<String, dynamic> buildTelemetry({
+  required String sessionId,
+  String? packId,
+  Map<String, dynamic>? data,
+}) {
+  bool isAscii(String s) => s.codeUnits.every((c) => c < 128);
+  final m = <String, dynamic>{'sessionId': sessionId};
+  if (packId != null && packId.isNotEmpty) m['packId'] = packId;
+  if (data != null) {
+    final d = <String, dynamic>{};
+    data.forEach((key, value) {
+      if (key == 'sessionId' || key == 'packId') return;
+      if (isAscii(key)) d[key] = value;
+    });
+    m.addAll(d);
+  }
+  return m;
+}

--- a/test/telemetry_builder_test.dart
+++ b/test/telemetry_builder_test.dart
@@ -1,0 +1,35 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/infra/telemetry_builder.dart';
+
+void main() {
+  group('buildTelemetry', () {
+    test('adds sessionId and data', () {
+      final r = buildTelemetry(sessionId: 's1', data: {'a': 1});
+      expect(r, {'sessionId': 's1', 'a': 1});
+      expect(r.containsKey('packId'), isFalse);
+    });
+
+    test('includes packId when provided', () {
+      final r = buildTelemetry(
+          sessionId: 's1', packId: 'p1', data: {'b': 'x'});
+      expect(r, {'sessionId': 's1', 'packId': 'p1', 'b': 'x'});
+    });
+
+    test('ignores overrides for sessionId and packId', () {
+      final r = buildTelemetry(
+        sessionId: 's1',
+        packId: 'p1',
+        data: {'sessionId': 'z', 'packId': 'y', 'c': 2},
+      );
+      expect(r, {'sessionId': 's1', 'packId': 'p1', 'c': 2});
+    });
+
+    test('drops non-ascii keys', () {
+      final r = buildTelemetry(sessionId: 's1', data: {'ключ': 1, 'a': 2});
+      expect(r, {'sessionId': 's1', 'a': 2});
+      for (final k in r.keys) {
+        expect(k.codeUnits.every((c) => c < 128), isTrue);
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- introduce standalone telemetry payload builder to normalize session and pack data
- cover telemetry builder with unit tests

## Testing
- `dart analyze` *(fails: command not found)*
- `dart test test/telemetry_builder_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2105a414c832a81d8a2184bef3ee4