### PR TITLE
Add hu_river_play skeleton module

### DIFF
--- a/curriculum_status.json
+++ b/curriculum_status.json
@@ -30,6 +30,7 @@
     "mtt_satellite_strategy",
     "hu_preflop",
     "hu_postflop",
-    "hu_turn_play"
+    "hu_turn_play",
+    "hu_river_play"
   ]
 }

--- a/lib/packs/hu_river_play_loader.dart
+++ b/lib/packs/hu_river_play_loader.dart
@@ -1,0 +1,11 @@
+import '../ui/session_player/models.dart';
+import '../services/spot_importer.dart';
+
+const String _huRiverPlayStub = '''
+{"kind":"l1_core_call_vs_price","hand":"AhKc","pos":"BB","stack":"10bb","action":"call"}
+''';
+
+List<UiSpot> loadHuRiverPlayStub() {
+  final r = SpotImporter.parse(_huRiverPlayStub, format: 'jsonl');
+  return r.spots;
+}


### PR DESCRIPTION
## Summary
- stub loader for `hu_river_play` pack
- update curriculum status with `hu_river_play`

## Testing
- `dart format lib/packs/hu_river_play_loader.dart`
- `dart analyze lib/packs/hu_river_play_loader.dart`


------
https://chatgpt.com/codex/tasks/task_e_68a410910128832aa12f3f17b9487f0f