### PR TITLE
Add mtt satellite strategy skeleton

### DIFF
--- a/curriculum_status.json
+++ b/curriculum_status.json
@@ -26,6 +26,7 @@
     "mtt_deep_stack",
     "mtt_icm_basics",
     "mtt_bubble_and_FT",
-    "mtt_pko_strategy"
+    "mtt_pko_strategy",
+    "mtt_satellite_strategy"
   ]
 }

--- a/lib/packs/mtt_satellite_strategy_loader.dart
+++ b/lib/packs/mtt_satellite_strategy_loader.dart
@@ -1,0 +1,11 @@
+import '../ui/session_player/models.dart';
+import '../services/spot_importer.dart';
+
+const String _mttSatelliteStrategyStub = '''
+{"kind":"l1_core_call_vs_price","hand":"AhKc","pos":"BB","stack":"10bb","action":"call"}
+''';
+
+List<UiSpot> loadMttSatelliteStrategyStub() {
+  final r = SpotImporter.parse(_mttSatelliteStrategyStub, format: 'jsonl');
+  return r.spots;
+}


### PR DESCRIPTION
## Summary
- stub loader for the upcoming `mtt_satellite_strategy` module
- record `mtt_satellite_strategy` as complete in curriculum status

## Testing
- `dart format lib/packs/mtt_satellite_strategy_loader.dart`
- `dart analyze` *(fails: many warnings)*
- `dart test` *(fails: Because poker_analyzer requires the Flutter SDK, version solving failed.)*

------
https://chatgpt.com/codex/tasks/task_e_68a407fbee7c832abd5e2bb5b065e0f5