### PR TITLE
Add mtt mid stack skeleton module

### DIFF
--- a/curriculum_status.json
+++ b/curriculum_status.json
@@ -21,6 +21,7 @@
     "cash_short_handed",
     "cash_population_exploits",
     "mtt_antes_phases",
-    "mtt_short_stack"
+    "mtt_short_stack",
+    "mtt_mid_stack"
   ]
 }

--- a/lib/packs/mtt_mid_stack_loader.dart
+++ b/lib/packs/mtt_mid_stack_loader.dart
@@ -1,0 +1,11 @@
+import '../ui/session_player/models.dart';
+import '../services/spot_importer.dart';
+
+const String _mttMidStackStub = '''
+{"kind":"l1_core_call_vs_price","hand":"AhKc","pos":"BB","stack":"10bb","action":"call"}
+''';
+
+List<UiSpot> loadMttMidStackStub() {
+  final r = SpotImporter.parse(_mttMidStackStub, format: 'jsonl');
+  return r.spots;
+}


### PR DESCRIPTION
## Summary
- add stub loader for mid stack pack
- track module completion status for mtt_mid_stack

## Testing
- `/tmp/dart-sdk/bin/dart format lib/packs/mtt_mid_stack_loader.dart`
- `/tmp/dart-sdk/bin/dart analyze`


------
https://chatgpt.com/codex/tasks/task_e_68a3ff6610bc832a9fda40fa650b2d48