### PR TITLE
feat: add logical curriculum ordering

### DIFF
--- a/test/curriculum_next_test.dart
+++ b/test/curriculum_next_test.dart
@@ -11,19 +11,12 @@ void main() {
             as Map<String, dynamic>;
     final done = (status['modules_done'] as List).cast<String>().toSet();
 
-    String? nextId;
-    for (final id in kCurriculumModuleIds) {
-      if (!done.contains(id)) {
-        nextId = id;
-        break;
-      }
-    }
-
+    final nextId = recommendedNext(done);
     print(nextId == null ? 'NEXT: done' : 'NEXT: $nextId');
 
     if (nextId != null) {
-      expect(nextId.contains(':'), isFalse);
       expect(kCurriculumModuleIds, contains(nextId));
+      expect(nextId.contains(':'), isFalse);
     }
   });
 }

--- a/tooling/curriculum_ids.dart
+++ b/tooling/curriculum_ids.dart
@@ -41,10 +41,40 @@ const List<String> kCurriculumModuleIds = [
   'core_board_textures',
 ];
 
+const Map<String, int> kModulePriority = {
+  'core_positions_and_initiative': 0,
+  'core_board_textures': 1,
+};
+
+List<String> logicalOrder() {
+  final entries = kCurriculumModuleIds.asMap().entries.toList()
+    ..sort((a, b) {
+      final pa = kModulePriority[a.value] ?? 999;
+      final pb = kModulePriority[b.value] ?? 999;
+      if (pa != pb) {
+        return pa.compareTo(pb);
+      }
+      return a.key.compareTo(b.key);
+    });
+  return [for (final e in entries) e.value];
+}
+
 String? firstMissing(Iterable<String> done) {
   final doneSet = done.toSet();
   for (final id in kCurriculumModuleIds) {
     if (!doneSet.contains(id)) {
+      return id;
+    }
+  }
+  return null;
+}
+
+String? recommendedNext(Set<String> done) {
+  for (final id in logicalOrder()) {
+    if (id.contains(':')) {
+      continue;
+    }
+    if (!done.contains(id)) {
       return id;
     }
   }


### PR DESCRIPTION
## Summary
- prioritize bridge modules when recommending next curriculum item
- expose `logicalOrder` and `recommendedNext` helpers
- update curriculum next test to use recommendation helper

## Testing
- `dart analyze`
- `flutter test test/curriculum_next_test.dart` *(fails: Error when reading 'test/tooling/curriculum_ids.dart')*


------
https://chatgpt.com/codex/tasks/task_e_68a443d18d68832ab9d5586fe3875a6d