### PR TITLE
Add Day 2 bagging and re-entry EV loader stub

### DIFF
--- a/curriculum_status.json
+++ b/curriculum_status.json
@@ -62,6 +62,7 @@
     "live_full_ring_adjustments",
     "online_fastfold_pool_dynamics",
     "cash_limp_pots_systems",
-    "mtt_pko_advanced_bounty_routing"
+    "mtt_pko_advanced_bounty_routing",
+    "mtt_day2_bagging_and_reentry_ev"
   ]
 }

--- a/lib/packs/mtt_day2_bagging_and_reentry_ev_loader.dart
+++ b/lib/packs/mtt_day2_bagging_and_reentry_ev_loader.dart
@@ -1,0 +1,14 @@
+import '../ui/session_player/models.dart';
+import '../services/spot_importer.dart';
+
+const String _mttDay2BaggingAndReentryEvStub = '''
+{"kind":"l1_core_call_vs_price","hand":"AhKc","pos":"BB","stack":"10bb","action":"call"}
+''';
+
+List<UiSpot> loadMttDay2BaggingAndReentryEvStub() {
+  final r = SpotImporter.parse(
+    _mttDay2BaggingAndReentryEvStub,
+    format: 'jsonl',
+  );
+  return r.spots;
+}


### PR DESCRIPTION
## Summary
- stub loader for `mtt_day2_bagging_and_reentry_ev`
- mark `mtt_day2_bagging_and_reentry_ev` as completed in curriculum status

## Testing
- `dart format --set-exit-if-changed .` (fails: parse errors in existing files)
- `dart analyze` (fails: 9032 issues)
- `dart test -r expanded test/guard_single_site_test.dart` (fails: requires Flutter SDK)
- `dart test -r expanded test/mvs_player_smoke_test.dart test/spotkind_integrity_smoke_test.dart` (fails: requires Flutter SDK)
- `flutter test` (fails: command not found)
- `dart run tool/validate_training_content.dart --ci` (fails: file not found)
- `python3 - <<'PY' ...` NEXT: database_leakfinder_playbook


------
https://chatgpt.com/codex/tasks/task_e_68a6e9e271b0832a94bf1daf26ebbda6