### PR TITLE
chore: add core blockers combos stub

### DIFF
--- a/curriculum_status.json
+++ b/curriculum_status.json
@@ -6,6 +6,7 @@
     "core_pot_odds_equity",
     "core_starting_hands",
     "core_flop_play",
-    "core_turn_river_play"
+    "core_turn_river_play",
+    "core_blockers_combos"
   ]
 }

--- a/lib/packs/core_blockers_combos_loader.dart
+++ b/lib/packs/core_blockers_combos_loader.dart
@@ -1,0 +1,11 @@
+import '../ui/session_player/models.dart';
+import '../services/spot_importer.dart';
+
+const String _coreBlockersCombosStub = '''
+{"kind":"l1_core_call_vs_price","hand":"AhKc","pos":"BB","stack":"10bb","action":"call"}
+''';
+
+List<UiSpot> loadCoreBlockersCombosStub() {
+  final r = SpotImporter.parse(_coreBlockersCombosStub, format: 'jsonl');
+  return r.spots;
+}


### PR DESCRIPTION
## Summary
- add stub loader for core blockers combos module
- mark core blockers combos module as completed

## Testing
- `dart format .` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `dart test -r expanded test/curriculum_status_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3cb730790832a80a8b4b1981eac53