### PR TITLE
Add cash threebet pots skeleton

### DIFF
--- a/curriculum_status.json
+++ b/curriculum_status.json
@@ -13,6 +13,7 @@
     "core_mental_game",
     "core_note_taking",
     "cash_rake_and_stakes",
-    "cash_single_raised_pots"
+    "cash_single_raised_pots",
+    "cash_threebet_pots"
   ]
 }

--- a/lib/packs/cash_threebet_pots_loader.dart
+++ b/lib/packs/cash_threebet_pots_loader.dart
@@ -1,0 +1,11 @@
+import '../ui/session_player/models.dart';
+import '../services/spot_importer.dart';
+
+const String _cashThreebetPotsStub = '''
+{"kind":"l1_core_call_vs_price","hand":"AhKc","pos":"BB","stack":"10bb","action":"call"}
+''';
+
+List<UiSpot> loadCashThreebetPotsStub() {
+  final r = SpotImporter.parse(_cashThreebetPotsStub, format: 'jsonl');
+  return r.spots;
+}


### PR DESCRIPTION
## Summary
- add stub loader for `cash_threebet_pots`
- mark `cash_threebet_pots` as completed in curriculum status

## Testing
- `dart format lib/packs/cash_threebet_pots_loader.dart curriculum_status.json` *(fails: command not found)*
- `apt-get install -y dart` *(fails: package not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3f32732b0832a82e45eac12cd92bf