### PR TITLE
feat: log session start telemetry

### DIFF
--- a/lib/ui/session_player/mvs_player.dart
+++ b/lib/ui/session_player/mvs_player.dart
@@ -334,6 +334,14 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
         _timeLeftMs = _timeLimitMs = p.timeLimitMs;
       });
     });
+    unawaited(Telemetry.logEvent(
+      'session_start',
+      buildTelemetry(
+        sessionId: _sessionId,
+        packId: widget.packId,
+        data: {'count': widget.spots.length},
+      ),
+    ));
   }
 
   @override


### PR DESCRIPTION
## Summary
- log `session_start` with pack and spot count when training sessions begin

## Testing
- ⚠️ `dart format lib/ui/session_player/mvs_player.dart` *(missing: dart)*
- ⚠️ `dart analyze` *(missing: dart)*

------
https://chatgpt.com/codex/tasks/task_e_68a25127b39c832a98eb141757bbe6a9