### PR TITLE
Add cash_short_handed skeleton module

### DIFF
--- a/curriculum_status.json
+++ b/curriculum_status.json
@@ -17,6 +17,7 @@
     "cash_threebet_pots",
     "cash_multiway_pots",
     "cash_blind_defense",
-    "cash_isolation_raises"
+    "cash_isolation_raises",
+    "cash_short_handed"
   ]
 }

--- a/lib/packs/cash_short_handed_loader.dart
+++ b/lib/packs/cash_short_handed_loader.dart
@@ -1,0 +1,11 @@
+import '../ui/session_player/models.dart';
+import '../services/spot_importer.dart';
+
+const String _cashShortHandedStub = '''
+{"kind":"l1_core_call_vs_price","hand":"AhKc","pos":"BB","stack":"10bb","action":"call"}
+''';
+
+List<UiSpot> loadCashShortHandedStub() {
+  final r = SpotImporter.parse(_cashShortHandedStub, format: 'jsonl');
+  return r.spots;
+}


### PR DESCRIPTION
## Summary
- add stub loader for cash short handed pack
- mark cash_short_handed as completed in curriculum status

## Testing
- `dart format lib/packs/cash_short_handed_loader.dart`
- `dart analyze` *(fails: 9032 issues found)*
- `dart test` *(fails: requires Flutter SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68a3f7c1c198832ab88b1814a34854d9