### PR TITLE
feat: add hu_exploit_adv skeleton loader and update curriculum status

### DIFF
--- a/curriculum_status.json
+++ b/curriculum_status.json
@@ -29,6 +29,7 @@
     "mtt_pko_strategy",
     "mtt_satellite_strategy",
     "hu_preflop_strategy",
-    "hu_postflop_play"
+    "hu_postflop_play",
+    "hu_exploit_adv"
   ]
 }

--- a/lib/packs/hu_exploit_adv_loader.dart
+++ b/lib/packs/hu_exploit_adv_loader.dart
@@ -1,6 +1,11 @@
-git add lib/packs/hu_exploit_adv_loader.dart curriculum_status.json
-git commit -m "feat: add hu_exploit_adv skeleton loader and update curriculum_status"
-dart format --output=none --set-exit-if-changed .
-dart analyze
-dart test -r expanded
-git push origin <branch>
+import '../ui/session_player/models.dart';
+import '../services/spot_importer.dart';
+
+const String _huExploitAdvStub = '''
+{"kind":"l1_core_call_vs_price","hand":"AhKc","pos":"BB","stack":"10bb","action":"call"}
+''';
+
+List<UiSpot> loadHuExploitAdvStub() {
+  final r = SpotImporter.parse(_huExploitAdvStub, format: 'jsonl');
+  return r.spots;
+}


### PR DESCRIPTION
## Summary
- add heads-up exploit advanced pack loader skeleton
- append `hu_exploit_adv` to completed modules list

## Testing
- `dart format --output=none --set-exit-if-changed .`
- `dart analyze lib/packs/hu_exploit_adv_loader.dart`
- `dart analyze` *(fails: 9032 issues found)*
- `dart test -r expanded` *(fails: Flutter SDK not available)*

------
https://chatgpt.com/codex/tasks/task_e_68a4644920ec832aa28340870c967fb4