### PR TITLE
feat: add cash overbets and blocker bets loader

### DIFF
--- a/curriculum_status.json
+++ b/curriculum_status.json
@@ -46,6 +46,7 @@
     "cash_fourbet_pots",
     "spr_advanced",
     "cash_multiway_3bet_pots",
-    "cash_delayed_cbet_and_probe_systems"
+    "cash_delayed_cbet_and_probe_systems",
+    "cash_overbets_and_blocker_bets"
   ]
 }

--- a/lib/packs/cash_overbets_and_blocker_bets_loader.dart
+++ b/lib/packs/cash_overbets_and_blocker_bets_loader.dart
@@ -1,0 +1,14 @@
+import '../ui/session_player/models.dart';
+import '../services/spot_importer.dart';
+
+const String _cashOverbetsAndBlockerBetsStub = '''
+{"kind":"l1_core_call_vs_price","hand":"AhKc","pos":"BB","stack":"10bb","action":"call"}
+''';
+
+List<UiSpot> loadCashOverbetsAndBlockerBetsStub() {
+  final r = SpotImporter.parse(
+    _cashOverbetsAndBlockerBetsStub,
+    format: 'jsonl',
+  );
+  return r.spots;
+}


### PR DESCRIPTION
## Summary
- add stub loader for cash_overbets_and_blocker_bets
- append cash_overbets_and_blocker_bets to modules_done

## Testing
- `dart format lib/packs/cash_overbets_and_blocker_bets_loader.dart`
- `dart format curriculum_status.json` *(fails: Expected a method, getter, setter or operator declaration)*
- `dart analyze lib/packs/cash_overbets_and_blocker_bets_loader.dart`
- `flutter test -r expanded test/curriculum_status_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_68a687afb72c832aa3e10739465ec607