### PR TITLE
Add cash isolation raises skeleton module

### DIFF
--- a/curriculum_status.json
+++ b/curriculum_status.json
@@ -16,6 +16,7 @@
     "cash_single_raised_pots",
     "cash_threebet_pots",
     "cash_multiway_pots",
-    "cash_blind_defense"
+    "cash_blind_defense",
+    "cash_isolation_raises"
   ]
 }

--- a/lib/packs/cash_isolation_raises_loader.dart
+++ b/lib/packs/cash_isolation_raises_loader.dart
@@ -1,0 +1,11 @@
+import '../ui/session_player/models.dart';
+import '../services/spot_importer.dart';
+
+const String _cashIsolationRaisesStub = '''
+{"kind":"l1_core_call_vs_price","hand":"AhKc","pos":"BB","stack":"10bb","action":"call"}
+''';
+
+List<UiSpot> loadCashIsolationRaisesStub() {
+  final r = SpotImporter.parse(_cashIsolationRaisesStub, format: 'jsonl');
+  return r.spots;
+}


### PR DESCRIPTION
## Summary
- add stub loader for upcoming `cash_isolation_raises` pack
- track `cash_isolation_raises` progress in curriculum status

## Testing
- `dart format lib/packs/cash_isolation_raises_loader.dart`
- `dart analyze` *(fails: Could not load `package:flutter`; tried installing Flutter but `snap` not available)*

------
https://chatgpt.com/codex/tasks/task_e_68a3f66ce308832aab182f8e20cabe9c