### PR TITLE
feat: add cash population exploits skeleton

### DIFF
--- a/curriculum_status.json
+++ b/curriculum_status.json
@@ -18,6 +18,7 @@
     "cash_multiway_pots",
     "cash_blind_defense",
     "cash_isolation_raises",
-    "cash_short_handed"
+    "cash_short_handed",
+    "cash_population_exploits"
   ]
 }

--- a/lib/packs/cash_population_exploits_loader.dart
+++ b/lib/packs/cash_population_exploits_loader.dart
@@ -1,0 +1,11 @@
+import '../ui/session_player/models.dart';
+import '../services/spot_importer.dart';
+
+const String _cashPopulationExploitsStub = '''
+{"kind":"l1_core_call_vs_price","hand":"AhKc","pos":"BB","stack":"10bb","action":"call"}
+''';
+
+List<UiSpot> loadCashPopulationExploitsStub() {
+  final r = SpotImporter.parse(_cashPopulationExploitsStub, format: 'jsonl');
+  return r.spots;
+}


### PR DESCRIPTION
## Summary
- scaffold cash population exploits pack loader
- track cash population exploits module status

## Testing
- `dart format lib/packs/cash_population_exploits_loader.dart`
- `dart analyze lib/packs/cash_population_exploits_loader.dart`
- `dart analyze`
- `flutter pub get` *(fails: The current Dart SDK version is 3.5.0. Because poker_analyzer requires SDK version >=3.9.0 <4.0.0, version solving failed.)*
- `dart test` *(fails: Flutter users should use `flutter pub` instead of `dart pub`.)*
- `flutter test` *(fails: Because poker_analyzer requires SDK version >=3.9.0 <4.0.0, version solving failed.)*

------
https://chatgpt.com/codex/tasks/task_e_68a3f9691fa4832abe5aebe895f9b22a