### PR TITLE
test: add curriculum consistency guard

### DIFF
--- a/test/curriculum_consistency_test.dart
+++ b/test/curriculum_consistency_test.dart
@@ -1,0 +1,40 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+import 'tooling/curriculum_ids.dart';
+import 'lib/packs/core_starting_hands_loader.dart';
+import 'lib/ui/session_player/models.dart';
+
+void main() {
+  test('curriculum ids stay consistent with status and stub loader', () {
+    final ids = List<String>.from(kCurriculumModuleIds);
+
+    expect(
+      ids.length,
+      ids.toSet().length,
+      reason: 'kCurriculumModuleIds has duplicates',
+    );
+
+    final status =
+        jsonDecode(File('curriculum_status.json').readAsStringSync())
+            as Map<String, dynamic>;
+    final done = (status['modules_done'] as List).cast<String>();
+
+    final extras = done.where((id) => !ids.contains(id)).toList();
+    expect(
+      extras,
+      isEmpty,
+      reason: 'modules_done contains unknown ids: $extras',
+    );
+
+    final spots = loadCoreStartingHandsStub();
+    expect(
+      spots.length,
+      1,
+      reason: 'core starting hands stub should load 1 spot',
+    );
+    expect(spots.single.kind, SpotKind.l1_core_call_vs_price);
+  });
+}


### PR DESCRIPTION
## Summary
- add pure Dart test verifying curriculum status vs SSOT and core starting hands stub

## Testing
- `dart format test/curriculum_consistency_test.dart`
- `dart analyze` (warnings: deprecated API uses)
- `dart test test/curriculum_consistency_test.dart` *(fails: requires Flutter SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68a43094620c832a8e4aa2e95609917a