### PR TITLE
Add mtt_bubble_and_FT skeleton module

### DIFF
--- a/curriculum_status.json
+++ b/curriculum_status.json
@@ -24,6 +24,7 @@
     "mtt_short_stack",
     "mtt_mid_stack",
     "mtt_deep_stack",
-    "mtt_icm_basics"
+    "mtt_icm_basics",
+    "mtt_bubble_and_FT"
   ]
 }

--- a/lib/packs/mtt_bubble_and_FT_loader.dart
+++ b/lib/packs/mtt_bubble_and_FT_loader.dart
@@ -1,0 +1,11 @@
+import '../ui/session_player/models.dart';
+import '../services/spot_importer.dart';
+
+const String _mttBubbleAndFtStub = '''
+{"kind":"l1_core_call_vs_price","hand":"AhKc","pos":"BB","stack":"10bb","action":"call"}
+''';
+
+List<UiSpot> loadMttBubbleAndFtStub() {
+  final r = SpotImporter.parse(_mttBubbleAndFtStub, format: 'jsonl');
+  return r.spots;
+}


### PR DESCRIPTION
## Summary
- add stub loader for upcoming mtt_bubble_and_FT pack
- mark mtt_bubble_and_FT as completed in curriculum status

## Testing
- `dart format lib/packs/mtt_bubble_and_FT_loader.dart`
- `dart analyze lib/packs/mtt_bubble_and_FT_loader.dart`
- `dart analyze` *(fails: The current Dart SDK version is 3.5.0, but >=3.9.0 <4.0.0 is required)*

------
https://chatgpt.com/codex/tasks/task_e_68a403406bc8832aa99ee3f7bb71f632