### PR TITLE
feat: add cash delayed cbet and probe systems loader

### DIFF
--- a/curriculum_status.json
+++ b/curriculum_status.json
@@ -46,6 +46,7 @@
     "cash_fourbet_pots",
     "hu_river_play",
     "spr_advanced",
-    "cash_multiway_3bet_pots"
+    "cash_multiway_3bet_pots",
+    "cash_delayed_cbet_and_probe_systems"
   ]
 }

--- a/lib/packs/cash_delayed_cbet_and_probe_systems_loader.dart
+++ b/lib/packs/cash_delayed_cbet_and_probe_systems_loader.dart
@@ -1,0 +1,14 @@
+import '../ui/session_player/models.dart';
+import '../services/spot_importer.dart';
+
+const String _cashDelayedCbetAndProbeSystemsStub = '''
+{"kind":"l1_core_call_vs_price","hand":"AhKc","pos":"BB","stack":"10bb","action":"call"}
+''';
+
+List<UiSpot> loadCashDelayedCbetAndProbeSystemsStub() {
+  final r = SpotImporter.parse(
+    _cashDelayedCbetAndProbeSystemsStub,
+    format: 'jsonl',
+  );
+  return r.spots;
+}


### PR DESCRIPTION
## Summary
- add loader for cash delayed cbet and probe systems
- track cash_delayed_cbet_and_probe_systems in curriculum status

## Testing
- `dart test -r expanded test/curriculum_status_test.dart` *(fails: requires Flutter SDK)*
- `dart format lib/packs/cash_delayed_cbet_and_probe_systems_loader.dart`
- `dart analyze lib/packs/cash_delayed_cbet_and_probe_systems_loader.dart`


------
https://chatgpt.com/codex/tasks/task_e_68a683a99260832a9474d425ecbf313a