### PR TITLE
Add spr_basics skeleton module

### DIFF
--- a/curriculum_status.json
+++ b/curriculum_status.json
@@ -31,6 +31,7 @@
     "hu_preflop",
     "hu_postflop",
     "hu_turn_play",
-    "hu_river_play"
+    "hu_river_play",
+    "spr_basics"
   ]
 }

--- a/lib/packs/spr_basics_loader.dart
+++ b/lib/packs/spr_basics_loader.dart
@@ -1,0 +1,11 @@
+import '../ui/session_player/models.dart';
+import '../services/spot_importer.dart';
+
+const String _sprBasicsStub = '''
+{"kind":"l1_core_call_vs_price","hand":"AhKc","pos":"BB","stack":"10bb","action":"call"}
+''';
+
+List<UiSpot> loadSprBasicsStub() {
+  final r = SpotImporter.parse(_sprBasicsStub, format: 'jsonl');
+  return r.spots;
+}


### PR DESCRIPTION
## Summary
- stub out spr_basics loader returning placeholder spot list
- track new spr_basics module in curriculum_status.json

## Testing
- ⚠️ `dart format lib/packs/spr_basics_loader.dart` (command not found: dart)
- ⚠️ `dart analyze` (command not found: dart)
- ⚠️ `dart test` (command not found: dart)


------
https://chatgpt.com/codex/tasks/task_e_68a411e680e8832a86a4d78ed089846d