### PR TITLE
Add online fastfold pool dynamics loader stub

### DIFF
--- a/curriculum_status.json
+++ b/curriculum_status.json
@@ -59,6 +59,7 @@
     "donk_bets_and_leads",
     "cash_squeeze_strategy",
     "icm_bubble_blind_vs_blind",
-    "live_full_ring_adjustments"
+    "live_full_ring_adjustments",
+    "online_fastfold_pool_dynamics"
   ]
 }

--- a/lib/packs/online_fastfold_pool_dynamics_loader.dart
+++ b/lib/packs/online_fastfold_pool_dynamics_loader.dart
@@ -1,0 +1,15 @@
+import '../ui/session_player/models.dart';
+import '../services/spot_importer.dart';
+
+/// Stub loader for the `online_fastfold_pool_dynamics` curriculum module.
+///
+/// The embedded spot acts as a canonical guard, ensuring the loader
+/// parses correctly during early development.
+const String _onlineFastfoldPoolDynamicsStub = '''
+{"kind":"l1_core_call_vs_price","hand":"AhKc","pos":"BB","stack":"10bb","action":"call"}
+''';
+
+List<UiSpot> loadOnlineFastfoldPoolDynamicsStub() {
+  final r = SpotImporter.parse(_onlineFastfoldPoolDynamicsStub, format: 'jsonl');
+  return r.spots;
+}


### PR DESCRIPTION
## Summary
- stub loader for online_fastfold_pool_dynamics
- mark online_fastfold_pool_dynamics as done in curriculum status

## Testing
- `dart format --set-exit-if-changed .` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `dart test -r expanded test/guard_single_site_test.dart` *(fails: command not found)*
- `dart test -r expanded test/mvs_player_smoke_test.dart test/spotkind_integrity_smoke_test.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `dart run tool/validate_training_content.dart --ci` *(fails: command not found)*
- `python - <<'PY' ... PY`

------
https://chatgpt.com/codex/tasks/task_e_68a6e2f28a9c832aa43bf6deea0595a0