### PR TITLE
chore: add core turn river play stub

### DIFF
--- a/curriculum_status.json
+++ b/curriculum_status.json
@@ -5,6 +5,7 @@
     "icm:l4:mix:v1",
     "core_pot_odds_equity",
     "core_starting_hands",
-    "core_flop_play"
+    "core_flop_play",
+    "core_turn_river_play"
   ]
 }

--- a/lib/packs/core_turn_river_play_loader.dart
+++ b/lib/packs/core_turn_river_play_loader.dart
@@ -1,0 +1,11 @@
+import '../ui/session_player/models.dart';
+import '../services/spot_importer.dart';
+
+const String _coreTurnRiverPlayStub = '''
+{"kind":"l1_core_call_vs_price","hand":"AhKc","pos":"BB","stack":"10bb","action":"call"}
+''';
+
+List<UiSpot> loadCoreTurnRiverPlayStub() {
+  final r = SpotImporter.parse(_coreTurnRiverPlayStub, format: 'jsonl');
+  return r.spots;
+}


### PR DESCRIPTION
## Summary
- add stub loader for core turn river play module
- mark core turn river play module done in curriculum status

## Testing
- `dart analyze` *(fails: Target of URI doesn't exist: 'package:poker_analyzer/models/v2/training_pack_template_v2.dart')*
- `flutter test -r expanded test/curriculum_status_test.dart` *(fails: The current Dart SDK version is 3.4.3. Because poker_analyzer requires SDK version >=3.9.0 <4.0.0)*


------
https://chatgpt.com/codex/tasks/task_e_68a3c5a9d76c832a838fc9079e9e3210