### PR TITLE
Add core river fundamentals stub loader

### DIFF
--- a/curriculum_status.json
+++ b/curriculum_status.json
@@ -5,6 +5,7 @@
     "core_pot_odds_equity",
     "core_starting_hands",
     "core_flop_fundamentals",
-    "core_turn_fundamentals"
+    "core_turn_fundamentals",
+    "core_river_fundamentals"
   ]
 }

--- a/lib/packs/core_river_fundamentals_loader.dart
+++ b/lib/packs/core_river_fundamentals_loader.dart
@@ -1,0 +1,12 @@
+import '../ui/session_player/models.dart';
+import '../services/spot_importer.dart';
+
+// Stub pack loader for the core_river_fundamentals module.
+const String _coreRiverFundamentalsStub = '''
+{"kind":"l1_core_call_vs_price","hand":"AsKd","pos":"BB","stack":"10bb","action":"call"}
+''';
+
+List<UiSpot> loadCoreRiverFundamentalsStub() {
+  final r = SpotImporter.parse(_coreRiverFundamentalsStub, format: 'jsonl');
+  return r.spots;
+}


### PR DESCRIPTION
## Summary
- add core_river_fundamentals stub loader
- append core_river_fundamentals to curriculum status

## Testing
- ⚠️ `dart format --set-exit-if-changed .` (command not found: dart)
- ⚠️ `dart analyze` (command not found: dart)
- ⚠️ `dart test -r expanded test/guard_single_site_test.dart` (command not found: dart)
- ⚠️ `dart test -r expanded test/mvs_player_smoke_test.dart test/spotkind_integrity_smoke_test.dart` (command not found: dart)
- ⚠️ `flutter test` (command not found: flutter)
- ⚠️ `dart run tool/validate_training_content.dart --ci` (command not found: dart)


------
https://chatgpt.com/codex/tasks/task_e_68a7877e5974832aa7eee2e8d1138c16