### PR TITLE
feat: add hu river play stub

### DIFF
--- a/curriculum_status.json
+++ b/curriculum_status.json
@@ -36,6 +36,7 @@
     "online_tells_and_dynamics",
     "hu_preflop",
     "hu_postflop",
-    "hu_turn_play"
+    "hu_turn_play",
+    "hu_river_play"
   ]
 }

--- a/lib/packs/hu_river_play_loader.dart
+++ b/lib/packs/hu_river_play_loader.dart
@@ -1,8 +1,10 @@
 import '../ui/session_player/models.dart';
 import '../services/spot_importer.dart';
 
-// Stub loader for the HU River Play module.
-
+/// Stub loader for the `hu_river_play` curriculum module.
+///
+/// The embedded spot acts as a canonical guard, ensuring the loader
+/// parses correctly during early development.
 const String _huRiverPlayStub = '''
 {"kind":"l1_core_call_vs_price","hand":"AhKc","pos":"BB","stack":"10bb","action":"call"}
 ''';


### PR DESCRIPTION
## Summary
- add skeleton loader for HU river play with canonical spot guard
- extend curriculum status to include hu_river_play module

## Testing
- ⚠️ `dart format lib/packs/hu_river_play_loader.dart curriculum_status.json` (missing `dart` command)
- ⚠️ `dart analyze lib/packs/hu_river_play_loader.dart` (missing `dart` command)
- ⚠️ `dart test -r expanded test/curriculum_status_test.dart` (missing `dart` command)


------
https://chatgpt.com/codex/tasks/task_e_68a4e2b71654832abe99dad39ca9ffba