### PR TITLE
chore: add core rule SpotKind values

### DIFF
--- a/tooling/spot_specs.dart
+++ b/tooling/spot_specs.dart
@@ -24,6 +24,14 @@ enum SpotKind {
   l4_icm_sb_jam_vs_fold,
   l4_icm_bb_jam_vs_fold,
   l1_core_call_vs_price,
+  l2_core_rules_check,
+  l2_core_actions,
+  l2_core_min_raise,
+  l2_core_allin_reopen,
+  l2_core_showdown,
+  l2_core_out_of_turn,
+  l2_core_string_bet,
+  l2_core_round_end,
 }
 
 const Set<String> kSpotKindUniverse = {
@@ -52,6 +60,14 @@ const Set<String> kSpotKindUniverse = {
   'l4_icm_sb_jam_vs_fold',
   'l4_icm_bb_jam_vs_fold',
   'l1_core_call_vs_price',
+  'l2_core_rules_check',
+  'l2_core_actions',
+  'l2_core_min_raise',
+  'l2_core_allin_reopen',
+  'l2_core_showdown',
+  'l2_core_out_of_turn',
+  'l2_core_string_bet',
+  'l2_core_round_end',
 };
 
 bool isValidSpotKind(String s) => kSpotKindUniverse.contains(s);


### PR DESCRIPTION
## Summary
- expand `SpotKind` enum with allowlisted core rule entries
- mirror new `SpotKind` strings in `kSpotKindUniverse`

## Testing
- `dart format --set-exit-if-changed .` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `dart test -r expanded test/guard_single_site_test.dart` *(fails: command not found)*
- `dart test -r expanded test/mvs_player_smoke_test.dart test/spotkind_integrity_smoke_test.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `dart run tool/validate_training_content.dart --ci` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8edf0c1c4832abf082d9fdff34662