### PR TITLE
Add cash blind vs blind loader stub and update curriculum

### DIFF
--- a/curriculum_status.json
+++ b/curriculum_status.json
@@ -41,6 +41,7 @@
     "core_positions_and_initiative",
     "core_board_textures",
     "core_river_play",
-    "core_check_raise_systems"
+    "core_check_raise_systems",
+    "cash_blind_vs_blind"
   ]
 }

--- a/lib/packs/cash_blind_vs_blind_loader.dart
+++ b/lib/packs/cash_blind_vs_blind_loader.dart
@@ -1,0 +1,11 @@
+import '../ui/session_player/models.dart';
+import '../services/spot_importer.dart';
+
+const String _cashBlindVsBlindStub = '''
+{"kind":"l1_core_call_vs_price","hand":"AhKc","pos":"BB","stack":"10bb","action":"call"}
+''';
+
+List<UiSpot> loadCashBlindVsBlindStub() {
+  final r = SpotImporter.parse(_cashBlindVsBlindStub, format: 'jsonl');
+  return r.spots;
+}


### PR DESCRIPTION
## Summary
- add stub pack loader for `cash_blind_vs_blind`
- mark `cash_blind_vs_blind` as completed in `curriculum_status.json`

## Testing
- `dart format lib/packs/cash_blind_vs_blind_loader.dart`
- `dart analyze lib/packs/cash_blind_vs_blind_loader.dart`
- `flutter test -r expanded test/curriculum_status_test.dart` *(fails: Dart SDK 3.4.0 < required 3.9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a6707c9968832aa4d35e94a90d0a2b