### PR TITLE
Collect content snapshots in CI

### DIFF
--- a/.github/workflows/content_ci.yml
+++ b/.github/workflows/content_ci.yml
@@ -115,3 +115,13 @@ jobs:
             build/links_report.json
             build/ui_assets
             build/demos_steps.json
+
+      - name: Snapshots (collect)
+        run: make snapshots || true
+
+      - name: Upload snapshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: snapshots
+          path: ci/snapshots

--- a/tooling/README_pipeline.md
+++ b/tooling/README_pipeline.md
@@ -10,6 +10,11 @@ Usage
 - Optional local zip of content/ after beta:
   - `make beta-zip`
 
+Snapshots
+- Collect current content snapshots for inspection:
+  - `make snapshots`
+- CI publishes any files from ci/snapshots/ as the `snapshots` artifact.
+
 Module‑Scoped Examples
 - Generate specs for a single module:
   - `dart run tooling/gen_image_specs.dart core_board_textures`


### PR DESCRIPTION
## Summary
- collect snapshot files during Content CI
- document `make snapshots` and the `snapshots` artifact in the pipeline README

## Testing
- `make pre-release && make ui-assets && make snapshots` *(fails: dart: No such file or directory)*
- `dart format --set-exit-if-changed .` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `dart test -r expanded test/guard_single_site_test.dart` *(fails: command not found)*
- `dart test -r expanded test/mvs_player_smoke_test.dart test/spotkind_integrity_smoke_test.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `dart run tool/validate_training_content.dart --ci` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb9696f4b0832ab51b36f66674e169