### PR TITLE
feat: add core board textures loader

### DIFF
--- a/curriculum_status.json
+++ b/curriculum_status.json
@@ -38,6 +38,7 @@
     "hu_postflop",
     "hu_turn_play",
     "hu_river_play",
-    "core_positions_and_initiative"
+    "core_positions_and_initiative",
+    "core_board_textures"
   ]
 }

--- a/lib/packs/core_board_textures_loader.dart
+++ b/lib/packs/core_board_textures_loader.dart
@@ -1,0 +1,12 @@
+import '../ui/session_player/models.dart';
+import '../services/spot_importer.dart';
+
+// Stub pack loader for the core_board_textures module.
+const String _coreBoardTexturesStub = '''
+{"kind":"l1_core_call_vs_price","hand":"AhKc","pos":"BB","stack":"10bb","action":"call"}
+''';
+
+List<UiSpot> loadCoreBoardTexturesStub() {
+  final r = SpotImporter.parse(_coreBoardTexturesStub, format: 'jsonl');
+  return r.spots;
+}


### PR DESCRIPTION
## Summary
- add stub loader for core_board_textures module
- include core_board_textures in curriculum status

## Testing
- `dart format lib/packs/core_board_textures_loader.dart`
- `dart analyze lib/packs/core_board_textures_loader.dart`
- `flutter test -r expanded test/curriculum_status_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_68a4e7c50600832a9dffa24ca81535b4