### PR TITLE
feat: add content next CLI

### DIFF
--- a/tooling/content_next.dart
+++ b/tooling/content_next.dart
@@ -1,0 +1,32 @@
+import 'dart:io';
+
+import 'curriculum_ids.dart';
+
+bool _hasContent(String id) {
+  final base = 'content/$id/v1';
+  return File('$base/theory.md').existsSync() &&
+      File('$base/demos.jsonl').existsSync() &&
+      File('$base/drills.jsonl').existsSync();
+}
+
+void main(List<String> args) {
+  final strict = args.contains('--strict');
+  final ids = kCurriculumIds;
+  var prefix = 0;
+  String? next;
+  for (final id in ids) {
+    if (_hasContent(id)) {
+      prefix++;
+    } else {
+      next = id;
+      break;
+    }
+  }
+  final missing = next == null ? <String>[] : ids.sublist(prefix);
+  print('CONTENT_DONE_PREFIX=$prefix');
+  print('CONTENT_NEXT=${next ?? 'ALL DONE'}');
+  print('CONTENT_MISSING:${missing.join(',')}');
+  if (strict && next != null) {
+    exitCode = 1;
+  }
+}


### PR DESCRIPTION
## Summary
- add CLI to report next curriculum module without full content

## Testing
- `dart run tooling/content_next.dart`
- `dart format --set-exit-if-changed .` *(fails: formatted many files; repository restored)*
- `dart analyze` *(9032 issues found)*
- `dart test -r expanded test/guard_single_site_test.dart` *(fails: requires Flutter SDK)*
- `dart test -r expanded test/mvs_player_smoke_test.dart test/spotkind_integrity_smoke_test.dart` *(fails: requires Flutter SDK)*
- `flutter test` *(command not found)*
- `dart run tool/validate_training_content.dart --ci` *(file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a47c3bb8832ab141f201556aa1fc