### PR TITLE
test: enforce SpotKind naming

### DIFF
--- a/test/spotkind_naming_validator_test.dart
+++ b/test/spotkind_naming_validator_test.dart
@@ -1,0 +1,15 @@
+import 'package:test/test.dart';
+import 'package:poker_analyzer/ui/session_player/models.dart';
+
+void main() {
+  test('SpotKind names follow l<num>_word_word format', () {
+    final regex = RegExp('^l\\d+_[a-z]+_[a-z_]+$');
+    final bad = [
+      for (final k in SpotKind.values)
+        if (!regex.hasMatch(k.name) ||
+            k.name.contains(RegExp(r'[^a-z0-9_]')))
+          k.name
+    ];
+    expect(bad, isEmpty, reason: 'Invalid SpotKind names: ${bad.join(', ')}');
+  });
+}


### PR DESCRIPTION
## Summary
- add pure Dart test validating SpotKind names follow `l<num>_word_word` pattern

## Testing
- `dart format test/spotkind_naming_validator_test.dart` *(command not found)*
- `dart analyze` *(command not found)*
- `dart test test/spotkind_naming_validator_test.dart` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a45623533c832a9aa64b8afc933968