### PR TITLE
Add mtt_pko_advanced_bounty_routing loader stub

### DIFF
--- a/curriculum_status.json
+++ b/curriculum_status.json
@@ -61,6 +61,7 @@
     "icm_bubble_blind_vs_blind",
     "live_full_ring_adjustments",
     "online_fastfold_pool_dynamics",
-    "cash_limp_pots_systems"
+    "cash_limp_pots_systems",
+    "mtt_pko_advanced_bounty_routing"
   ]
 }

--- a/lib/packs/mtt_pko_advanced_bounty_routing_loader.dart
+++ b/lib/packs/mtt_pko_advanced_bounty_routing_loader.dart
@@ -1,0 +1,12 @@
+import '../ui/session_player/models.dart';
+import '../services/spot_importer.dart';
+
+const String _mttPkoAdvancedBountyRoutingStub = '''
+{"kind":"l1_core_call_vs_price","hand":"AhKc","pos":"BB","stack":"10bb","action":"call"}
+''';
+
+List<UiSpot> loadMttPkoAdvancedBountyRoutingStub() {
+  final r =
+      SpotImporter.parse(_mttPkoAdvancedBountyRoutingStub, format: 'jsonl');
+  return r.spots;
+}


### PR DESCRIPTION
## Summary
- stub loader for `mtt_pko_advanced_bounty_routing`
- mark `mtt_pko_advanced_bounty_routing` as completed in curriculum status

## Testing
- `dart format --set-exit-if-changed .` *(failed: parse errors across repository; reverted unrelated changes)*
- `dart analyze`
- `dart test -r expanded test/guard_single_site_test.dart` *(failed: Flutter SDK required)*
- `dart test -r expanded test/mvs_player_smoke_test.dart test/spotkind_integrity_smoke_test.dart` *(failed: Flutter SDK required)*
- `flutter test` *(failed: Flutter SDK 3.35.1+ required)*
- `dart run tool/validate_training_content.dart --ci` *(failed: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e704a624832ab681997882f11a94