### PR TITLE
feat: log session end telemetry

### DIFF
--- a/lib/ui/session_player/mvs_player.dart
+++ b/lib/ui/session_player/mvs_player.dart
@@ -1097,6 +1097,26 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
   Widget build(BuildContext context) {
     if (_index >= _spots.length && !_clearedAtSummary) {
       _clearedAtSummary = true;
+      unawaited(Telemetry.logEvent(
+        'session_end',
+        buildTelemetry(
+          sessionId: _sessionId,
+          packId: widget.packId,
+          data: {
+            'total': _answers.length,
+            'correct': _answers.where((a) => a.correct).length,
+            'wrong': _answers.length - _answers.where((a) => a.correct).length,
+            'skipped':
+                _answers.where((a) => a.chosen == '(skip)').length,
+            'timeouts':
+                _answers.where((a) => a.chosen == '(timeout)').length,
+            'elapsedMs': _answers.fold<int>(
+              0,
+              (s, a) => s + a.elapsed.inMilliseconds,
+            ),
+          },
+        ),
+      ));
       unawaited(_clearSaved());
       unawaited(SessionResume.clear());
     }


### PR DESCRIPTION
## Summary
- log `session_end` telemetry when summary screen is first reached

## Testing
- `dart format lib/ui/session_player/mvs_player.dart` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `dart analyze` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a254ace218832abef8db22cfac0633