### PR TITLE
Add hu turn play skeleton module

### DIFF
--- a/curriculum_status.json
+++ b/curriculum_status.json
@@ -29,6 +29,7 @@
     "mtt_pko_strategy",
     "mtt_satellite_strategy",
     "hu_preflop",
-    "hu_postflop"
+    "hu_postflop",
+    "hu_turn_play"
   ]
 }

--- a/lib/packs/hu_turn_play_loader.dart
+++ b/lib/packs/hu_turn_play_loader.dart
@@ -1,0 +1,11 @@
+import '../ui/session_player/models.dart';
+import '../services/spot_importer.dart';
+
+const String _huTurnPlayStub = '''
+{"kind":"l1_core_call_vs_price","hand":"AhKc","pos":"BB","stack":"10bb","action":"call"}
+''';
+
+List<UiSpot> loadHuTurnPlayStub() {
+  final r = SpotImporter.parse(_huTurnPlayStub, format: 'jsonl');
+  return r.spots;
+}


### PR DESCRIPTION
## Summary
- stub loader for HU turn play pack
- mark hu_turn_play as done in curriculum_status.json

## Testing
- `dart format lib/packs/hu_turn_play_loader.dart curriculum_status.json` *(fails: dart: command not found)*
- `dart analyze` *(fails: dart: command not found)*
- `dart test` *(fails: dart: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a40e7760e0832a8661610152b8e720