### PR TITLE
Add HU preflop strategy loader skeleton

### DIFF
--- a/curriculum_status.json
+++ b/curriculum_status.json
@@ -6,6 +6,7 @@
     "core_starting_hands",
     "core_flop_fundamentals",
     "core_turn_fundamentals",
-    "core_river_fundamentals"
+    "core_river_fundamentals",
+    "hu_preflop_strategy"
   ]
 }

--- a/lib/packs/hu_preflop_strategy_loader.dart
+++ b/lib/packs/hu_preflop_strategy_loader.dart
@@ -1,0 +1,15 @@
+import '../ui/session_player/models.dart';
+import '../services/spot_importer.dart';
+
+/// Stub loader for the `hu_preflop_strategy` curriculum module.
+///
+/// The embedded spot acts as a canonical guard, ensuring the loader
+/// parses correctly during early development.
+const String _huPreflopStrategyStub = '''
+{"kind":"l1_core_call_vs_price","hand":"AdKc","pos":"BB","stack":"10bb","action":"call"}
+''';
+
+List<UiSpot> loadHuPreflopStrategyStub() {
+  final r = SpotImporter.parse(_huPreflopStrategyStub, format: 'jsonl');
+  return r.spots;
+}


### PR DESCRIPTION
## Summary
- stub loader for `hu_preflop_strategy`
- track `hu_preflop_strategy` completion in curriculum status

## Testing
- `dart format --set-exit-if-changed .` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `dart test -r expanded test/guard_single_site_test.dart` *(fails: command not found)*
- `dart test -r expanded test/mvs_player_smoke_test.dart test/spotkind_integrity_smoke_test.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `dart run tool/validate_training_content.dart --ci` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a788d01844832a92f034ccc7cfd04b