### PR TITLE
chore: tidy delayed cbet stub

### DIFF
--- a/curriculum_status.json
+++ b/curriculum_status.json
@@ -44,7 +44,6 @@
     "core_check_raise_systems",
     "cash_blind_vs_blind",
     "cash_fourbet_pots",
-    "hu_river_play",
     "spr_advanced",
     "cash_multiway_3bet_pots",
     "cash_delayed_cbet_and_probe_systems"

--- a/lib/packs/cash_delayed_cbet_and_probe_systems_loader.dart
+++ b/lib/packs/cash_delayed_cbet_and_probe_systems_loader.dart
@@ -6,9 +6,6 @@ const String _cashDelayedCbetAndProbeSystemsStub = '''
 ''';
 
 List<UiSpot> loadCashDelayedCbetAndProbeSystemsStub() {
-  final r = SpotImporter.parse(
-    _cashDelayedCbetAndProbeSystemsStub,
-    format: 'jsonl',
-  );
+  final r = SpotImporter.parse(_cashDelayedCbetAndProbeSystemsStub, format: 'jsonl');
   return r.spots;
 }


### PR DESCRIPTION
## Summary
- streamline delayed cbet and probe systems loader
- remove duplicate `hu_river_play` entry from curriculum status

## Testing
- `dart format lib/packs/cash_delayed_cbet_and_probe_systems_loader.dart curriculum_status.json` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `dart test test/curriculum_next_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6861767ac832ab689c220078aa67e