### PR TITLE
feat: add hudless strategy stub loader

### DIFF
--- a/curriculum_status.json
+++ b/curriculum_status.json
@@ -67,6 +67,7 @@
     "database_leakfinder_playbook",
     "solver_node_locking_basics",
     "live_special_formats_straddle_bomb_ante",
-    "online_economics_rakeback_promos"
+    "online_economics_rakeback_promos",
+    "hudless_strategy_and_note_coding"
   ]
 }

--- a/lib/packs/hudless_strategy_and_note_coding_loader.dart
+++ b/lib/packs/hudless_strategy_and_note_coding_loader.dart
@@ -1,0 +1,18 @@
+import '../ui/session_player/models.dart';
+import '../services/spot_importer.dart';
+
+/// Stub loader for the `hudless_strategy_and_note_coding` curriculum module.
+///
+/// The embedded spot acts as a canonical guard, ensuring the loader
+/// parses correctly during early development.
+const String _hudlessStrategyAndNoteCodingStub = '''
+{"kind":"l1_core_call_vs_price","hand":"AhKc","pos":"BB","stack":"10bb","action":"call"}
+''';
+
+List<UiSpot> loadHudlessStrategyAndNoteCodingStub() {
+  final r = SpotImporter.parse(
+    _hudlessStrategyAndNoteCodingStub,
+    format: 'jsonl',
+  );
+  return r.spots;
+}


### PR DESCRIPTION
## Summary
- stub loader for `hudless_strategy_and_note_coding`
- add module to `curriculum_status.json`

## Testing
- `dart format --set-exit-if-changed .` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `dart test -r expanded test/guard_single_site_test.dart` *(fails: command not found)*
- `dart test -r expanded test/mvs_player_smoke_test.dart test/spotkind_integrity_smoke_test.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `dart run tool/validate_training_content.dart --ci` *(fails: command not found)*
- `dart test -r expanded test/curriculum_status_test.dart` *(fails: command not found)*
- `python tooling NEXT check`

------
https://chatgpt.com/codex/tasks/task_e_68a6f257cf30832a9d7d8e047d8aa7dc