### PR TITLE
feat: add mtt short stack skeleton module

### DIFF
--- a/curriculum_status.json
+++ b/curriculum_status.json
@@ -20,6 +20,7 @@
     "cash_isolation_raises",
     "cash_short_handed",
     "cash_population_exploits",
-    "mtt_antes_phases"
+    "mtt_antes_phases",
+    "mtt_short_stack"
   ]
 }

--- a/lib/packs/mtt_short_stack_loader.dart
+++ b/lib/packs/mtt_short_stack_loader.dart
@@ -1,0 +1,11 @@
+import '../ui/session_player/models.dart';
+import '../services/spot_importer.dart';
+
+const String _mttShortStackStub = '''
+{"kind":"l1_core_call_vs_price","hand":"AhKc","pos":"BB","stack":"10bb","action":"call"}
+''';
+
+List<UiSpot> loadMttShortStackStub() {
+  final r = SpotImporter.parse(_mttShortStackStub, format: 'jsonl');
+  return r.spots;
+}


### PR DESCRIPTION
## Summary
- add placeholder loader for upcoming mtt short stack module
- register mtt_short_stack as completed in curriculum_status

## Testing
- `dart format lib/packs/mtt_short_stack_loader.dart`
- `dart analyze` *(fails: 9032 issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a3fde37cfc832a8c519968485c048b