### PR TITLE
Add cash single raised pots skeleton loader

### DIFF
--- a/curriculum_status.json
+++ b/curriculum_status.json
@@ -12,6 +12,7 @@
     "core_bankroll_management",
     "core_mental_game",
     "core_note_taking",
-    "cash_rake_and_stakes"
+    "cash_rake_and_stakes",
+    "cash_single_raised_pots"
   ]
 }

--- a/lib/packs/cash_single_raised_pots_loader.dart
+++ b/lib/packs/cash_single_raised_pots_loader.dart
@@ -1,0 +1,11 @@
+import '../ui/session_player/models.dart';
+import '../services/spot_importer.dart';
+
+const String _cashSingleRaisedPotsStub = '''
+{"kind":"l1_core_call_vs_price","hand":"AhKc","pos":"BB","stack":"10bb","action":"call"}
+''';
+
+List<UiSpot> loadCashSingleRaisedPotsStub() {
+  final r = SpotImporter.parse(_cashSingleRaisedPotsStub, format: 'jsonl');
+  return r.spots;
+}


### PR DESCRIPTION
## Summary
- add placeholder loader for cash_single_raised_pots pack
- mark cash_single_raised_pots module as done in curriculum_status.json

## Testing
- `dart analyze lib/packs/cash_single_raised_pots_loader.dart`
- `flutter test` *(fails: file_picker plugin missing inline implementation)*

------
https://chatgpt.com/codex/tasks/task_e_68a3ed5f8160832aa5d545edec1b929f