### PR TITLE
chore: add HU postflop play stub

### DIFF
--- a/curriculum_status.json
+++ b/curriculum_status.json
@@ -7,6 +7,7 @@
     "core_flop_fundamentals",
     "core_turn_fundamentals",
     "core_river_fundamentals",
-    "hu_preflop_strategy"
+    "hu_preflop_strategy",
+    "hu_postflop_play"
   ]
 }

--- a/lib/packs/hu_postflop_play_loader.dart
+++ b/lib/packs/hu_postflop_play_loader.dart
@@ -1,0 +1,15 @@
+import '../ui/session_player/models.dart';
+import '../services/spot_importer.dart';
+
+/// Stub loader for the `hu_postflop_play` curriculum module.
+///
+/// The embedded spot acts as a canonical guard, ensuring the loader
+/// parses correctly during early development.
+const String _huPostflopPlayStub = '''
+{"kind":"l1_core_call_vs_price","hand":"AdKc","pos":"BB","stack":"10bb","action":"call"}
+''';
+
+List<UiSpot> loadHuPostflopPlayStub() {
+  final r = SpotImporter.parse(_huPostflopPlayStub, format: 'jsonl');
+  return r.spots;
+}


### PR DESCRIPTION
## Summary
- add stub loader for `hu_postflop_play`
- record `hu_postflop_play` in curriculum status
- NEXT: `math_intro_basics`

## Testing
- `dart format --set-exit-if-changed .` *(failed: command not found)*
- `dart analyze` *(failed: command not found)*
- `dart test -r expanded test/guard_single_site_test.dart` *(failed: command not found)*
- `dart test -r expanded test/mvs_player_smoke_test.dart test/spotkind_integrity_smoke_test.dart` *(failed: command not found)*
- `flutter test` *(failed: command not found)*
- `dart run tool/validate_training_content.dart --ci` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a78a6a2cfc832a89548b08f6dcd0a5