### PR TITLE
Add math pot odds equity loader skeleton

### DIFF
--- a/curriculum_status.json
+++ b/curriculum_status.json
@@ -9,6 +9,7 @@
     "core_river_fundamentals",
     "hu_preflop_strategy",
     "hu_postflop_play",
-    "math_intro_basics"
+    "math_intro_basics",
+    "math_pot_odds_equity"
   ]
 }

--- a/lib/packs/math_pot_odds_equity_loader.dart
+++ b/lib/packs/math_pot_odds_equity_loader.dart
@@ -1,0 +1,15 @@
+import '../ui/session_player/models.dart';
+import '../services/spot_importer.dart';
+
+/// Stub loader for the `math_pot_odds_equity` curriculum module.
+///
+/// The embedded spot acts as a canonical guard, ensuring the loader
+/// parses correctly during early development.
+const String _mathPotOddsEquityStub = '''
+{"kind":"l1_core_call_vs_price","hand":"AcKd","pos":"BB","stack":"10bb","action":"call"}
+''';
+
+List<UiSpot> loadMathPotOddsEquityStub() {
+  final r = SpotImporter.parse(_mathPotOddsEquityStub, format: 'jsonl');
+  return r.spots;
+}


### PR DESCRIPTION
## Summary
- add stub loader for `math_pot_odds_equity`
- append `math_pot_odds_equity` to `curriculum_status.json`

## Testing
- `dart format --set-exit-if-changed .` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `dart test -r expanded test/guard_single_site_test.dart` *(fails: command not found)*
- `dart test -r expanded test/mvs_player_smoke_test.dart test/spotkind_integrity_smoke_test.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `dart run tool/validate_training_content.dart --ci` *(fails: command not found)*
- Attempts to install `dart` and `flutter` via apt-get reported packages not found.

------
https://chatgpt.com/codex/tasks/task_e_68a78d67e794832ab1b2392f3c61f1a2