### PR TITLE
feat: add mtt icm basics skeleton module

### DIFF
--- a/curriculum_status.json
+++ b/curriculum_status.json
@@ -23,6 +23,7 @@
     "mtt_antes_phases",
     "mtt_short_stack",
     "mtt_mid_stack",
-    "mtt_deep_stack"
+    "mtt_deep_stack",
+    "mtt_icm_basics"
   ]
 }

--- a/lib/packs/mtt_icm_basics_loader.dart
+++ b/lib/packs/mtt_icm_basics_loader.dart
@@ -1,0 +1,11 @@
+import '../ui/session_player/models.dart';
+import '../services/spot_importer.dart';
+
+const String _mttIcmBasicsStub = '''
+{"kind":"l1_core_call_vs_price","hand":"AhKc","pos":"BB","stack":"10bb","action":"call"}
+''';
+
+List<UiSpot> loadMttIcmBasicsStub() {
+  final r = SpotImporter.parse(_mttIcmBasicsStub, format: 'jsonl');
+  return r.spots;
+}


### PR DESCRIPTION
## Summary
- add skeleton loader for upcoming `mtt_icm_basics` pack
- track `mtt_icm_basics` in curriculum status

## Testing
- `dart format lib/packs/mtt_icm_basics_loader.dart curriculum_status.json` *(fails: command not found: dart)*
- `dart analyze` *(fails: command not found: dart)*

------
https://chatgpt.com/codex/tasks/task_e_68a402361b80832a9e00095910cd3e28