### PR TITLE
feat: add core flop play skeleton module

### DIFF
--- a/curriculum_status.json
+++ b/curriculum_status.json
@@ -34,6 +34,7 @@
     "spr_basics",
     "live_tells_and_dynamics",
     "online_tells_and_dynamics",
-    "core_starting_hands"
+    "core_starting_hands",
+    "core_flop_play"
   ]
 }

--- a/lib/packs/core_flop_play_loader.dart
+++ b/lib/packs/core_flop_play_loader.dart
@@ -1,8 +1,9 @@
 import '../ui/session_player/models.dart';
 import '../services/spot_importer.dart';
 
+// Stub pack loader for the core_flop_play module.
 const String _coreFlopPlayStub = '''
-{"kind":"l1_core_call_vs_price","hand":"AhKc","pos":"BB","stack":"10bb","action":"call"}
+{"kind":"l1_core_call_vs_price","hand":"AsKd","pos":"BB","stack":"10bb","action":"call"}
 ''';
 
 List<UiSpot> loadCoreFlopPlayStub() {


### PR DESCRIPTION
## Summary
- stub loader for core flop play module
- track core flop play progress in curriculum

## Testing
- `dart format lib/packs/core_flop_play_loader.dart curriculum_status.json` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a42304dd00832a8b62bc2e97ceec12