### PR TITLE
feat: log session abort telemetry

### DIFF
--- a/lib/ui/session_player/mvs_player.dart
+++ b/lib/ui/session_player/mvs_player.dart
@@ -353,6 +353,23 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
     _answerPulseCtrl.dispose();
     _autoNextAnim?.dispose();
     _focusNode.dispose();
+    if (_index < _spots.length && !_clearedAtSummary) {
+      unawaited(Telemetry.logEvent(
+        'session_abort',
+        buildTelemetry(
+          sessionId: _sessionId,
+          packId: widget.packId,
+          data: {
+            'answered': _answers.length,
+            'remaining': _spots.length - _index,
+            'elapsedMs': _answers.fold<int>(
+              0,
+              (s, a) => s + a.elapsed.inMilliseconds,
+            ),
+          },
+        ),
+      ));
+    }
     unawaited(SessionResume.clear());
     super.dispose();
   }


### PR DESCRIPTION
## Summary
- emit `session_abort` telemetry when session closed before summary in `MvsSessionPlayer`

## Testing
- `dart format lib/ui/session_player/mvs_player.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a25778fd80832aab4ccab89dd1dc57