### PR TITLE
Add cash rake and stakes skeleton module

### DIFF
--- a/curriculum_status.json
+++ b/curriculum_status.json
@@ -11,6 +11,7 @@
     "core_gto_vs_exploit",
     "core_bankroll_management",
     "core_mental_game",
-    "core_note_taking"
+    "core_note_taking",
+    "cash_rake_and_stakes"
   ]
 }

--- a/lib/packs/cash_rake_and_stakes_loader.dart
+++ b/lib/packs/cash_rake_and_stakes_loader.dart
@@ -1,0 +1,11 @@
+import '../ui/session_player/models.dart';
+import '../services/spot_importer.dart';
+
+const String _cashRakeAndStakesStub = '''
+{"kind":"l1_core_call_vs_price","hand":"AhKc","pos":"BB","stack":"10bb","action":"call"}
+''';
+
+List<UiSpot> loadCashRakeAndStakesStub() {
+  final r = SpotImporter.parse(_cashRakeAndStakesStub, format: 'jsonl');
+  return r.spots;
+}


### PR DESCRIPTION
## Summary
- add placeholder loader for cash rake and stakes
- track cash rake and stakes in curriculum status

## Testing
- `dart format lib/packs/cash_rake_and_stakes_loader.dart`
- `dart format curriculum_status.json` *(fails: Expected a method, getter, setter or operator declaration)*
- `dart analyze` *(fails: Target of URI doesn't exist: 'package:flutter/material.dart'; 9032 issues found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3ec10ebf8832aa93e7262b7d7a16d