### PR TITLE
feat: tag quick start sessions with pack ID

### DIFF
--- a/lib/ui/modules/modules_screen.dart
+++ b/lib/ui/modules/modules_screen.dart
@@ -71,7 +71,10 @@ class _ModulesScreenState extends State<ModulesScreen> {
                       Navigator.push(
                         context,
                         MaterialPageRoute(
-                          builder: (_) => MvsSessionPlayer(spots: widget.spots),
+                          builder: (_) => MvsSessionPlayer(
+                            spots: widget.spots,
+                            packId: 'import:last',
+                          ),
                         ),
                       );
                     }


### PR DESCRIPTION
## Summary
- tag quick start "Start last import" sessions with a stable `packId`

## Testing
- `dart format lib/ui/modules/modules_screen.dart`
- `dart analyze` *(fails: Target of URI doesn't exist: 'package:flutter/material.dart')*
- `dart test` *(fails: Flutter SDK is not available)*

------
https://chatgpt.com/codex/tasks/task_e_68a24719f268832aade87bcfbad82e2f