### PR TITLE
feat: add cash multiway 3bet pots stub loader

### DIFF
--- a/curriculum_status.json
+++ b/curriculum_status.json
@@ -45,6 +45,7 @@
     "cash_blind_vs_blind",
     "cash_fourbet_pots",
     "hu_river_play",
-    "spr_advanced"
+    "spr_advanced",
+    "cash_multiway_3bet_pots"
   ]
 }

--- a/lib/packs/cash_multiway_3bet_pots_loader.dart
+++ b/lib/packs/cash_multiway_3bet_pots_loader.dart
@@ -1,0 +1,11 @@
+import '../ui/session_player/models.dart';
+import '../services/spot_importer.dart';
+
+const String _cashMultiway3betPotsStub = '''
+{"kind":"l1_core_call_vs_price","hand":"AhKc","pos":"BB","stack":"10bb","action":"call"}
+''';
+
+List<UiSpot> loadCashMultiway3betPotsStub() {
+  final r = SpotImporter.parse(_cashMultiway3betPotsStub, format: 'jsonl');
+  return r.spots;
+}


### PR DESCRIPTION
## Summary
- add stub loader for cash multiway 3bet pots
- mark cash_multiway_3bet_pots module as done in curriculum status

## Testing
- `dart format lib/packs/cash_multiway_3bet_pots_loader.dart curriculum_status.json`
- `dart analyze` *(fails: Target of URI doesn't exist, 9044 issues found)*
- `dart test test/curriculum_next_test.dart` *(fails: Dart SDK version is 3.5.0, requires >=3.9.0 <4.0.0)*


------
https://chatgpt.com/codex/tasks/task_e_68a67d2de2e4832a88f1629049f7e675