### PR TITLE
feat: add core positions and initiative stub loader

### DIFF
--- a/curriculum_status.json
+++ b/curriculum_status.json
@@ -37,6 +37,7 @@
     "hu_preflop",
     "hu_postflop",
     "hu_turn_play",
-    "hu_river_play"
+    "hu_river_play",
+    "core_positions_and_initiative"
   ]
 }

--- a/lib/packs/core_positions_and_initiative_loader.dart
+++ b/lib/packs/core_positions_and_initiative_loader.dart
@@ -1,0 +1,15 @@
+import '../ui/session_player/models.dart';
+import '../services/spot_importer.dart';
+
+/// Stub loader for the `core_positions_and_initiative` curriculum module.
+///
+/// The embedded spot acts as a canonical guard, ensuring the loader
+/// parses correctly during early development.
+const String _corePositionsAndInitiativeStub = '''
+{"kind":"l1_core_call_vs_price","hand":"AhKc","pos":"BB","stack":"10bb","action":"call"}
+''';
+
+List<UiSpot> loadCorePositionsAndInitiativeStub() {
+  final r = SpotImporter.parse(_corePositionsAndInitiativeStub, format: 'jsonl');
+  return r.spots;
+}


### PR DESCRIPTION
## Summary
- add stub loader for core positions and initiative module
- track core_positions_and_initiative in curriculum status

## Testing
- `dart format lib/packs/core_positions_and_initiative_loader.dart` *(fails: command not found)*
- `dart analyze lib/packs/core_positions_and_initiative_loader.dart` *(fails: command not found)*
- `dart test -r expanded test/curriculum_status_test.dart` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a4e49457c0832aa422b59f1306ea81