### PR TITLE
test: add curriculum NEXT printer

### DIFF
--- a/test/curriculum_next_test.dart
+++ b/test/curriculum_next_test.dart
@@ -1,0 +1,29 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:test/test.dart';
+import 'tooling/curriculum_ids.dart';
+
+void main() {
+  test('curriculum NEXT printer', () {
+    final status =
+        jsonDecode(File('curriculum_status.json').readAsStringSync())
+            as Map<String, dynamic>;
+    final done = (status['modules_done'] as List).cast<String>().toSet();
+
+    String? nextId;
+    for (final id in kCurriculumModuleIds) {
+      if (!done.contains(id)) {
+        nextId = id;
+        break;
+      }
+    }
+
+    print(nextId == null ? 'NEXT: done' : 'NEXT: $nextId');
+
+    if (nextId != null) {
+      expect(nextId.contains(':'), isFalse);
+      expect(kCurriculumModuleIds, contains(nextId));
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- add pure-Dart test that prints NEXT curriculum module and asserts it's a valid module id
- ensure NEXT printer uses string interpolation

## Testing
- `dart analyze test/curriculum_next_test.dart` *(fails: Target of URI doesn't exist: 'package:test/test.dart')*
- `dart test test/curriculum_next_test.dart` *(fails: project requires the Flutter SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68a441a208e4832a9bcf7620b90558fd