### PR TITLE
Add core mental game skeleton module

### DIFF
--- a/curriculum_status.json
+++ b/curriculum_status.json
@@ -9,6 +9,7 @@
     "core_equity_realization",
     "core_bet_sizing_fe",
     "core_gto_vs_exploit",
-    "core_bankroll_management"
+    "core_bankroll_management",
+    "core_mental_game"
   ]
 }

--- a/lib/packs/core_mental_game_loader.dart
+++ b/lib/packs/core_mental_game_loader.dart
@@ -1,0 +1,11 @@
+import '../ui/session_player/models.dart';
+import '../services/spot_importer.dart';
+
+const String _coreMentalGameStub = '''
+{"kind":"l1_core_call_vs_price","hand":"AhKc","pos":"BB","stack":"10bb","action":"call"}
+''';
+
+List<UiSpot> loadCoreMentalGameStub() {
+  final r = SpotImporter.parse(_coreMentalGameStub, format: 'jsonl');
+  return r.spots;
+}


### PR DESCRIPTION
## Summary
- stub loader for `core_mental_game`
- append `core_mental_game` to `curriculum_status.json`

## Testing
- `dart format lib/packs/core_mental_game_loader.dart`
- `dart analyze` *(fails: Target of URI doesn't exist: 'package:poker_analyzer/models/v2/training_pack_template_v2.dart', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a3e940cc64832aa1da85c607ad6508