### PR TITLE
chore: append core position modules

### DIFF
--- a/tooling/curriculum_ids.dart
+++ b/tooling/curriculum_ids.dart
@@ -37,6 +37,8 @@ const List<String> kCurriculumModuleIds = [
   'hu_postflop',
   'hu_turn_play',
   'hu_river_play',
+  'core_positions_and_initiative',
+  'core_board_textures',
 ];
 
 String? firstMissing(Iterable<String> done) {


### PR DESCRIPTION
## Summary
- extend kCurriculumModuleIds with core_positions_and_initiative and core_board_textures

## Testing
- `dart format tooling/curriculum_ids.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `dart test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a42c618990832a946b05061b899ff5