### PR TITLE
feat: add cash fourbet pots loader stub

### DIFF
--- a/curriculum_status.json
+++ b/curriculum_status.json
@@ -42,6 +42,7 @@
     "core_board_textures",
     "core_river_play",
     "core_check_raise_systems",
-    "cash_blind_vs_blind"
+    "cash_blind_vs_blind",
+    "cash_fourbet_pots"
   ]
 }

--- a/lib/packs/cash_fourbet_pots_loader.dart
+++ b/lib/packs/cash_fourbet_pots_loader.dart
@@ -1,0 +1,11 @@
+import '../ui/session_player/models.dart';
+import '../services/spot_importer.dart';
+
+const String _cashFourbetPotsStub = '''
+{"kind":"l1_core_call_vs_price","hand":"AhKc","pos":"BB","stack":"10bb","action":"call"}
+''';
+
+List<UiSpot> loadCashFourbetPotsStub() {
+  final r = SpotImporter.parse(_cashFourbetPotsStub, format: 'jsonl');
+  return r.spots;
+}


### PR DESCRIPTION
## Summary
- scaffold cash fourbet pots loader stub
- mark cash_fourbet_pots module as done in curriculum status

## Testing
- `dart format lib/packs/cash_fourbet_pots_loader.dart curriculum_status.json`
- `dart analyze`
- `dart test -r expanded test/curriculum_status_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_68a673dbe72c832a9f8d26424af443af