### PR TITLE
feat: add core gto vs exploit stub

### DIFF
--- a/curriculum_status.json
+++ b/curriculum_status.json
@@ -9,6 +9,7 @@
     "core_turn_river_play",
     "core_blockers_combos",
     "core_equity_realization",
-    "core_bet_sizing_fe"
+    "core_bet_sizing_fe",
+    "core_gto_vs_exploit"
   ]
 }

--- a/lib/packs/core_gto_vs_exploit_loader.dart
+++ b/lib/packs/core_gto_vs_exploit_loader.dart
@@ -1,0 +1,11 @@
+import '../ui/session_player/models.dart';
+import '../services/spot_importer.dart';
+
+const String _coreGtoVsExploitStub = '''
+{"kind":"l1_core_call_vs_price","hand":"AhKc","pos":"BB","stack":"10bb","action":"call"}
+''';
+
+List<UiSpot> loadCoreGtoVsExploitStub() {
+  final r = SpotImporter.parse(_coreGtoVsExploitStub, format: 'jsonl');
+  return r.spots;
+}


### PR DESCRIPTION
## Summary
- add stub loader for core_gto_vs_exploit pack
- mark core_gto_vs_exploit as completed in curriculum_status.json

## Testing
- `flutter test -r expanded test/curriculum_status_test.dart`
- `dart analyze`


------
https://chatgpt.com/codex/tasks/task_e_68a3d1e75f24832abc6433c8dde341f3