### PR TITLE
Capture full import metrics

### DIFF
--- a/lib/ui/session_player/mvs_player.dart
+++ b/lib/ui/session_player/mvs_player.dart
@@ -1032,7 +1032,12 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
           buildTelemetry(
             sessionId: _sessionId,
             packId: widget.packId,
-            data: {'count': report.spots.length},
+            data: {
+              'total': report.spots.length,
+              'added': report.added,
+              'skipped': report.skipped,
+              'dups': report.skippedDuplicates,
+            },
           ),
         ),
       );
@@ -1063,7 +1068,13 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
           buildTelemetry(
             sessionId: _sessionId,
             packId: widget.packId,
-            data: {'result': start ? 'start' : 'cancel'},
+            data: {
+              'result': start ? 'start' : 'cancel',
+              'total': report.spots.length,
+              'added': report.added,
+              'skipped': report.skipped,
+              'dups': report.skippedDuplicates,
+            },
           ),
         ),
       );


### PR DESCRIPTION
## Summary
- include total, added, skipped, and duplicate counts in `import_confirm_shown`
- extend `import_confirm_result` with full import metrics and result

## Testing
- `dart format lib/ui/session_player/mvs_player.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a24d4684b4832ab6a78c37d052565d