### PR TITLE
Add core check raise systems loader stub

### DIFF
--- a/curriculum_status.json
+++ b/curriculum_status.json
@@ -40,6 +40,7 @@
     "hu_river_play",
     "core_positions_and_initiative",
     "core_board_textures",
-    "core_river_play"
+    "core_river_play",
+    "core_check_raise_systems"
   ]
 }

--- a/lib/packs/core_check_raise_systems_loader.dart
+++ b/lib/packs/core_check_raise_systems_loader.dart
@@ -1,0 +1,12 @@
+import '../ui/session_player/models.dart';
+import '../services/spot_importer.dart';
+
+// Stub pack loader for the core_check_raise_systems module.
+const String _coreCheckRaiseSystemsStub = '''
+{"kind":"l1_core_call_vs_price","hand":"AsKd","pos":"BB","stack":"10bb","action":"call"}
+''';
+
+List<UiSpot> loadCoreCheckRaiseSystemsStub() {
+  final r = SpotImporter.parse(_coreCheckRaiseSystemsStub, format: 'jsonl');
+  return r.spots;
+}


### PR DESCRIPTION
## Summary
- stub loader for new core_check_raise_systems module
- mark core_check_raise_systems as completed in curriculum status

## Testing
- `dart analyze lib/packs/core_check_raise_systems_loader.dart`
- `flutter test -r expanded test/curriculum_status_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_68a66e7bc9b8832a82cd3f31b02437f8