### PR TITLE
feat: add ICM L4 SB jam vs fold starter pack

### DIFF
--- a/lib/ui/modules/icm_packs.dart
+++ b/lib/ui/modules/icm_packs.dart
@@ -1,0 +1,25 @@
+import '../session_player/models.dart';
+import '../../services/spot_importer.dart';
+
+/// JSONL starter pack for ICM L4 SB jam vs fold drills.
+const String icmL4SbV1Jsonl = '''
+{"kind":"l4_icm_sb_jam_vs_fold","hand":"AhKc","pos":"SB","stack":"8bb","action":"jam"}
+{"kind":"l4_icm_sb_jam_vs_fold","hand":"QdJd","pos":"SB","stack":"9bb","action":"fold"}
+{"kind":"l4_icm_sb_jam_vs_fold","hand":"Ts9s","pos":"SB","stack":"10bb","action":"jam"}
+{"kind":"l4_icm_sb_jam_vs_fold","hand":"7h7c","pos":"SB","stack":"11bb","action":"jam"}
+{"kind":"l4_icm_sb_jam_vs_fold","hand":"Ad5d","pos":"SB","stack":"12bb","action":"fold"}
+{"kind":"l4_icm_sb_jam_vs_fold","hand":"KcQh","pos":"SB","stack":"13bb","action":"jam"}
+{"kind":"l4_icm_sb_jam_vs_fold","hand":"Jh8h","pos":"SB","stack":"14bb","action":"fold"}
+{"kind":"l4_icm_sb_jam_vs_fold","hand":"9c9d","pos":"SB","stack":"15bb","action":"jam"}
+{"kind":"l4_icm_sb_jam_vs_fold","hand":"5s4s","pos":"SB","stack":"16bb","action":"fold","vsPos":""}
+{"kind":"l4_icm_sb_jam_vs_fold","hand":"QcTd","pos":"SB","stack":"17bb","action":"jam","vsPos":""}
+{"kind":"l4_icm_sb_jam_vs_fold","hand":"8d6d","pos":"SB","stack":"18bb","action":"fold"}
+{"kind":"l4_icm_sb_jam_vs_fold","hand":"As2s","pos":"SB","stack":"20bb","action":"jam"}
+''';
+
+/// Parses [icmL4SbV1Jsonl] and returns its spots.
+List<UiSpot> loadIcmL4SbV1() {
+  final r = SpotImporter.parse(icmL4SbV1Jsonl, format: 'jsonl');
+  return r.spots;
+}
+

--- a/test/icm_l4_sb_pack_test.dart
+++ b/test/icm_l4_sb_pack_test.dart
@@ -1,0 +1,19 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/ui/modules/icm_packs.dart';
+import 'package:poker_analyzer/services/spot_importer.dart';
+import 'package:poker_analyzer/ui/session_player/models.dart';
+
+void main() {
+  test('ICM L4 SB starter pack parses correctly', () {
+    final report = SpotImporter.parse(icmL4SbV1Jsonl, format: 'jsonl');
+    expect(report.errors, isEmpty);
+    expect(report.spots.length, greaterThanOrEqualTo(10));
+    for (final spot in report.spots) {
+      expect(spot.kind, SpotKind.l4_icm_sb_jam_vs_fold);
+      expect(spot.pos, 'SB');
+      expect(['jam', 'fold'], contains(spot.action));
+      expect(spot.stack, isNotEmpty);
+    }
+  });
+}
+


### PR DESCRIPTION
## Summary
- add JSONL ICM L4 SB jam vs fold starter pack and loader
- cover starter pack with parsing test

## Testing
- `dart format lib/ui/modules/icm_packs.dart` *(fails: command not found)*
- `dart format test/icm_l4_sb_pack_test.dart` *(fails: command not found)*
- `dart test test/icm_l4_sb_pack_test.dart` *(fails: command not found)*
- `flutter test test/icm_l4_sb_pack_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a25ba020c0832a8b98fc32f905eda3