### PR TITLE
feat: add snapshot targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ coverage/
 build/
 .dart_tool/
 
+# Track CI snapshots
+!ci/snapshots/
+

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: allowlists allowlists-sync allowlists-check images gap beta beta-zip check fix-terms beta-fix beta-fix-continue pre-release research-check ui-assets discover ascii-check gap-details ascii-fix demos-steps demo-token-tag demos-steps-fix demos-count-fix theory-fix wordcount-balance drills-fix drills-seed
+.PHONY: allowlists allowlists-sync allowlists-check images gap beta beta-zip check fix-terms beta-fix beta-fix-continue pre-release research-check ui-assets discover ascii-check gap-details ascii-fix demos-steps demo-token-tag demos-steps-fix demos-count-fix theory-fix wordcount-balance drills-fix drills-seed snapshots snapshots-clean
 allowlists:
 	@dart run tooling/derive_allowlists.dart --write --clear
 allowlists-sync:
@@ -184,3 +184,25 @@ ui-telemetry:
 ui-i18n:
 	@dart run tooling/export_i18n_strings.dart --out build/i18n
 	@head -n 40 build/i18n/en.json
+
+# Copy selected build artifacts into ci/snapshots
+snapshots:
+	@mkdir -p ci/snapshots
+	@for f in build/pre_release_check.txt \
+	         build/gaps.json \
+	         build/term_lint.json \
+	         build/links_report.json \
+	         build/demos_steps.json \
+	         build/gap_details.json \
+	         build/ui_assets/manifest.json; do \
+	        if [ -f $$f ]; then \
+	                dest=ci/snapshots/$${f#build/}; \
+	                mkdir -p $$(dirname $$dest); \
+	                cp $$f $$dest; \
+	        else \
+	                echo "missing: $$f"; \
+	        fi; \
+	done
+
+snapshots-clean:
+	@rm -rf ci/snapshots


### PR DESCRIPTION
## Summary
- add `snapshots` and `snapshots-clean` Makefile targets to copy build artifacts into `ci/snapshots`
- ensure `ci/snapshots` is tracked by git ignore rules

## Testing
- `dart format --set-exit-if-changed .` *(fails: command not found: dart)*
- `dart analyze` *(fails: command not found: dart)*
- `dart test -r expanded test/guard_single_site_test.dart` *(fails: command not found: dart)*
- `dart test -r expanded test/mvs_player_smoke_test.dart test/spotkind_integrity_smoke_test.dart` *(fails: command not found: dart)*
- `flutter test` *(fails: command not found: flutter)*
- `dart run tool/validate_training_content.dart --ci` *(fails: command not found: dart)*

------
https://chatgpt.com/codex/tasks/task_e_68bb951f2c0c832aa4ab6e0bf2ec29be