### PR TITLE
feat: add telemetry for exported L3 errors

### DIFF
--- a/lib/ui/session_player/mvs_player.dart
+++ b/lib/ui/session_player/mvs_player.dart
@@ -929,6 +929,16 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
         context,
         'Exported ${rows.length} spots${dups > 0 ? ' (dups $dups)' : ''} to out/packs/l3_jam_errors.jsonl',
       );
+      unawaited(
+        Telemetry.logEvent(
+          'export_l3_errors_file',
+          buildTelemetry(
+            sessionId: _sessionId,
+            packId: widget.packId,
+            data: {'count': rows.length},
+          ),
+        ),
+      );
     } catch (_) {
       Clipboard.setData(ClipboardData(text: text));
       showMiniToast(context, 'Copied L3 errors to clipboard');


### PR DESCRIPTION
## Summary
- log `export_l3_errors_file` after writing L3 error export file to capture success metrics

## Testing
- `dart format lib/ui/session_player/mvs_player.dart` *(fails: dart: command not found)*
- `dart analyze` *(fails: dart: command not found)*

## Quality
- enum append-only (n/a)
- dart format *(fails: dart: command not found)*
- dart analyze *(fails: dart: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a248af7b60832a900343d9be435912