### PR TITLE
ci: publish snapshots and document usage

### DIFF
--- a/.github/workflows/content_ci.yml
+++ b/.github/workflows/content_ci.yml
@@ -116,12 +116,13 @@ jobs:
             build/ui_assets
             build/demos_steps.json
 
-      - name: Snapshots (collect)
-        run: make snapshots || true
+      - name: Collect snapshots
+        if: always()
+        run: make snapshots
 
       - name: Upload snapshots
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: snapshots
-          path: ci/snapshots
+          path: ci/snapshots/**

--- a/tooling/README_snapshots.md
+++ b/tooling/README_snapshots.md
@@ -1,0 +1,20 @@
+Snapshots
+
+Purpose
+- Collect selected build outputs for quick inspection.
+
+Files
+- pre_release_check.txt
+- gaps.json
+- term_lint.json
+- links_report.json
+- demos_steps.json
+- gap_details.json
+- ui_assets/manifest.json
+
+Local Usage
+- make snapshots
+- make snapshots-clean
+
+CI
+- Content CI uploads these files as the snapshots artifact.


### PR DESCRIPTION
## Summary
- collect snapshot outputs in CI and upload as `snapshots` artifact
- document available snapshot files and local commands

## Testing
- `dart format --set-exit-if-changed .` *(fails: dart not installed)*
- `dart analyze` *(fails: dart not installed)*
- `dart test -r expanded test/guard_single_site_test.dart` *(fails: dart not installed)*
- `dart test -r expanded test/mvs_player_smoke_test.dart test/spotkind_integrity_smoke_test.dart` *(fails: dart not installed)*
- `flutter test` *(fails: flutter not installed)*
- `dart run tool/validate_training_content.dart --ci` *(fails: dart not installed)*
- `make snapshots && ls -l ci/snapshots/`
- `make snapshots-clean && ls ci`


------
https://chatgpt.com/codex/tasks/task_e_68bb975cefac832aa79cd6c1b7653f28