### PR TITLE
feat: add core bet sizing fe stub

### DIFF
--- a/curriculum_status.json
+++ b/curriculum_status.json
@@ -8,6 +8,7 @@
     "core_flop_play",
     "core_turn_river_play",
     "core_blockers_combos",
-    "core_equity_realization"
+    "core_equity_realization",
+    "core_bet_sizing_fe"
   ]
 }

--- a/lib/packs/core_bet_sizing_fe_loader.dart
+++ b/lib/packs/core_bet_sizing_fe_loader.dart
@@ -1,0 +1,11 @@
+import '../ui/session_player/models.dart';
+import '../services/spot_importer.dart';
+
+const String _coreBetSizingFeStub = '''
+{"kind":"l1_core_call_vs_price","hand":"AhKc","pos":"BB","stack":"10bb","action":"call"}
+''';
+
+List<UiSpot> loadCoreBetSizingFeStub() {
+  final r = SpotImporter.parse(_coreBetSizingFeStub, format: 'jsonl');
+  return r.spots;
+}


### PR DESCRIPTION
## Summary
- add core bet sizing FE pack loader stub
- record core_bet_sizing_fe as completed in curriculum_status.json

## Testing
- `dart format lib/packs/core_bet_sizing_fe_loader.dart curriculum_status.json` *(fails: command not found: dart)*
- `dart analyze` *(fails: command not found: dart)*
- `dart test -r expanded test/curriculum_status_test.dart` *(fails: command not found: dart)*

------
https://chatgpt.com/codex/tasks/task_e_68a3cfca1374832a923d0420f33137c9