### PR TITLE
feat: stub core equity realization module

### DIFF
--- a/curriculum_status.json
+++ b/curriculum_status.json
@@ -7,6 +7,7 @@
     "core_starting_hands",
     "core_flop_play",
     "core_turn_river_play",
-    "core_blockers_combos"
+    "core_blockers_combos",
+    "core_equity_realization"
   ]
 }

--- a/lib/packs/core_equity_realization_loader.dart
+++ b/lib/packs/core_equity_realization_loader.dart
@@ -1,0 +1,11 @@
+import '../ui/session_player/models.dart';
+import '../services/spot_importer.dart';
+
+const String _coreEquityRealizationStub = '''
+{"kind":"l1_core_call_vs_price","hand":"AhKc","pos":"BB","stack":"10bb","action":"call"}
+''';
+
+List<UiSpot> loadCoreEquityRealizationStub() {
+  final r = SpotImporter.parse(_coreEquityRealizationStub, format: 'jsonl');
+  return r.spots;
+}


### PR DESCRIPTION
## Summary
- add stub pack loader for core_equity_realization
- append core_equity_realization to curriculum_status.json

## Testing
- `dart analyze lib/packs/core_equity_realization_loader.dart`
- `dart test -r expanded test/curriculum_status_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_68a3cd9c3d20832aa8e2fd6a76b60320