### PR TITLE
feat: add math icm advanced loader

### DIFF
--- a/curriculum_status.json
+++ b/curriculum_status.json
@@ -13,6 +13,7 @@
     "math_pot_odds_equity",
     "math_combo_blockers",
     "math_ev_calculations",
-    "math_icm_basics"
+    "math_icm_basics",
+    "math_icm_advanced"
   ]
 }

--- a/lib/packs/math_icm_advanced_loader.dart
+++ b/lib/packs/math_icm_advanced_loader.dart
@@ -1,0 +1,15 @@
+import '../ui/session_player/models.dart';
+import '../services/spot_importer.dart';
+
+/// Stub loader for the `math_icm_advanced` curriculum module.
+///
+/// The embedded spot acts as a canonical guard, ensuring the loader
+/// parses correctly during early development.
+const String _mathIcmAdvancedStub = '''
+{"kind":"l1_core_call_vs_price","hand":"AhKd","pos":"BB","stack":"10bb","action":"call"}
+''';
+
+List<UiSpot> loadMathIcmAdvancedStub() {
+  final r = SpotImporter.parse(_mathIcmAdvancedStub, format: 'jsonl');
+  return r.spots;
+}


### PR DESCRIPTION
## Summary
- add stub loader for `math_icm_advanced`
- track `math_icm_advanced` in curriculum status

## Testing
- `dart format --set-exit-if-changed .` *(fails: dart: command not found)*
- `dart analyze` *(fails: dart: command not found)*
- `dart test -r expanded test/guard_single_site_test.dart` *(fails: dart: command not found)*
- `dart test -r expanded test/mvs_player_smoke_test.dart test/spotkind_integrity_smoke_test.dart` *(fails: dart: command not found)*
- `flutter test` *(fails: flutter: command not found)*
- `dart run tool/validate_training_content.dart --ci` *(fails: dart: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a79402f7cc832aa04081ae2e04003f