### PR TITLE
hotfix: restore SSOT order in curriculum_status.json and correct core…

### DIFF
--- a/curriculum_status.json
+++ b/curriculum_status.json
@@ -1,8 +1,7 @@
 {
   "modules_done": [
     "core_rules_and_setup",
-    "cash:l3:v1",
-    "icm:l4:mix:v1",
+    "core_pot_odds_equity",
     "core_starting_hands",
     "core_flop_play",
     "core_turn_river_play",
@@ -10,7 +9,6 @@
     "core_equity_realization",
     "core_bet_sizing_fe",
     "core_gto_vs_exploit",
-    "core_bankroll_management",
-    "core_pot_odds_equity"
+    "core_bankroll_management"
   ]
 }

--- a/lib/packs/core_pot_odds_equity_loader.dart
+++ b/lib/packs/core_pot_odds_equity_loader.dart
@@ -1,4 +1,3 @@
-// Placeholder pack for core_pot_odds_equity.
 import '../ui/session_player/models.dart';
 import '../services/spot_importer.dart';
 


### PR DESCRIPTION
…_pot_odds_equity loader

<!-- Title: short, imperative, scoped (e.g., feat(l3): ..., fix(ui): ..., ci: ...) -->

## Summary
- what/why
- scope
- rollback

## Quality Footer (must pass)
- [ ] enum append-only: SpotKind changed only by appending last + trailing comma, no renames/reorders
- [ ] single guard occurrence: exactly 1 occurrence of .contains(spot.kind) (canonical guard path only)
- [ ] format/analyze clean: `dart format --set-exit-if-changed .` and `dart analyze` are clean
- [ ] actions/subtitle match task: new/changed kinds have correct actions and subtitle mapping
- [ ] no new deps/strings unless required (i18n later)
- [ ] tiny, reversible diff: 1-2 files, minimal surface, rollback plan noted
- [ ] tests (if touched): pass locally; Flutter-free where possible

Canonical guard (keep centralized):

```
!correct && autoWhy && (spot.kind == SpotKind.l3_flop_jam_vs_raise || spot.kind == SpotKind.l3_turn_jam_vs_raise || spot.kind == SpotKind.l3_river_jam_vs_raise) && !_replayed.contains(spot)
```
