### PR TITLE
Add live tells and dynamics skeleton module

### DIFF
--- a/curriculum_status.json
+++ b/curriculum_status.json
@@ -32,6 +32,7 @@
     "hu_postflop",
     "hu_turn_play",
     "hu_river_play",
-    "spr_basics"
+    "spr_basics",
+    "live_tells_and_dynamics"
   ]
 }

--- a/lib/packs/live_tells_and_dynamics_loader.dart
+++ b/lib/packs/live_tells_and_dynamics_loader.dart
@@ -1,0 +1,11 @@
+import '../ui/session_player/models.dart';
+import '../services/spot_importer.dart';
+
+const String _liveTellsAndDynamicsStub = '''
+{"kind":"l1_core_call_vs_price","hand":"AhKc","pos":"BB","stack":"10bb","action":"call"}
+''';
+
+List<UiSpot> loadLiveTellsAndDynamicsStub() {
+  final r = SpotImporter.parse(_liveTellsAndDynamicsStub, format: 'jsonl');
+  return r.spots;
+}


### PR DESCRIPTION
## Summary
- stub loader for `live_tells_and_dynamics`
- mark `live_tells_and_dynamics` module as done in curriculum status

## Testing
- `dart format lib/packs/live_tells_and_dynamics_loader.dart`
- `dart analyze` *(fails: Target of URI doesn't exist, etc.)*
- `/tmp/flutter/bin/flutter test` *(fails: plugin warnings, compile errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a412f7f394832a86c9dbf0934f763b