### PR TITLE
feat: add mtt antes phases skeleton module

### DIFF
--- a/curriculum_status.json
+++ b/curriculum_status.json
@@ -19,6 +19,7 @@
     "cash_blind_defense",
     "cash_isolation_raises",
     "cash_short_handed",
-    "cash_population_exploits"
+    "cash_population_exploits",
+    "mtt_antes_phases"
   ]
 }

--- a/lib/packs/mtt_antes_phases_loader.dart
+++ b/lib/packs/mtt_antes_phases_loader.dart
@@ -1,0 +1,11 @@
+import '../ui/session_player/models.dart';
+import '../services/spot_importer.dart';
+
+const String _mttAntesPhasesStub = '''
+{"kind":"l1_core_call_vs_price","hand":"AhKc","pos":"BB","stack":"10bb","action":"call"}
+''';
+
+List<UiSpot> loadMttAntesPhasesStub() {
+  final r = SpotImporter.parse(_mttAntesPhasesStub, format: 'jsonl');
+  return r.spots;
+}


### PR DESCRIPTION
## Summary
- add stub loader for mtt antes phases pack
- append mtt_antes_phases to curriculum status

## Testing
- `dart format lib/packs/mtt_antes_phases_loader.dart`
- `flutter analyze` *(fails: 426 issues)*
- `flutter test` *(fails: dependency and compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a3fb3550b8832a90000e4b1e117eee