### PR TITLE
Add Cash L3 pack launcher

### DIFF
--- a/lib/ui/modules/modules_screen.dart
+++ b/lib/ui/modules/modules_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:math';
 
 import 'package:flutter/material.dart';
+import 'package:poker_analyzer/ui/modules/cash_packs.dart';
 
 import '../session_player/models.dart';
 import '../session_player/mvs_player.dart';
@@ -74,6 +75,25 @@ class _ModulesScreenState extends State<ModulesScreen> {
                           builder: (_) => MvsSessionPlayer(
                             spots: widget.spots,
                             packId: 'import:last',
+                          ),
+                        ),
+                      );
+                    }
+                  },
+                ),
+                ActionChip(
+                  label: const Text('Start Cash L3'),
+                  onPressed: () {
+                    final spots = loadCashL3V1();
+                    if (spots.isEmpty) {
+                      showMiniToast(context, 'Pack is empty');
+                    } else {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => MvsSessionPlayer(
+                            spots: spots,
+                            packId: 'cash:l3:v1',
                           ),
                         ),
                       );


### PR DESCRIPTION
## Summary
- add Start Cash L3 action chip to modules screen

## Testing
- `dart format lib/ui/modules/modules_screen.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2502874e4832aa7175140681009d5