### PR TITLE
feat: add online tells dynamics stub

### DIFF
--- a/curriculum_status.json
+++ b/curriculum_status.json
@@ -32,6 +32,7 @@
     "hu_postflop_play",
     "hu_exploit_adv",
     "spr_basics",
-    "live_tells_and_dynamics"
+    "live_tells_and_dynamics",
+    "online_tells_and_dynamics"
   ]
 }

--- a/lib/packs/online_tells_and_dynamics_loader.dart
+++ b/lib/packs/online_tells_and_dynamics_loader.dart
@@ -1,6 +1,10 @@
 import '../ui/session_player/models.dart';
 import '../services/spot_importer.dart';
 
+/// Stub loader for the `online_tells_and_dynamics` curriculum module.
+///
+/// The embedded spot acts as a canonical guard, ensuring the loader
+/// parses correctly during early development.
 const String _onlineTellsAndDynamicsStub = '''
 {"kind":"l1_core_call_vs_price","hand":"AhKc","pos":"BB","stack":"10bb","action":"call"}
 ''';


### PR DESCRIPTION
## Summary
- add stub loader for online tells and dynamics module
- track online_tells_and_dynamics completion in curriculum status

## Testing
- `dart format lib/packs/online_tells_and_dynamics_loader.dart`
- `flutter analyze` *(fails: The current Dart SDK version is 3.5.0; project requires >=3.9.0)*
- `/tmp/dart-sdk/dart-sdk/bin/dart test` *(fails: Flutter SDK required)*


------
https://chatgpt.com/codex/tasks/task_e_68a46d83bd68832a92d894ed8c43fd52