### PR TITLE
Add core turn fundamentals stub loader

### DIFF
--- a/curriculum_status.json
+++ b/curriculum_status.json
@@ -1,3 +1,10 @@
 {
-  "modules_done": ["core_rules_and_setup", "core_positions_and_initiative", "core_pot_odds_equity", "core_starting_hands", "core_flop_fundamentals"]
+  "modules_done": [
+    "core_rules_and_setup",
+    "core_positions_and_initiative",
+    "core_pot_odds_equity",
+    "core_starting_hands",
+    "core_flop_fundamentals",
+    "core_turn_fundamentals"
+  ]
 }

--- a/lib/packs/core_turn_fundamentals_loader.dart
+++ b/lib/packs/core_turn_fundamentals_loader.dart
@@ -1,0 +1,12 @@
+import '../ui/session_player/models.dart';
+import '../services/spot_importer.dart';
+
+// Stub pack loader for the core_turn_fundamentals module.
+const String _coreTurnFundamentalsStub = '''
+{"kind":"l1_core_call_vs_price","hand":"AsKd","pos":"BB","stack":"10bb","action":"call"}
+''';
+
+List<UiSpot> loadCoreTurnFundamentalsStub() {
+  final r = SpotImporter.parse(_coreTurnFundamentalsStub, format: 'jsonl');
+  return r.spots;
+}


### PR DESCRIPTION
## Summary
- add stub loader for core_turn_fundamentals module
- track core_turn_fundamentals completion in curriculum status

## Testing
- `dart format --output=none --set-exit-if-changed .` *(fails: Could not format because the source could not be parsed)*
- `dart analyze` *(fails: 9032 issues found)*
- `dart test -r expanded test/guard_single_site_test.dart` *(fails: requires Flutter SDK)*
- `dart test -r expanded test/mvs_player_smoke_test.dart test/spotkind_integrity_smoke_test.dart` *(fails: requires Flutter SDK)*
- `flutter test` *(fails: command not found)*
- `dart run tool/validate_training_content.dart --ci` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a785b46b98832ab6969876551256b6