### PR TITLE
feat: add hu preflop skeleton module

### DIFF
--- a/curriculum_status.json
+++ b/curriculum_status.json
@@ -27,6 +27,7 @@
     "mtt_icm_basics",
     "mtt_bubble_and_FT",
     "mtt_pko_strategy",
-    "mtt_satellite_strategy"
+    "mtt_satellite_strategy",
+    "hu_preflop"
   ]
 }

--- a/lib/packs/hu_preflop_loader.dart
+++ b/lib/packs/hu_preflop_loader.dart
@@ -1,0 +1,11 @@
+import '../ui/session_player/models.dart';
+import '../services/spot_importer.dart';
+
+const String _huPreflopStub = '''
+{"kind":"l1_core_call_vs_price","hand":"AhKc","pos":"BB","stack":"10bb","action":"call"}
+''';
+
+List<UiSpot> loadHuPreflopStub() {
+  final r = SpotImporter.parse(_huPreflopStub, format: 'jsonl');
+  return r.spots;
+}


### PR DESCRIPTION
## Summary
- add hu preflop pack loader stub
- mark hu_preflop module done in curriculum status

## Testing
- `dart format lib/packs/hu_preflop_loader.dart`
- `flutter pub get` *(warnings: file_picker default plugin references)*
- `flutter analyze` *(426 issues found)*
- `flutter test` *(many errors; exit 1)*

------
https://chatgpt.com/codex/tasks/task_e_68a4098a7308832a825938265cd608a7