### PR TITLE
feat: add mtt deep stack skeleton

### DIFF
--- a/curriculum_status.json
+++ b/curriculum_status.json
@@ -22,6 +22,7 @@
     "cash_population_exploits",
     "mtt_antes_phases",
     "mtt_short_stack",
-    "mtt_mid_stack"
+    "mtt_mid_stack",
+    "mtt_deep_stack"
   ]
 }

--- a/lib/packs/mtt_deep_stack_loader.dart
+++ b/lib/packs/mtt_deep_stack_loader.dart
@@ -1,0 +1,11 @@
+import '../ui/session_player/models.dart';
+import '../services/spot_importer.dart';
+
+const String _mttDeepStackStub = '''
+{"kind":"l1_core_call_vs_price","hand":"AhKc","pos":"BB","stack":"10bb","action":"call"}
+''';
+
+List<UiSpot> loadMttDeepStackStub() {
+  final r = SpotImporter.parse(_mttDeepStackStub, format: 'jsonl');
+  return r.spots;
+}


### PR DESCRIPTION
## Summary
- add placeholder loader for upcoming MTT deep stack module
- mark mtt_deep_stack as done in curriculum status

## Testing
- `dart format lib/packs/mtt_deep_stack_loader.dart`
- `dart analyze` *(9032 issues, see log)*

------
https://chatgpt.com/codex/tasks/task_e_68a4009f7a1c832a9435dc4188af0f91