### PR TITLE
Add database leakfinder playbook loader stub

### DIFF
--- a/curriculum_status.json
+++ b/curriculum_status.json
@@ -63,6 +63,7 @@
     "online_fastfold_pool_dynamics",
     "cash_limp_pots_systems",
     "mtt_pko_advanced_bounty_routing",
-    "mtt_day2_bagging_and_reentry_ev"
+    "mtt_day2_bagging_and_reentry_ev",
+    "database_leakfinder_playbook"
   ]
 }

--- a/lib/packs/database_leakfinder_playbook_loader.dart
+++ b/lib/packs/database_leakfinder_playbook_loader.dart
@@ -1,0 +1,11 @@
+import '../ui/session_player/models.dart';
+import '../services/spot_importer.dart';
+
+const String _databaseLeakfinderPlaybookStub = '''
+{"kind":"l1_core_call_vs_price","hand":"AhKc","pos":"BB","stack":"10bb","action":"call"}
+''';
+
+List<UiSpot> loadDatabaseLeakfinderPlaybookStub() {
+  final r = SpotImporter.parse(_databaseLeakfinderPlaybookStub, format: 'jsonl');
+  return r.spots;
+}


### PR DESCRIPTION
## Summary
- stub loader for `database_leakfinder_playbook`
- record `database_leakfinder_playbook` in `curriculum_status.json`

## Testing
- `dart format --set-exit-if-changed .` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `dart test -r expanded test/guard_single_site_test.dart` *(fails: command not found)*
- `dart test -r expanded test/mvs_player_smoke_test.dart test/spotkind_integrity_smoke_test.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `dart run tool/validate_training_content.dart --ci` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a6ebfec384832a9faf85503ad9173c