### PR TITLE
fix snapshots path duplicate

### DIFF
--- a/.github/workflows/content_ci.yml
+++ b/.github/workflows/content_ci.yml
@@ -125,5 +125,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: snapshots
-          path: |
-            ci/snapshots/**
+          path: ci/snapshots/**


### PR DESCRIPTION
## Summary
- remove duplicate `path` entry in `Upload snapshots` step of content CI workflow

## Testing
- `dart format --set-exit-if-changed .` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `dart test -r expanded test/guard_single_site_test.dart` *(fails: command not found)*
- `dart test -r expanded test/mvs_player_smoke_test.dart test/spotkind_integrity_smoke_test.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `dart run tool/validate_training_content.dart --ci` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68bc11217868832a888093ffcab6bb7a