### PR TITLE
Add core note taking skeleton module

### DIFF
--- a/curriculum_status.json
+++ b/curriculum_status.json
@@ -10,6 +10,7 @@
     "core_bet_sizing_fe",
     "core_gto_vs_exploit",
     "core_bankroll_management",
-    "core_mental_game"
+    "core_mental_game",
+    "core_note_taking"
   ]
 }

--- a/lib/packs/core_note_taking_loader.dart
+++ b/lib/packs/core_note_taking_loader.dart
@@ -1,0 +1,11 @@
+import '../ui/session_player/models.dart';
+import '../services/spot_importer.dart';
+
+const String _coreNoteTakingStub = '''
+{"kind":"l1_core_call_vs_price","hand":"AhKc","pos":"BB","stack":"10bb","action":"call"}
+''';
+
+List<UiSpot> loadCoreNoteTakingStub() {
+  final r = SpotImporter.parse(_coreNoteTakingStub, format: 'jsonl');
+  return r.spots;
+}


### PR DESCRIPTION
## Summary
- stub loader for core note taking pack
- track core_note_taking module as completed

## Testing
- `dart format lib/packs/core_note_taking_loader.dart` *(command not found: dart)*
- `dart analyze` *(command not found: dart)*

------
https://chatgpt.com/codex/tasks/task_e_68a3eb077114832aa8b95d03fcf1ce21