### PR TITLE
Add Start Cash L3 launcher

### DIFF
--- a/lib/ui/session_player/mvs_player.dart
+++ b/lib/ui/session_player/mvs_player.dart
@@ -27,6 +27,7 @@ import '../coverage/coverage_dashboard.dart';
 import '../modules/modules_screen.dart';
 import 'package:poker_analyzer/infra/telemetry_builder.dart';
 import 'package:poker_analyzer/ui/session_player/l3_jsonl_export.dart';
+import 'package:poker_analyzer/ui/modules/cash_packs.dart';
 
 void _assertSpotKindIntegrity(Set<SpotKind> usedKinds) {
   assert(() {
@@ -1184,6 +1185,25 @@ class _MvsSessionPlayerState extends State<MvsSessionPlayer>
                 ActionChip(
                   label: const Text('Import spots'),
                   onPressed: _importSpots,
+                ),
+                ActionChip(
+                  label: const Text('Start Cash L3'),
+                  onPressed: () {
+                    final spots = loadCashL3V1();
+                    if (spots.isEmpty) {
+                      showMiniToast(context, 'Pack is empty');
+                    } else {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => MvsSessionPlayer(
+                            spots: spots,
+                            packId: 'cash:l3:v1',
+                          ),
+                        ),
+                      );
+                    }
+                  },
                 ),
               ],
             ),


### PR DESCRIPTION
## Summary
- add Start Cash L3 launcher in summary ActionChip row for quick access
- import cash pack utilities to load Cash L3 v1 spots

## Testing
- `dart format lib/ui/session_player/mvs_player.dart` *(fails: command not found)*
- `dart test test/mvs_player_smoke_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a258835734832aa8341c8489dd7d05