### PR TITLE
Add Cash L3 starter pack and loader

### DIFF
--- a/lib/ui/modules/cash_packs.dart
+++ b/lib/ui/modules/cash_packs.dart
@@ -1,0 +1,24 @@
+import '../session_player/models.dart';
+import '../../services/spot_importer.dart';
+
+/// JSONL starter pack for cash L3 drills.
+const String cashL3V1Jsonl = '''
+{"kind":"l3_flop_jam_vs_raise","hand":"AhKh","pos":"BTN","stack":"30bb","action":"jam","vsPos":"SB"}
+{"kind":"l3_flop_jam_vs_raise","hand":"QdQs","pos":"SB","stack":"35bb","action":"jam","vsPos":"BTN"}
+{"kind":"l3_flop_jam_vs_raise","hand":"JcTc","pos":"BB","stack":"25bb","action":"fold"}
+{"kind":"l3_flop_jam_vs_raise","hand":"9h8h","pos":"BTN","stack":"20bb","action":"fold","vsPos":"BB"}
+{"kind":"l3_turn_jam_vs_raise","hand":"AsQs","pos":"SB","stack":"40bb","action":"jam","vsPos":"BTN"}
+{"kind":"l3_turn_jam_vs_raise","hand":"KdQd","pos":"BTN","stack":"32bb","action":"fold","vsPos":"SB"}
+{"kind":"l3_turn_jam_vs_raise","hand":"7s7d","pos":"BB","stack":"28bb","action":"jam"}
+{"kind":"l3_turn_jam_vs_raise","hand":"Jh9h","pos":"SB","stack":"22bb","action":"fold"}
+{"kind":"l3_river_jam_vs_raise","hand":"AcJc","pos":"BTN","stack":"24bb","action":"jam","vsPos":"BB"}
+{"kind":"l3_river_jam_vs_raise","hand":"Td9d","pos":"BB","stack":"30bb","action":"fold","vsPos":"BTN"}
+{"kind":"l3_river_jam_vs_raise","hand":"QhJh","pos":"SB","stack":"27bb","action":"jam"}
+{"kind":"l3_river_jam_vs_raise","hand":"8c7c","pos":"BTN","stack":"36bb","action":"fold"}
+''';
+
+/// Parses [cashL3V1Jsonl] and returns its spots.
+List<UiSpot> loadCashL3V1() {
+  final r = SpotImporter.parse(cashL3V1Jsonl, format: 'jsonl');
+  return r.spots;
+}

--- a/test/cash_l3_pack_test.dart
+++ b/test/cash_l3_pack_test.dart
@@ -1,0 +1,22 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/ui/modules/cash_packs.dart';
+import 'package:poker_analyzer/services/spot_importer.dart';
+import 'package:poker_analyzer/ui/session_player/models.dart';
+
+void main() {
+  test('cash L3 starter pack parses correctly', () {
+    final report = SpotImporter.parse(cashL3V1Jsonl, format: 'jsonl');
+    expect(report.errors, isEmpty);
+    expect(report.spots.length, greaterThanOrEqualTo(10));
+    const allowedKinds = {
+      SpotKind.l3_flop_jam_vs_raise,
+      SpotKind.l3_turn_jam_vs_raise,
+      SpotKind.l3_river_jam_vs_raise,
+    };
+    for (final spot in report.spots) {
+      expect(allowedKinds, contains(spot.kind));
+      expect(['jam', 'fold'], contains(spot.action));
+      expect(spot.stack, isNotEmpty);
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- add JSONL Cash L3 v1 pack and loader utility
- cover Cash L3 pack with basic parsing test

## Testing
- `dart format lib/ui/modules/cash_packs.dart test/cash_l3_pack_test.dart`
- `dart analyze lib/ui/modules/cash_packs.dart test/cash_l3_pack_test.dart` *(fails: Target of URI doesn't exist)*
- `dart test test/cash_l3_pack_test.dart` *(fails: Flutter users should use `flutter pub` instead of `dart pub`)*

------
https://chatgpt.com/codex/tasks/task_e_68a24e4b87f0832a8919f64c4400662a