### PR TITLE
Add CI YAML duplicate key guard

### DIFF
--- a/.github/workflows/content_ci.yml
+++ b/.github/workflows/content_ci.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Setup Dart
         uses: dart-lang/setup-dart@v1
 
+      - name: Validate workflow YAML
+        run: dart run tooling/ci_yaml_guard.dart
+
       - name: Dart version
         run: dart --version
 

--- a/tooling/ci_yaml_guard.dart
+++ b/tooling/ci_yaml_guard.dart
@@ -1,0 +1,100 @@
+import 'dart:io';
+
+class _Context {
+  final int indent;
+  final Set<String> keys = {};
+  bool pathSeen = false;
+  final bool checkUploadArtifact;
+  _Context(this.indent, {this.checkUploadArtifact = false});
+}
+
+int _indentOf(String line) {
+  var i = 0;
+  while (i < line.length && line[i] == ' ') i++;
+  return i;
+}
+
+void main() {
+  final issues = <String>[];
+  final dir = Directory('.github/workflows');
+  if (!dir.existsSync()) exit(0);
+  final files = dir
+      .listSync()
+      .whereType<File>()
+      .where((f) => f.path.endsWith('.yml') || f.path.endsWith('.yaml'))
+      .toList()
+    ..sort((a, b) => a.path.compareTo(b.path));
+  for (final file in files) {
+    final rel = file.path.startsWith('./') ? file.path.substring(2) : file.path;
+    final lines = file.readAsLinesSync();
+    final stack = <_Context>[_Context(-1)];
+    int? blockIndent;
+    bool expectUploadWith = false;
+    for (var i = 0; i < lines.length; i++) {
+      final lineNo = i + 1;
+      final line = lines[i];
+      if (blockIndent != null) {
+        if (_indentOf(line) > blockIndent!) {
+          continue; // inside block scalar
+        } else {
+          blockIndent = null;
+        }
+      }
+      final trimmed = line.trimLeft();
+      if (trimmed.isEmpty || trimmed.startsWith('#')) {
+        continue;
+      }
+      final m = RegExp(r'^(\s*)(- )?([A-Za-z0-9_-]+):').firstMatch(line);
+      if (m == null) continue;
+      final baseIndent = m.group(1)!.length;
+      final isList = m.group(2) != null;
+      var indent = baseIndent + (isList ? 2 : 0);
+      final key = m.group(3)!;
+
+      if (isList) {
+        while (stack.isNotEmpty && indent <= stack.last.indent) {
+          stack.removeLast();
+        }
+        stack.add(_Context(indent));
+      } else {
+        while (stack.isNotEmpty && indent < stack.last.indent) {
+          stack.removeLast();
+        }
+      }
+      final ctx = stack.last;
+      if (ctx.checkUploadArtifact && key == 'path') {
+        if (ctx.pathSeen) {
+          issues.add('CI-YAML key-dupe $rel:$lineNo path');
+        }
+        ctx.pathSeen = true;
+      } else {
+        if (!ctx.keys.add(key)) {
+          issues.add('CI-YAML key-dupe $rel:$lineNo $key');
+        }
+      }
+      final rest = line.substring(m.end).trim();
+      if (key == 'uses' && rest.contains('actions/upload-artifact@v4')) {
+        expectUploadWith = true;
+      } else if (key == 'with') {
+        final special = expectUploadWith && indent == stack.last.indent;
+        expectUploadWith = false;
+        final child = _Context(indent + 2, checkUploadArtifact: special);
+        stack.add(child);
+        continue;
+      } else {
+        expectUploadWith = false;
+      }
+      if (rest.isEmpty) {
+        stack.add(_Context(indent + 2));
+      } else if (rest == '|' || rest == '>') {
+        blockIndent = indent;
+      }
+    }
+  }
+  if (issues.isNotEmpty) {
+    for (final issue in issues) {
+      stdout.writeln(issue);
+    }
+    exit(1);
+  }
+}


### PR DESCRIPTION
## Summary
- add Dart script to scan workflow YAML files for duplicate keys and repeated `path` entries for upload-artifact
- integrate YAML validation step in Content CI workflow

## Testing
- `dart format --set-exit-if-changed .` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `dart test -r expanded test/guard_single_site_test.dart` *(fails: command not found)*
- `dart test -r expanded test/mvs_player_smoke_test.dart test/spotkind_integrity_smoke_test.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `dart run tool/validate_training_content.dart --ci` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc12443610832aaef0e79185c68c1a