### PR TITLE
test: add auto replay guard test

### DIFF
--- a/test/auto_replay_guard_test.dart
+++ b/test/auto_replay_guard_test.dart
@@ -1,0 +1,65 @@
+import 'package:test/test.dart';
+import '../lib/ui/session_player/spot_specs.dart';
+import '../lib/ui/session_player/models.dart';
+
+void main() {
+  test('canonical auto replay guard', () {
+    const kinds = [
+      SpotKind.l3_flop_jam_vs_raise,
+      SpotKind.l3_turn_jam_vs_raise,
+      SpotKind.l3_river_jam_vs_raise,
+    ];
+
+    for (final k in kinds) {
+      expect(
+        shouldAutoReplay(
+          correct: false,
+          autoWhy: true,
+          kind: k,
+          alreadyReplayed: false,
+        ),
+        isTrue,
+      );
+      expect(
+        shouldAutoReplay(
+          correct: true,
+          autoWhy: true,
+          kind: k,
+          alreadyReplayed: false,
+        ),
+        isFalse,
+      );
+      expect(
+        shouldAutoReplay(
+          correct: false,
+          autoWhy: false,
+          kind: k,
+          alreadyReplayed: false,
+        ),
+        isFalse,
+      );
+      expect(
+        shouldAutoReplay(
+          correct: false,
+          autoWhy: true,
+          kind: k,
+          alreadyReplayed: true,
+        ),
+        isFalse,
+      );
+    }
+
+    final nonL3 = SpotKind.values.firstWhere(
+      (k) => !kinds.contains(k),
+    );
+    expect(
+      shouldAutoReplay(
+        correct: false,
+        autoWhy: true,
+        kind: nonL3,
+        alreadyReplayed: false,
+      ),
+      isFalse,
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- guard shouldAutoReplay with pure-Dart test for L3 jam vs raise kinds

## Testing
- `dart format test/auto_replay_guard_test.dart`
- `dart analyze`
- `dart test test/auto_replay_guard_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_68a23f89e3d0832a9d3934a2037992a8